### PR TITLE
Fix ESLint config for JSX parsing

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,16 +5,17 @@ import reactRefresh from "eslint-plugin-react-refresh";
 
 // Removed: import tseslint from "typescript-eslint";
 
-export default [ // Changed from tseslint.config to a plain array
+export default [
   { ignores: ["dist"] },
   {
-    // Removed: extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    // Now only extends js.configs.recommended
-    extends: [js.configs.recommended],
-    files: ["**/*.{js,jsx}"], // Changed from ts,tsx to js,jsx
+    files: ["**/*.{js,jsx}"],
+    ...js.configs.recommended,
     languageOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module", // Added for clarity with ES modules
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+        ecmaFeatures: { jsx: true },
+      },
       globals: globals.browser,
     },
     plugins: {
@@ -27,8 +28,6 @@ export default [ // Changed from tseslint.config to a plain array
         "warn",
         { allowConstantExport: true },
       ],
-      // Removed: "@typescript-eslint/no-unused-vars": "off",
-      // Standard 'no-unused-vars' from js.configs.recommended will apply.
     },
-  }
+  },
 ];


### PR DESCRIPTION
## Summary
- update ESLint flat config to extend `@eslint/js` using object spread
- enable JSX parsing via `parserOptions`

## Testing
- `composer install --no-interaction --no-progress --no-scripts`
- `./vendor/bin/phpunit -c phpunit.xml.dist`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68777ed58d788332a46283e2aeae2c68