### PR TITLE
Fix duplicate method in session manager

### DIFF
--- a/frontend/src/lib/session-manager.js
+++ b/frontend/src/lib/session-manager.js
@@ -284,20 +284,6 @@ class SessionManager {
     }
   }
   
-  /**
-   * Force an immediate session check
-   * @returns {Promise<boolean>} True if session is valid, false otherwise
-   */
-  async forceSessionCheck() {
-    // If a check is already in progress, don't force another one
-    if (this.checkInProgress) {
-      logger.log('Session check already in progress, not forcing another');
-      return true; // Assume success to prevent cascading failures
-    }
-    
-    logger.log('Forcing session check');
-    return await this.checkSession(true);
-  }
 }
 
 // Create a singleton instance


### PR DESCRIPTION
## Summary
- remove redundant `forceSessionCheck` definition in `session-manager.js`

## Testing
- `./vendor/bin/phpunit -c phpunit.xml.dist`
- `npm run lint` *(fails: config uses unsupported `extends` option)*

------
https://chatgpt.com/codex/tasks/task_e_68777b7adf688332a74b40efd6b58148