### PR TITLE
feat: Implement secure serving for cover images

### DIFF
--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -13,8 +13,11 @@ use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\String\Slugger\SluggerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use ZipArchive;
@@ -23,16 +26,26 @@ use ZipArchive;
 class ComicController extends AbstractController
 {
     private string $tempUploadDir;
+    private RequestStack $requestStack;
+    private UrlGeneratorInterface $urlGenerator;
     
-    public function __construct(private string $comicsDirectory)
-    {
+    public function __construct(
+        private string $comicsDirectory,
+        RequestStack $requestStack,
+        UrlGeneratorInterface $urlGenerator
+    ) {
         $this->tempUploadDir = sys_get_temp_dir() . '/comic_uploads';
+        $this->requestStack = $requestStack;
+        $this->urlGenerator = $urlGenerator;
         
         // Ensure temp directory exists
         if (!file_exists($this->tempUploadDir)) {
             mkdir($this->tempUploadDir, 0777, true);
         }
     }
+
+    // Removed getPublicBaseUrlForUploads() method as it's no longer needed.
+
     #[Route('', name: 'list', methods: ['GET'])]
     public function list(EntityManagerInterface $entityManager): JsonResponse
     {
@@ -48,13 +61,36 @@ class ComicController extends AbstractController
         // Transform comics to array
         $comicsArray = [];
         foreach ($comics as $comic) {
+            $fullCoverUrl = null;
+            if ($comic->getCoverImagePath()) {
+                try {
+                    $filename = basename($comic->getCoverImagePath());
+                    $fullCoverUrl = $this->urlGenerator->generate(
+                        'api_comics_cover_image', // Ensure this matches the route name in getCoverImage
+                        [
+                            'userId' => $user->getId(),
+                            'comicId' => $comic->getId(),
+                            'filename' => $filename,
+                        ],
+                        UrlGeneratorInterface::ABSOLUTE_URL
+                    );
+                } catch (\Symfony\Component\Routing\Exception\RouteNotFoundException $e) {
+                    // Log the error (e.g., using Monolog or error_log)
+                    error_log("Route 'api_comics_cover_image' not found for comic ID " . $comic->getId() . ": " . $e->getMessage());
+                    // $fullCoverUrl remains null
+                } catch (\Exception $e) {
+                    error_log("Error generating cover URL for comic ID " . $comic->getId() . ": " . $e->getMessage());
+                    // $fullCoverUrl remains null
+                }
+            }
+
             $comicsArray[] = [
                 'id' => $comic->getId(),
                 'title' => $comic->getTitle(),
                 'author' => $comic->getAuthor(),
                 'publisher' => $comic->getPublisher(),
                 'description' => $comic->getDescription(),
-                'coverImagePath' => $comic->getCoverImagePath(),
+                'coverImagePath' => $fullCoverUrl,
                 'pageCount' => $comic->getPageCount(),
                 'uploadedAt' => $comic->getUploadedAt()->format('c'),
                 'tags' => array_map(function ($tag) {
@@ -89,13 +125,35 @@ class ComicController extends AbstractController
             ->findOneBy(['comic' => $comic, 'user' => $user]);
 
         // Transform comic to array
+        $fullCoverUrl = null;
+        if ($comic->getCoverImagePath()) {
+            try {
+                $filename = basename($comic->getCoverImagePath());
+                $fullCoverUrl = $this->urlGenerator->generate(
+                    'api_comics_cover_image', // Ensure this matches the route name in getCoverImage
+                    [
+                        'userId' => $user->getId(),
+                        'comicId' => $comic->getId(),
+                        'filename' => $filename,
+                    ],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                );
+            } catch (\Symfony\Component\Routing\Exception\RouteNotFoundException $e) {
+                error_log("Route 'api_comics_cover_image' not found for comic ID " . $comic->getId() . ": " . $e->getMessage());
+                // $fullCoverUrl remains null
+            } catch (\Exception $e) {
+                error_log("Error generating cover URL for comic ID " . $comic->getId() . ": " . $e->getMessage());
+                // $fullCoverUrl remains null
+            }
+        }
+
         $comicArray = [
             'id' => $comic->getId(),
             'title' => $comic->getTitle(),
             'author' => $comic->getAuthor(),
             'publisher' => $comic->getPublisher(),
             'description' => $comic->getDescription(),
-            'coverImagePath' => $comic->getCoverImagePath(),
+            'coverImagePath' => $fullCoverUrl,
             'pageCount' => $comic->getPageCount(),
             'uploadedAt' => $comic->getUploadedAt()->format('c'),
             'tags' => array_map(function ($tag) {
@@ -792,3 +850,50 @@ class ComicController extends AbstractController
         return $mimeTypes[$extension] ?? 'application/octet-stream';
     }
 }
+
+    #[Route('/cover/{userId}/{comicId}/{filename}', name: 'cover_image', methods: ['GET'])]
+    public function getCoverImage(int $userId, int $comicId, string $filename, EntityManagerInterface $entityManager): Response
+    {
+        /** @var \App\Entity\User|null $currentUser */
+        $currentUser = $this->getUser();
+        if (!$currentUser) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if ($currentUser->getId() !== $userId) {
+            // Log this attempt, as it could be a sign of probing or misconfiguration
+            error_log("Forbidden access attempt: User {$currentUser->getId()} tried to access cover for user {$userId}.");
+            return $this->json(['message' => 'Forbidden.'], Response::HTTP_FORBIDDEN);
+        }
+
+        $comic = $entityManager->getRepository(Comic::class)->findOneBy(['id' => $comicId, 'owner' => $currentUser]);
+        if (!$comic) {
+            return $this->json(['message' => 'Comic not found or not owned by user.'], Response::HTTP_NOT_FOUND);
+        }
+
+        $coverPath = $comic->getCoverImagePath(); // This is relative to user's comic dir, e.g., "covers/COMIC_ID/file.jpg"
+        if (!$coverPath) {
+            return $this->json(['message' => 'Comic has no cover image path.'], Response::HTTP_NOT_FOUND);
+        }
+        
+        $expectedFilename = basename($coverPath);
+        if ($filename !== $expectedFilename) {
+            error_log("Requested filename '{$filename}' does not match expected '{$expectedFilename}' for comic ID {$comicId} by user ID {$userId}");
+            return $this->json(['message' => 'Invalid filename requested.'], Response::HTTP_NOT_FOUND);
+        }
+
+        // $this->comicsDirectory is the base path like "/var/www/public/uploads/comics"
+        // $currentUser->getId() is the user's ID
+        // $coverPath is "covers/{comic_id}/actual_cover.jpg"
+        $absolutePath = $this->comicsDirectory . '/' . $currentUser->getId() . '/' . ltrim($coverPath, '/');
+
+        if (!file_exists($absolutePath) || !is_readable($absolutePath)) {
+            error_log("Cover file not found on disk or not readable: {$absolutePath} for comic ID {$comicId}, user ID {$userId}");
+            return $this->json(['message' => 'Cover image file not found on server.'], Response::HTTP_NOT_FOUND);
+        }
+
+        // Use BinaryFileResponse to serve the image
+        // This handles Content-Type, Content-Length, and other necessary headers.
+        // It also supports range requests if the client asks for partial content.
+        return new BinaryFileResponse($absolutePath);
+    }

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button.jsx";
-import { mockComics, generateComicPages } from "@/lib/mockData.js";
+// import { mockComics, generateComicPages } from "@/lib/mockData.js";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useToast } from "@/hooks/use-toast.js";
 import { Skeleton } from "@/components/ui/skeleton.jsx";
@@ -11,32 +11,90 @@ export default function ComicReader() {
   const [comic, setComic] = useState(null);
   const [comicPages, setComicPages] = useState([]);
   const [currentPage, setCurrentPage] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true); // For overall comic data
+  const [isPageImageLoading, setIsPageImageLoading] = useState(true); // For individual page images
+  const [imageLoadedSuccessfully, setImageLoadedSuccessfully] = useState(true); // To track if image loaded
+  const [isSavingProgress, setIsSavingProgress] = useState(false); // For UI feedback on saving
+  const [imageCache, setImageCache] = useState({});
   const navigate = useNavigate();
   const { toast } = useToast();
 
+  const CACHE_SIZE_FORWARD = 3;
+  const CACHE_SIZE_BACKWARD = 2;
+
+  const updateReadingProgress = useCallback(async (pageToSave) => {
+    if (!comicId || !comic || isSavingProgress) return;
+
+    // console.log(`Attempting to save progress: Page ${pageToSave} for comic ${comicId}`);
+    setIsSavingProgress(true);
+
+    try {
+      const response = await fetch(`/api/comics/${comicId}/progress`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ currentPage: pageToSave }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ message: "Failed to save progress." }));
+        throw new Error(errorData.message || "Server error saving progress.");
+      }
+      // Optional: toast({ title: "Progress Saved", description: `Page ${pageToSave} saved.` });
+    } catch (error) {
+      console.error("Failed to save reading progress:", error);
+      toast({
+        title: "Error Saving Progress",
+        description: error.message || "Could not save your reading progress. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSavingProgress(false);
+    }
+  }, [comicId, comic, toast, isSavingProgress]);
+
+
   useEffect(() => {
     const loadComic = async () => {
+      setIsLoading(true);
       try {
-        await new Promise(resolve => setTimeout(resolve, 800));
-        
-        const foundComic = mockComics.find(c => c.id === comicId);
-        
-        if (foundComic) {
-          setComic(foundComic);
-          setComicPages(generateComicPages(comicId, foundComic.totalPages));
-          
-          if (foundComic.lastReadPage !== undefined) {
-            setCurrentPage(foundComic.lastReadPage - 1);
-          }
-        } else {
+        const response = await fetch(`/api/comics/${comicId}`);
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({ message: "Failed to load comic details." }));
           toast({
-            title: "Comic not found",
-            description: "The requested comic could not be found.",
+            title: "Error loading comic",
+            description: errorData.message || "The comic could not be loaded.",
             variant: "destructive",
           });
           navigate("/dashboard");
+          return;
         }
+        const data = await response.json();
+        setComic(data.comic);
+        // Reset image loading states for the new comic
+        setIsPageImageLoading(true);
+        setImageLoadedSuccessfully(false);
+
+        if (data.comic && data.comic.pageCount > 0) {
+          setComicPages(
+            Array.from({ length: data.comic.pageCount }, (_, i) => `/api/comics/${comicId}/pages/${i + 1}`)
+          );
+          if (data.comic.readingProgress && data.comic.readingProgress.currentPage) {
+            setCurrentPage(data.comic.readingProgress.currentPage - 1);
+          } else {
+            setCurrentPage(0); // Default to first page
+          }
+        } else {
+          toast({
+            title: "Comic has no pages", // Or "Comic data loaded, but no pages found"
+            description: "This comic cannot be displayed as it has no pages.",
+            variant: "destructive",
+          });
+          setComicPages([]);
+          // Potentially navigate away or show a different message
+        }
+
       } catch (error) {
         console.error("Failed to load comic:", error);
         toast({
@@ -44,23 +102,103 @@ export default function ComicReader() {
           description: "There was a problem loading the comic. Please try again.",
           variant: "destructive",
         });
+        // navigate("/dashboard"); // Optional: navigate away on general error
       } finally {
         setIsLoading(false);
       }
     };
 
     if (comicId) {
-        loadComic();
+      loadComic();
     } else {
-        toast({
-            title: "Error",
-            description: "Comic ID is missing.",
-            variant: "destructive",
-        });
-        navigate("/dashboard");
-        setIsLoading(false);
+      toast({
+        title: "Error",
+        description: "Comic ID is missing.",
+        variant: "destructive",
+      });
+      navigate("/dashboard");
+      setIsLoading(false);
     }
   }, [comicId, navigate, toast]);
+
+  // Effect to handle per-page image loading state based on JS imageCache
+  useEffect(() => {
+    if (comicPages.length > 0 && comicPages[currentPage]) {
+      const cachedImage = imageCache[currentPage];
+      if (cachedImage && cachedImage !== 'loading' && cachedImage !== 'failed' && cachedImage.complete) {
+        // Image is in our JS cache and fully loaded (already decoded)
+        setIsPageImageLoading(false);
+        setImageLoadedSuccessfully(true);
+      } else if (cachedImage === 'failed') {
+        setIsPageImageLoading(false);
+        setImageLoadedSuccessfully(false);
+      } else {
+        // Image not in JS cache, or is an Image object still loading, or just URL.
+        // Rely on the <img> tag's onLoad/onError for these cases.
+        // Ensure isPageImageLoading is true if we don't have it readily available.
+        setIsPageImageLoading(true);
+        setImageLoadedSuccessfully(false); // Will be set by img.onLoad or if cache hit occurs before render.
+      }
+    } else if (comicPages.length > 0 && !comicPages[currentPage]) {
+        // Current page is out of bounds of comicPages (should not happen with proper navigation)
+        setIsPageImageLoading(false);
+        setImageLoadedSuccessfully(false);
+        // console.warn("Current page index is out of bounds for comicPages array.");
+    } else {
+        // No comicPages available yet, or comicPages is empty
+        setIsPageImageLoading(true); // Default to loading if no pages.
+        setImageLoadedSuccessfully(false);
+    }
+  }, [currentPage, comicPages, imageCache]);
+
+  // Effect for pre-loading images
+  useEffect(() => {
+    if (!comicPages || comicPages.length === 0) return;
+
+    const preloadPage = (pageIndex) => {
+      if (pageIndex < 0 || pageIndex >= comicPages.length) return; // Out of bounds
+
+      // Check cache: if it's an Image object, or 'loading', or 'failed', skip
+      if (imageCache[pageIndex] && (imageCache[pageIndex] instanceof Image || imageCache[pageIndex] === 'loading' || imageCache[pageIndex] === 'failed')) {
+        return;
+      }
+
+      // Mark as "being cached" to avoid re-fetching in quick succession
+      setImageCache(prevCache => ({ ...prevCache, [pageIndex]: 'loading' }));
+      
+      const img = new Image();
+      img.src = comicPages[pageIndex];
+      img.onload = () => {
+        setImageCache(prevCache => ({ ...prevCache, [pageIndex]: img }));
+        // console.log(`Page ${pageIndex + 1} pre-loaded and cached.`);
+      };
+      img.onerror = () => {
+        setImageCache(prevCache => ({ ...prevCache, [pageIndex]: 'failed' }));
+        // console.error(`Failed to pre-load page ${pageIndex + 1}.`);
+      };
+    };
+
+    // Preload forward
+    for (let i = 1; i <= CACHE_SIZE_FORWARD; i++) {
+      preloadPage(currentPage + i);
+    }
+    // Preload backward
+    for (let i = 1; i <= CACHE_SIZE_BACKWARD; i++) {
+      preloadPage(currentPage - i);
+    }
+    // Ensure current page is also in cache (could be missed if navigation is too fast or first load)
+    // preloadPage(currentPage); // This might be redundant due to <img> onLoad, but can ensure cache consistency.
+
+  }, [currentPage, comicPages, imageCache, CACHE_SIZE_FORWARD, CACHE_SIZE_BACKWARD]); // imageCache added as dependency
+
+  // Effect to save reading progress when currentPage changes
+  useEffect(() => {
+    // Consider debouncing this for production to avoid rapid API calls.
+    if (comic && comicId && typeof currentPage === 'number' && currentPage >= 0 && comicPages.length > 0) {
+      // We add 1 because currentPage is 0-indexed, but backend expects 1-indexed.
+      updateReadingProgress(currentPage + 1);
+    }
+  }, [currentPage, comic, comicId, comicPages.length, updateReadingProgress]);
 
   const handlePreviousPage = () => {
     if (currentPage > 0) {
@@ -71,7 +209,7 @@ export default function ComicReader() {
   const handleNextPage = () => {
     if (currentPage < comicPages.length - 1) {
       setCurrentPage(currentPage + 1);
-      console.log(`Updating reading progress: Page ${currentPage + 2} of ${comicPages.length}`);
+      // The useEffect hook watching currentPage will handle the progress update.
     }
   };
 
@@ -133,13 +271,72 @@ export default function ComicReader() {
       ></div>
       
       <div className="max-w-4xl w-full h-[calc(100vh-8rem)] flex items-center justify-center py-8">
-        <div className="relative max-h-full">
-          {comicPages[currentPage] && (
+        <div className="relative max-h-full w-full h-full flex items-center justify-center">
+          {isPageImageLoading && comicPages.length > 0 && comicPages[currentPage] && (
+            <Skeleton className="w-full h-full max-w-full object-contain mx-auto" />
+          )}
+          {/* Error display for failed image load */}
+          {!isPageImageLoading && !imageLoadedSuccessfully && comicPages.length > 0 && comicPages[currentPage] && (
+            <div className="flex flex-col items-center justify-center text-destructive p-4 bg-destructive-foreground rounded-md">
+              <p className="mb-2">Error loading page {currentPage + 1}.</p>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  // Retry logic: Clear from cache and set to loading to trigger reload by main <img>
+                  // And also ensure the preloader might pick it up again if needed.
+                  setImageCache(prevCache => {
+                    const newCache = { ...prevCache };
+                    delete newCache[currentPage]; // Remove 'failed' or old Image object
+                    return newCache;
+                  });
+                  setIsPageImageLoading(true);
+                  setImageLoadedSuccessfully(false);
+                  // The main img tag's src will attempt to reload.
+                  // The preloader might also try again if it's in its range.
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+          {/* Main image display */}
+          {comicPages.length > 0 && comicPages[currentPage] && (
             <img
+              key={comicPages[currentPage]} // Helps React differentiate if src string itself is identical but needs re-eval
               src={comicPages[currentPage]}
               alt={`Page ${currentPage + 1} of ${comic.title}`}
-              className="max-h-full max-w-full object-contain mx-auto shadow-lg"
+              className={`max-h-full max-w-full object-contain mx-auto shadow-lg ${
+                isPageImageLoading || !imageLoadedSuccessfully ? 'hidden' : 'block'
+              }`}
+              onLoad={() => {
+                setIsPageImageLoading(false);
+                setImageLoadedSuccessfully(true);
+                // Update JS cache if this image wasn't preloaded or was 'loading'
+                if (!imageCache[currentPage] || imageCache[currentPage] === 'loading') {
+                  const img = new Image();
+                  img.src = comicPages[currentPage]; // Browser should serve from its cache
+                  img.onload = () => { // Ensure it's fully loaded before storing the Image object
+                     setImageCache(prevCache => ({ ...prevCache, [currentPage]: img }));
+                  };
+                  // No explicit img.onerror here as the main <img> tag's onError handles failure for the current page.
+                }
+              }}
+              onError={() => {
+                setIsPageImageLoading(false);
+                setImageLoadedSuccessfully(false);
+                // Also mark as failed in our JS cache
+                setImageCache(prevCache => ({ ...prevCache, [currentPage]: 'failed' }));
+                toast({
+                  title: "Error loading page image",
+                  description: `Could not load image for page ${currentPage + 1}.`,
+                  variant: "destructive",
+                });
+              }}
             />
+          )}
+          {/* Case where there are no pages for the comic */}
+          {comicPages.length === 0 && !isLoading && (
+             <div className="text-xl">This comic has no pages to display.</div>
           )}
         </div>
       </div>


### PR DESCRIPTION
This commit introduces a secure mechanism for serving comic cover images:

- Cover images are now served via a new controller action: `/api/comics/cover/{userId}/{comicId}/{filename}`. This action performs authentication and authorization checks, ensuring you can only access cover images for comics you own.

- `ComicController`'s `list` and `get` actions have been updated to generate URLs pointing to this new secure endpoint using `UrlGeneratorInterface`.

- `ComicService` was updated earlier to store cover images in user-specific paths (`uploads/comics/{userId}/covers/{comicId}/`), and this commit ensures the new secure serving mechanism correctly accesses these paths.

- The `deleteComic` method in `ComicService` was also updated to correctly remove covers from their new user-specific locations.

This change enhances security by preventing direct static file access to cover images and centralizing access control within the application logic.