### PR TITLE
fix: repair Dropbox sync, share quota and reader bugs; remove duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 .windsurf/*
+.claude/*
 
 # Local testing files
 passwords.txt

--- a/backend/.env
+++ b/backend/.env
@@ -53,6 +53,16 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
 # =============================================================================
+# REVERSE PROXY
+# =============================================================================
+# Comma-separated list of proxy addresses to trust for X-Forwarded-* headers.
+# Leave empty when Nginx talks to PHP-FPM directly (the Docker setup).
+# Set it when the app sits behind an extra proxy or CDN (e.g. Cloudflare),
+# otherwise per-IP rate limiting sees every visitor as the same address.
+# Example: TRUSTED_PROXIES=127.0.0.1,REMOTE_ADDR
+TRUSTED_PROXIES=
+
+# =============================================================================
 # EMAIL CONFIGURATION
 # =============================================================================
 MAILER_TRANSPORT=sync

--- a/backend/config/packages/framework.yaml
+++ b/backend/config/packages/framework.yaml
@@ -21,6 +21,18 @@ framework:
         default_uri: '%env(APP_SCHEME)%://%env(APP_HOST)%:%env(APP_PORT)%'
         utf8: true
 
+    # Behind a reverse proxy or CDN, REMOTE_ADDR is the proxy rather than the
+    # visitor. Rate limiting keys on the client IP, so without this every
+    # request looks like it comes from one address and the login/register
+    # limiters become global instead of per-client.
+    #
+    # Set TRUSTED_PROXIES to the proxy addresses (e.g. "127.0.0.1,REMOTE_ADDR"
+    # or your CDN's ranges) in production. Left empty it changes nothing, which
+    # is correct for the Docker-only setup where Nginx passes the real
+    # REMOTE_ADDR straight through to PHP-FPM.
+    trusted_proxies: '%env(default::TRUSTED_PROXIES)%'
+    trusted_headers: ['x-forwarded-for', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-host']
+
 when@test:
     framework:
         test: true

--- a/backend/config/routes.yaml
+++ b/backend/config/routes.yaml
@@ -4,11 +4,5 @@ controllers:
         namespace: App\Controller
     type: attribute
 
-# React frontend routes - let the frontend handle routing
-frontend:
-    path: /{reactRouting}
-    controller: App\Controller\FrontendController::index
-    requirements:
-        reactRouting: ^(?!api|_wdt|_profiler).+
-    defaults:
-        reactRouting: ''
+# The catch-all that hands routing to React is declared on FrontendController
+# itself, like every other route in this application.

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -107,6 +107,12 @@ services:
         arguments:
             $comicsDirectory: '%comics_directory%'
             $frontendUrl: '%frontend_url%'
+            $mailerFromAddress: '%mailer_from_address%'
+            $mailerFromName: '%mailer_from_name%'
+
+    App\Service\DropboxImportService:
+        arguments:
+            $dropboxAppFolder: '%dropbox_app_folder%'
 
     App\Controller\DropboxController:
         arguments:
@@ -114,13 +120,10 @@ services:
             $dropboxAppSecret: '%env(DROPBOX_APP_SECRET)%'
             $dropboxRedirectUri: '%env(DROPBOX_REDIRECT_URI)%'
             $frontendBaseUrl: '%frontend_url%'
-            $comicsDirectory: '%comics_directory%'
-            $dropboxAppFolder: '%dropbox_app_folder%'
+            $dropboxSyncLimit: '%dropbox_sync_limit%'
 
     App\Command\DropboxSyncCommand:
         arguments:
-            $comicsDirectory: '%comics_directory%'
-            $dropboxAppFolder: '%dropbox_app_folder%'
             $defaultSyncLimit: '%dropbox_sync_limit%'
 
     App\Command\BackfillComicFileSizeCommand:

--- a/backend/migrations/Version20260805120000.php
+++ b/backend/migrations/Version20260805120000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260805120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Record the source Dropbox path on imported comics so re-syncs can skip them.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comic ADD dropbox_path VARCHAR(500) DEFAULT NULL');
+        $this->addSql('CREATE INDEX IDX_comic_owner_dropbox_path ON comic (owner_id, dropbox_path)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_comic_owner_dropbox_path ON comic');
+        $this->addSql('ALTER TABLE comic DROP dropbox_path');
+    }
+}

--- a/backend/migrations/Version20260805130000.php
+++ b/backend/migrations/Version20260805130000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260805130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Track a per-reader revision on reading progress so out-of-order saves cannot overwrite a newer page.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comic_reading_progress ADD revision INT DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comic_reading_progress DROP revision');
+    }
+}

--- a/backend/src/Command/CleanupExpiredSharesCommand.php
+++ b/backend/src/Command/CleanupExpiredSharesCommand.php
@@ -37,7 +37,7 @@ class CleanupExpiredSharesCommand extends Command
         private EntityManagerInterface $entityManager,
         private ShareTokenRepository $shareTokenRepository,
         private LoggerInterface $logger,
-        string $publicSharesDirectory = null
+        ?string $publicSharesDirectory = null
     ) {
         parent::__construct();
         // If not explicitly provided, use a default path

--- a/backend/src/Command/DropboxSyncCommand.php
+++ b/backend/src/Command/DropboxSyncCommand.php
@@ -151,62 +151,62 @@ class DropboxSyncCommand extends Command
      */
     private function syncUserDropbox(User $user, SymfonyStyle $io, bool $dryRun, int $limit): array
     {
-        $newFiles = 0;
-        $errors = 0;
-
         try {
             $client = $this->dropboxClientFactory->createForUser($user);
-            $files = $this->dropboxImport->listCbzFiles($client);
 
-            if ($files === []) {
-                $io->text('No CBZ files found in Dropbox');
-                return ['newFiles' => 0, 'errors' => 0];
-            }
+            // The loop itself lives in the service, shared with the HTTP sync
+            // endpoint; this callback is all the console adds to it.
+            $result = $this->dropboxImport->syncUser(
+                $client,
+                $user,
+                $limit,
+                $dryRun,
+                fn (string $event, array $context) => $this->report($io, $dryRun, $event, $context)
+            );
 
-            $io->text(sprintf('Found %d CBZ file(s) in Dropbox', count($files)));
-            $importedIndex = $this->dropboxImport->getImportedIndex($user);
-
-            $processedCount = 0;
-            foreach ($files as $fileInfo) {
-                if ($this->dropboxImport->isImported($fileInfo, $importedIndex)) {
-                    $io->text("Skipping {$fileInfo['name']} (already imported)");
-                    continue;
-                }
-
-                if ($processedCount >= $limit) {
-                    $io->text(sprintf('Reached limit of %d files for this user. Skipping remaining files.', $limit));
-                    break;
-                }
-
-                $folderPath = dirname($fileInfo['path']);
-                $folderInfo = $folderPath !== '/' ? " (in {$folderPath})" : '';
-                $tagsInfo = $fileInfo['tags'] !== [] ? ' [Tags: ' . implode(', ', $fileInfo['tags']) . ']' : '';
-                $io->text("Processing {$fileInfo['name']}{$folderInfo}...");
-
-                if ($dryRun) {
-                    $io->text("  [DRY RUN] Would download and import {$fileInfo['name']}{$tagsInfo}");
-                    $newFiles++;
-                    $processedCount++;
-                    continue;
-                }
-
-                try {
-                    $this->dropboxImport->import($client, $user, $fileInfo);
-                    $importedIndex['paths'][mb_strtolower($fileInfo['path'])] = true;
-                    $io->text("  ✓ Successfully imported {$fileInfo['name']}{$tagsInfo}");
-                    $newFiles++;
-                } catch (\Throwable $e) {
-                    $io->error("  ✗ Failed to import {$fileInfo['name']}: " . $e->getMessage());
-                    $errors++;
-                }
-
-                $processedCount++; // Failed attempts count towards the limit too.
-            }
+            return ['newFiles' => $result['newFiles'], 'errors' => $result['failed']];
         } catch (\Throwable $e) {
             $io->error('Failed to connect to Dropbox: ' . $e->getMessage());
-            $errors++;
-        }
 
-        return ['newFiles' => $newFiles, 'errors' => $errors];
+            return ['newFiles' => 0, 'errors' => 1];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function report(SymfonyStyle $io, bool $dryRun, string $event, array $context): void
+    {
+        $file = $context['file'] ?? null;
+        $tagsInfo = $file && $file['tags'] !== [] ? ' [Tags: ' . implode(', ', $file['tags']) . ']' : '';
+
+        switch ($event) {
+            case 'listed':
+                $io->text($context['count'] === 0
+                    ? 'No CBZ files found in Dropbox'
+                    : sprintf('Found %d CBZ file(s) in Dropbox', $context['count']));
+                break;
+            case 'skipped':
+                $io->text("Skipping {$file['name']} (already imported)");
+                break;
+            case 'limitReached':
+                $io->text(sprintf('Reached limit of %d files for this user. Skipping remaining files.', $context['limit']));
+                break;
+            case 'importing':
+                $folderPath = dirname($file['path']);
+                $folderInfo = $folderPath !== '/' ? " (in {$folderPath})" : '';
+                $io->text("Processing {$file['name']}{$folderInfo}...");
+
+                if ($dryRun) {
+                    $io->text("  [DRY RUN] Would download and import {$file['name']}{$tagsInfo}");
+                }
+                break;
+            case 'imported':
+                $io->text("  ✓ Successfully imported {$file['name']}{$tagsInfo}");
+                break;
+            case 'failed':
+                $io->error("  ✗ Failed to import {$file['name']}: " . $context['exception']->getMessage());
+                break;
+        }
     }
 }

--- a/backend/src/Command/DropboxSyncCommand.php
+++ b/backend/src/Command/DropboxSyncCommand.php
@@ -3,18 +3,15 @@
 namespace App\Command;
 
 use App\Entity\User;
-use App\Entity\Comic;
-use App\Service\ComicService;
 use App\Service\DropboxClientFactory;
+use App\Service\DropboxImportService;
 use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * Syncs comics from Dropbox for all connected users.
@@ -25,7 +22,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  * Usage Examples:
  * --------------
  *
- * 1. Sync all users (default: 3 files per user):
+ * 1. Sync all users (default limit from DROPBOX_SYNC_LIMIT):
  *    php bin/console app:dropbox-sync
  *
  * 2. Sync all users with custom limit:
@@ -40,12 +37,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  * 5. Cron job example (run at midnight with 3 file limit):
  *    0 0 * * * cd /path/to/project && php bin/console app:dropbox-sync --limit=3
  *
- * The command will:
- * - Find all users with Dropbox tokens
- * - Check their Dropbox app folder for new CBZ files
- * - Download and import any new comics
- * - Create comics with "Dropbox" tag for easy identification
- * - Store files in user-specific dropbox subdirectories
+ * The listing, duplicate detection and import logic live in DropboxImportService,
+ * which this command shares with the /api/dropbox endpoints.
  */
 #[AsCommand(
     name: 'app:dropbox-sync',
@@ -53,31 +46,13 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 )]
 class DropboxSyncCommand extends Command
 {
-    private EntityManagerInterface $entityManager;
-    private ComicService $comicService;
-    private string $comicsDirectory;
-    private string $dropboxAppFolder;
-    private int $defaultSyncLimit;
-    private LoggerInterface $logger;
-    private DropboxClientFactory $dropboxClientFactory;
-
     public function __construct(
-        EntityManagerInterface $entityManager,
-        ComicService $comicService,
-        LoggerInterface $logger,
-        DropboxClientFactory $dropboxClientFactory,
-        string $comicsDirectory,
-        string $dropboxAppFolder,
-        int $defaultSyncLimit
+        private readonly EntityManagerInterface $entityManager,
+        private readonly DropboxClientFactory $dropboxClientFactory,
+        private readonly DropboxImportService $dropboxImport,
+        private readonly int $defaultSyncLimit
     ) {
         parent::__construct();
-        $this->entityManager = $entityManager;
-        $this->comicService = $comicService;
-        $this->logger = $logger;
-        $this->dropboxClientFactory = $dropboxClientFactory;
-        $this->comicsDirectory = $comicsDirectory;
-        $this->dropboxAppFolder = $dropboxAppFolder;
-        $this->defaultSyncLimit = $defaultSyncLimit;
     }
 
     protected function configure(): void
@@ -91,8 +66,7 @@ class DropboxSyncCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $userId = $input->getOption('user-id');
-        $dryRun = $input->getOption('dry-run');
+        $dryRun = (bool) $input->getOption('dry-run');
         $limit = $input->getOption('limit') ? (int) $input->getOption('limit') : $this->defaultSyncLimit;
 
         if ($dryRun) {
@@ -101,28 +75,12 @@ class DropboxSyncCommand extends Command
 
         $io->info(sprintf('Sync limit: %d files per user', $limit));
 
-        // Get users with Dropbox tokens
-        $userRepository = $this->entityManager->getRepository(User::class);
-        
-        if ($userId) {
-            $users = [$userRepository->find($userId)];
-            if (!$users[0]) {
-                $io->error("User with ID {$userId} not found");
-                return Command::FAILURE;
-            }
-            if (!$users[0]->getDropboxAccessToken()) {
-                $io->error("User with ID {$userId} does not have Dropbox connected");
-                return Command::FAILURE;
-            }
-        } else {
-            $qb = $userRepository->createQueryBuilder('u')
-                ->where('u.dropboxAccessToken IS NOT NULL')
-                ->andWhere('u.dropboxAccessToken != :empty')
-                ->setParameter('empty', '');
-            $users = $qb->getQuery()->getResult();
+        $users = $this->resolveUsers($input->getOption('user-id'), $io);
+        if ($users === null) {
+            return Command::FAILURE;
         }
 
-        if (empty($users)) {
+        if ($users === []) {
             $io->info('No users with Dropbox connections found');
             return Command::SUCCESS;
         }
@@ -134,7 +92,7 @@ class DropboxSyncCommand extends Command
 
         foreach ($users as $user) {
             $io->section(sprintf('Processing user: %s (ID: %d)', $user->getEmail(), $user->getId()));
-            
+
             try {
                 $result = $this->syncUserDropbox($user, $io, $dryRun, $limit);
                 if (!$dryRun) {
@@ -143,7 +101,7 @@ class DropboxSyncCommand extends Command
                 }
                 $totalNewFiles += $result['newFiles'];
                 $totalErrors += $result['errors'];
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $io->error(sprintf('Failed to sync user %s: %s', $user->getEmail(), $e->getMessage()));
                 $totalErrors++;
             }
@@ -158,240 +116,97 @@ class DropboxSyncCommand extends Command
         return $totalErrors > 0 ? Command::FAILURE : Command::SUCCESS;
     }
 
-    private function syncUserDropbox(User $user, SymfonyStyle $io, bool $dryRun, int $limit = null): array
+    /**
+     * @return list<User>|null Null signals a fatal argument error already reported to the console.
+     */
+    private function resolveUsers(mixed $userId, SymfonyStyle $io): ?array
     {
-        $limit = $limit ?? $this->defaultSyncLimit;
+        $userRepository = $this->entityManager->getRepository(User::class);
+
+        if (!$userId) {
+            return $userRepository->createQueryBuilder('u')
+                ->where('u.dropboxAccessToken IS NOT NULL')
+                ->andWhere('u.dropboxAccessToken != :empty')
+                ->setParameter('empty', '')
+                ->getQuery()
+                ->getResult();
+        }
+
+        $user = $userRepository->find($userId);
+        if (!$user) {
+            $io->error("User with ID {$userId} not found");
+            return null;
+        }
+
+        if (!$user->getDropboxAccessToken()) {
+            $io->error("User with ID {$userId} does not have Dropbox connected");
+            return null;
+        }
+
+        return [$user];
+    }
+
+    /**
+     * @return array{newFiles: int, errors: int}
+     */
+    private function syncUserDropbox(User $user, SymfonyStyle $io, bool $dryRun, int $limit): array
+    {
         $newFiles = 0;
         $errors = 0;
 
         try {
             $client = $this->dropboxClientFactory->createForUser($user);
-            
-            // Get existing comics for this user
-            $existingComics = $this->entityManager->getRepository(Comic::class)->findBy(['owner' => $user]);
-            $existingFiles = array_map(function($comic) {
-                return basename($comic->getFilePath());
-            }, $existingComics);
+            $files = $this->dropboxImport->listCbzFiles($client);
 
-            // Get all files recursively with folder structure from the configured app folder
-            $allFiles = $this->getAllDropboxFiles($client, $this->dropboxAppFolder);
-
-            if (empty($allFiles)) {
+            if ($files === []) {
                 $io->text('No CBZ files found in Dropbox');
                 return ['newFiles' => 0, 'errors' => 0];
             }
 
-            $io->text(sprintf('Found %d CBZ file(s) in Dropbox', count($allFiles)));
-
-            $userDirectory = $this->comicsDirectory . '/' . $user->getId();
-            $dropboxDirectory = $userDirectory . '/dropbox';
-
-            if (!$dryRun) {
-                // Ensure directories exist
-                if (!file_exists($userDirectory)) {
-                    mkdir($userDirectory, 0777, true);
-                }
-                if (!file_exists($dropboxDirectory)) {
-                    mkdir($dropboxDirectory, 0777, true);
-                }
-            }
+            $io->text(sprintf('Found %d CBZ file(s) in Dropbox', count($files)));
+            $importedIndex = $this->dropboxImport->getImportedIndex($user);
 
             $processedCount = 0;
-            foreach ($allFiles as $fileInfo) {
-                $fileName = basename($fileInfo['path']);
-                
-                if (in_array($fileName, $existingFiles)) {
-                    $io->text("Skipping {$fileName} (already exists)");
+            foreach ($files as $fileInfo) {
+                if ($this->dropboxImport->isImported($fileInfo, $importedIndex)) {
+                    $io->text("Skipping {$fileInfo['name']} (already imported)");
                     continue;
                 }
 
-                // Check if we've reached the limit for this user
                 if ($processedCount >= $limit) {
-                    $io->text(sprintf("Reached limit of %d files for this user. Skipping remaining files.", $limit));
+                    $io->text(sprintf('Reached limit of %d files for this user. Skipping remaining files.', $limit));
                     break;
                 }
 
                 $folderPath = dirname($fileInfo['path']);
-                $folderInfo = $folderPath !== '/' ? " (in {$folderPath})" : "";
-                $io->text("Processing {$fileName}{$folderInfo}...");
+                $folderInfo = $folderPath !== '/' ? " (in {$folderPath})" : '';
+                $tagsInfo = $fileInfo['tags'] !== [] ? ' [Tags: ' . implode(', ', $fileInfo['tags']) . ']' : '';
+                $io->text("Processing {$fileInfo['name']}{$folderInfo}...");
 
                 if ($dryRun) {
-                    $tagsInfo = !empty($fileInfo['tags']) ? ' [Tags: ' . implode(', ', $fileInfo['tags']) . ']' : '';
-                    $io->text("  [DRY RUN] Would download and import {$fileName}{$tagsInfo}");
+                    $io->text("  [DRY RUN] Would download and import {$fileInfo['name']}{$tagsInfo}");
                     $newFiles++;
                     $processedCount++;
                     continue;
                 }
 
                 try {
-                    // Download the file from Dropbox
-                    $fileContent = $client->download($fileInfo['path']);
-                    
-                    // Save to dropbox subdirectory
-                    $localPath = $dropboxDirectory . '/' . $fileName;
-                    file_put_contents($localPath, $fileContent);
-                    
-                    // Create a temporary UploadedFile object for the ComicService
-                    $tempFile = new UploadedFile(
-                        $localPath,
-                        $fileName,
-                        'application/zip',
-                        null,
-                        true // Test mode
-                    );
-                    
-                    // Extract title from filename
-                    $title = pathinfo($fileName, PATHINFO_FILENAME);
-                    $title = str_replace(['_', '-'], ' ', $title);
-                    $title = ucwords($title);
-                    
-                    // Create tags from folder structure + Dropbox tag
-                    $tags = array_merge(['Dropbox'], $fileInfo['tags']);
-                    
-                    // Create comic entry
-                    $comic = $this->comicService->uploadComic(
-                        $tempFile,
-                        $user,
-                        $title,
-                        null, // author
-                        null, // publisher
-                        'Synced from Dropbox', // description
-                        $tags
-                    );
-                    
-                    $tagsInfo = !empty($fileInfo['tags']) ? ' [Tags: ' . implode(', ', $tags) . ']' : '';
-                    $io->text("  ✓ Successfully imported {$fileName}{$tagsInfo}");
+                    $this->dropboxImport->import($client, $user, $fileInfo);
+                    $importedIndex['paths'][mb_strtolower($fileInfo['path'])] = true;
+                    $io->text("  ✓ Successfully imported {$fileInfo['name']}{$tagsInfo}");
                     $newFiles++;
-                    $processedCount++;
-                    
-                } catch (\Exception $e) {
-                    $io->error("  ✗ Failed to import {$fileName}: " . $e->getMessage());
+                } catch (\Throwable $e) {
+                    $io->error("  ✗ Failed to import {$fileInfo['name']}: " . $e->getMessage());
                     $errors++;
-                    $processedCount++; // Count failed attempts towards limit too
                 }
-            }
 
-        } catch (\Exception $e) {
+                $processedCount++; // Failed attempts count towards the limit too.
+            }
+        } catch (\Throwable $e) {
             $io->error('Failed to connect to Dropbox: ' . $e->getMessage());
             $errors++;
         }
 
         return ['newFiles' => $newFiles, 'errors' => $errors];
-    }
-
-    private function formatFileSize(int $bytes): string
-    {
-        $units = ['B', 'KB', 'MB', 'GB'];
-        $bytes = max($bytes, 0);
-        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
-        $pow = min($pow, count($units) - 1);
-        
-        $bytes /= (1 << (10 * $pow));
-        
-        return round($bytes, 2) . ' ' . $units[$pow];
-    }
-
-    /**
-     * Recursively get all CBZ files from Dropbox with their folder structure
-     */
-    private function getAllDropboxFiles($client, string $path = '/'): array
-    {
-        $allFiles = [];
-        
-        try {
-            $response = $client->listFolder($path);
-            
-            foreach ($response['entries'] as $entry) {
-                if ($entry['.tag'] === 'file' && strtolower(pathinfo($entry['name'], PATHINFO_EXTENSION)) === 'cbz') {
-                    // Extract folder path and convert to tags
-                    $folderPath = trim(dirname($entry['path_display']), '/');
-                    $tags = $this->convertPathToTags($folderPath);
-
-                    $allFiles[] = [
-                        'path' => $entry['path_display'],
-                        'name' => $entry['name'],
-                        'size' => $entry['size'],
-                        'modified' => $entry['client_modified'],
-                        'tags' => $tags
-                    ];
-                } elseif ($entry['.tag'] === 'folder') {
-                    // Recursively get files from subfolders
-                    $subFiles = $this->getAllDropboxFiles($client, $entry['path_display']);
-                    $allFiles = array_merge($allFiles, $subFiles);
-                }
-            }
-        } catch (\Exception $e) {
-            // Handle pagination or other errors
-            $this->logger->warning('Error listing Dropbox folder during sync.', ['exception' => $e]);
-        }
-        
-        return $allFiles;
-    }
-
-    /**
-     * Convert folder path to tags
-     * Examples:
-     * - "/Applications/StarbugStoneComics/superHero" -> ["Super Hero"]
-     * - "/Applications/StarbugStoneComics/Manga/Anime" -> ["Manga", "Anime"]
-     * - "/Applications/StarbugStoneComics/sci-fi/space_opera" -> ["Sci Fi", "Space Opera"]
-     */
-    private function convertPathToTags(string $path): array
-    {
-        if (empty($path) || $path === '.') {
-            return [];
-        }
-        
-        // Remove the app folder prefix from the path to get only the user's folder structure
-        $appFolderPrefix = trim($this->dropboxAppFolder, '/') . '/';
-        $relativePath = ltrim($path, '/');
-        
-        if (str_starts_with($relativePath, $appFolderPrefix)) {
-            $relativePath = substr($relativePath, strlen($appFolderPrefix));
-        }
-        
-        if (empty($relativePath)) {
-            return [];
-        }
-        
-        $folders = explode('/', $relativePath);
-        $tags = [];
-        
-        foreach ($folders as $folder) {
-            if (!empty($folder)) {
-                // Convert camelCase and snake_case to readable format
-                $tag = $this->formatFolderName($folder);
-                if (!empty($tag)) {
-                    $tags[] = $tag;
-                }
-            }
-        }
-        
-        return $tags;
-    }
-
-    /**
-     * Format folder name to readable tag
-     * Examples:
-     * - "superHero" -> "Super Hero"
-     * - "sci-fi" -> "Sci Fi"
-     * - "space_opera" -> "Space Opera"
-     * - "MANGA" -> "Manga"
-     */
-    private function formatFolderName(string $folderName): string
-    {
-        // Replace underscores and hyphens with spaces
-        $formatted = str_replace(['_', '-'], ' ', $folderName);
-        
-        // Split camelCase
-        $formatted = preg_replace('/([a-z])([A-Z])/', '$1 $2', $formatted);
-        
-        // Clean up multiple spaces
-        $formatted = preg_replace('/\s+/', ' ', $formatted);
-        
-        // Trim and convert to title case
-        $formatted = trim($formatted);
-        $formatted = ucwords(strtolower($formatted));
-        
-        return $formatted;
     }
 }

--- a/backend/src/Command/ImportComicsCommand.php
+++ b/backend/src/Command/ImportComicsCommand.php
@@ -142,7 +142,7 @@ class ImportComicsCommand extends Command
                 // Create user directory if it doesn't exist
                 $userDirectory = $comicsDirectory . '/' . $user->getId();
                 if (!is_dir($userDirectory)) {
-                    mkdir($userDirectory, 0777, true);
+                    mkdir($userDirectory, 0775, true);
                 }
                 
                 // Copy file to user's comics directory
@@ -243,7 +243,7 @@ class ImportComicsCommand extends Command
 
         // Create covers directory if it doesn't exist
         if (!file_exists($coverPath)) {
-            mkdir($coverPath, 0777, true);
+            mkdir($coverPath, 0775, true);
         }
 
         // Extract cover image

--- a/backend/src/Command/SetupUploadDirectoriesCommand.php
+++ b/backend/src/Command/SetupUploadDirectoriesCommand.php
@@ -84,7 +84,7 @@ class SetupUploadDirectoriesCommand extends Command
     {
         if (!file_exists($directory)) {
             $io->note(sprintf('Creating directory: %s', $directory));
-            if (!mkdir($directory, 0777, true)) {
+            if (!mkdir($directory, 0775, true)) {
                 $io->error(sprintf('Failed to create directory: %s', $directory));
                 return;
             }
@@ -92,10 +92,11 @@ class SetupUploadDirectoriesCommand extends Command
             $io->note(sprintf('Directory already exists: %s', $directory));
         }
         
-        // Ensure directory is writable
+        // Ensure directory is writable by the owner and group (PHP-FPM and the
+        // web server share a group; world-writable uploads are not needed).
         if (!is_writable($directory)) {
             $io->note(sprintf('Setting permissions on directory: %s', $directory));
-            chmod($directory, 0777);
+            chmod($directory, 0775);
         }
     }
 }

--- a/backend/src/Controller/AuthController.php
+++ b/backend/src/Controller/AuthController.php
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Event\LogoutEvent;

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -7,23 +7,19 @@ use App\Entity\ComicReadingProgress;
 use App\Entity\Tag;
 use App\Entity\User;
 use App\Service\AdminAuditService;
+use App\Service\ComicSerializer;
 use App\Service\ComicUploadFilenameValidator;
 use App\Service\ComicService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\String\Slugger\SluggerInterface;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use ZipArchive;
 
 #[Route('/api/comics', name: 'api_comics_')]
@@ -33,27 +29,29 @@ class ComicController extends AbstractController
     private const ASSEMBLED_UPLOAD_FILENAME = 'assembled.cbz';
 
     private string $tempUploadDir;
-    private RequestStack $requestStack;
-    private UrlGeneratorInterface $urlGenerator;
-    
+
     public function __construct(
-        private string $comicsDirectory,
-        RequestStack $requestStack,
-        UrlGeneratorInterface $urlGenerator,
+        private readonly string $comicsDirectory,
         private readonly LoggerInterface $logger,
         private readonly int $uploadMaxChunkBytes,
         private readonly int $uploadMaxTotalBytes,
         private readonly int $uploadMaxTotalChunks,
         private readonly int $uploadUserQuotaBytes,
-        private readonly ComicUploadFilenameValidator $uploadFilenameValidator
+        private readonly ComicUploadFilenameValidator $uploadFilenameValidator,
+        private readonly ComicSerializer $comicSerializer
     ) {
         $this->tempUploadDir = sys_get_temp_dir() . '/comic_uploads';
-        $this->requestStack = $requestStack;
-        $this->urlGenerator = $urlGenerator;
-        
-        // Ensure temp directory exists
-        if (!file_exists($this->tempUploadDir)) {
-            mkdir($this->tempUploadDir, 0775, true);
+    }
+
+    /**
+     * Chunk staging lives under the system temp dir; create it lazily so a
+     * filesystem write does not happen on every request that touches this
+     * controller.
+     */
+    private function ensureTempUploadDir(string $directory): void
+    {
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new \RuntimeException('Failed to create the upload staging directory.');
         }
     }
 
@@ -163,62 +161,9 @@ class ComicController extends AbstractController
         
         $comics = $qb->getQuery()->getResult();
 
-        // Transform comics to array
-        $comicsArray = [];
-        foreach ($comics as $comic) {
-            $fullCoverUrl = null;
-            if ($comic->getCoverImagePath()) {
-                try {
-                    $filename = basename($comic->getCoverImagePath());
-                    // Manually construct the URL path to avoid using internal Docker hostnames
-                    $fullCoverUrl = '/api/comics/cover/' . $comic->getOwner()->getId() . '/' . $comic->getId() . '/' . $filename;
-                } catch (\Exception $e) {
-                    $this->logger->debug('Could not generate cover URL.', ['comic_id' => $comic->getId()]);
-                    // $fullCoverUrl remains null
-                }
-            }
-
-            // Get reading progress if exists
-            // Ensure $user is available in this scope for reading progress.
-            // It should be, as it's defined at the beginning of the method.
-            $readingProgress = $entityManager->getRepository(ComicReadingProgress::class)
-                ->findOneBy(['comic' => $comic, 'user' => $user]);
-
-            $comicData = [
-                'id' => $comic->getId(),
-                'title' => $comic->getTitle(),
-                'author' => $comic->getAuthor(),
-                'publisher' => $comic->getPublisher(),
-                'description' => $comic->getDescription(),
-                'coverImagePath' => $fullCoverUrl,
-                'pageCount' => $comic->getPageCount(),
-                'uploadedAt' => $comic->getUploadedAt()->format('c'),
-                'tags' => array_map(function ($tag) {
-                    return [
-                        'id' => $tag->getId(),
-                        'name' => $tag->getName()
-                    ];
-                }, $comic->getTags()->toArray()),
-                'readingProgress' => $readingProgress ? [
-                    'currentPage' => $readingProgress->getCurrentPage(),
-                    'lastReadAt' => $readingProgress->getLastReadAt()->format('c'),
-                    'completed' => $readingProgress->isCompleted()
-                ] : null
-            ];
-
-            if ($adminContext) {
-                $owner = $comic->getOwner();
-                $comicData['owner'] = [
-                    'id' => $owner?->getId(),
-                    'email' => $owner?->getEmail(),
-                    'name' => $owner?->getName(),
-                ];
-            }
-
-            $comicsArray[] = $comicData;
-        }
-
-        return $this->json(['comics' => $comicsArray]);
+        return $this->json([
+            'comics' => $this->comicSerializer->serializeMany($comics, $user, $adminContext),
+        ]);
     }
 
     #[Route('', name: 'batch_update', methods: ['PATCH'])]
@@ -401,58 +346,12 @@ class ComicController extends AbstractController
             return $this->json(['message' => 'Access denied or comic not found'], Response::HTTP_FORBIDDEN); // Or HTTP_NOT_FOUND
         }
 
-        // Get reading progress if exists
-        $readingProgress = $entityManager->getRepository(ComicReadingProgress::class)
-            ->findOneBy(['comic' => $comic, 'user' => $user]);
-
-        // Transform comic to array
-        $fullCoverUrl = null;
-        if ($comic->getCoverImagePath()) {
-            try {
-                $filename = basename($comic->getCoverImagePath());
-                // Manually construct the URL path to avoid using internal Docker hostnames
-                $fullCoverUrl = '/api/comics/cover/' . $comic->getOwner()->getId() . '/' . $comic->getId() . '/' . $filename;
-            } catch (\Exception $e) {
-                $this->logger->debug('Could not generate cover URL.', ['comic_id' => $comic->getId()]);
-                // $fullCoverUrl remains null
-            }
-        }
-
-        $comicArray = [
-            'id' => $comic->getId(),
-            'title' => $comic->getTitle(),
-            'author' => $comic->getAuthor(),
-            'publisher' => $comic->getPublisher(),
-            'description' => $comic->getDescription(),
-            'coverImagePath' => $fullCoverUrl,
-            'pageCount' => $comic->getPageCount(),
-            'uploadedAt' => $comic->getUploadedAt()->format('c'),
-            'tags' => array_map(function ($tag) {
-                return [
-                    'id' => $tag->getId(),
-                    'name' => $tag->getName()
-                ];
-            }, $comic->getTags()->toArray()),
-            'readingProgress' => $readingProgress ? [
-                'currentPage' => $readingProgress->getCurrentPage(),
-                'lastReadAt' => $readingProgress->getLastReadAt()->format('c'),
-                'completed' => $readingProgress->isCompleted()
-            ] : null,
-            'owner' => [
-                'id' => $comic->getOwner()?->getId(),
-                'email' => $comic->getOwner()?->getEmail(),
-                'name' => $comic->getOwner()?->getName(),
-            ],
-        ];
-
-        return $this->json(['comic' => $comicArray]);
+        return $this->json(['comic' => $this->comicSerializer->serialize($comic, $user)]);
     }
 
     #[Route('', name: 'create', methods: ['POST'])]
     public function create(
-        Request $request, 
-        EntityManagerInterface $entityManager, 
-        ValidatorInterface $validator,
+        Request $request,
         ComicService $comicService
     ): JsonResponse {
         // Get the current user
@@ -510,10 +409,9 @@ class ComicController extends AbstractController
 
     #[Route('/{id}', name: 'update', methods: ['PUT', 'PATCH'])]
     public function update(
-        int $id, 
-        Request $request, 
+        int $id,
+        Request $request,
         EntityManagerInterface $entityManager,
-        ValidatorInterface $validator,
         AdminAuditService $auditService
     ): JsonResponse {
         // Get the current user
@@ -621,7 +519,7 @@ class ComicController extends AbstractController
 
     #[Route('/{id}', name: 'delete', methods: ['DELETE'])]
     public function delete(
-        string $id, 
+        int $id,
         EntityManagerInterface $entityManager,
         ComicService $comicService
     ): JsonResponse {
@@ -733,10 +631,8 @@ class ComicController extends AbstractController
             
             // Create user-specific directory for chunks
             $userChunkDir = $this->tempUploadDir . '/' . $user->getId() . '/' . $fileId;
-            if (!file_exists($userChunkDir)) {
-                mkdir($userChunkDir, 0775, true);
-            }
-            
+            $this->ensureTempUploadDir($userChunkDir);
+
             // Save metadata
             file_put_contents(
                 $userChunkDir . '/metadata.json', 
@@ -776,14 +672,13 @@ class ComicController extends AbstractController
         try {
             $fileId = (string) $request->request->get('fileId');
             $this->assertSafeFileId($fileId);
-            $chunkIndex = (int)$request->request->get('chunkIndex');
-            $totalChunks = (int)$request->request->get('totalChunks');
+            $chunkIndex = (int) $request->request->get('chunkIndex');
             $chunk = $request->files->get('chunk');
-            
-            if (!$fileId || !isset($chunkIndex) || !$chunk) {
+
+            if (!$chunk) {
                 return $this->json(['message' => 'Missing required parameters'], Response::HTTP_BAD_REQUEST);
             }
-            
+
             // Check if chunk is valid
             if (!$chunk->isValid()) {
                 return $this->json(['message' => 'Invalid chunk: ' . $chunk->getErrorMessage()], Response::HTTP_BAD_REQUEST);
@@ -933,26 +828,31 @@ class ComicController extends AbstractController
                 true // Test mode to avoid moving the file
             );
             
-            // Extract metadata
-            $comicMetadata = $metadata['metadata'];
-            
+            // Extract metadata. Only the title is required; the rest are optional
+            // and may legitimately be absent from the init payload.
+            $comicMetadata = is_array($metadata['metadata'] ?? null) ? $metadata['metadata'] : [];
+            $title = trim((string) ($comicMetadata['title'] ?? ''));
+            if ($title === '') {
+                return $this->json(['message' => 'Title is required'], Response::HTTP_BAD_REQUEST);
+            }
+
             // Create comic in database
             $comic = $comicService->uploadComic(
                 $tempFile,
                 $user,
-                $comicMetadata['title'],
-                $comicMetadata['author'],
-                $comicMetadata['publisher'],
-                $comicMetadata['description'],
+                $title,
+                $comicMetadata['author'] ?? null,
+                $comicMetadata['publisher'] ?? null,
+                $comicMetadata['description'] ?? null,
                 $comicMetadata['tags'] ?? []
             );
-            
+
             // Clean up temp directory
             $this->cleanupTempDirectory($userChunkDir);
-            
+
             return $this->json([
                 'message' => 'Upload completed successfully',
-                'comic' => $comic->toArray()
+                'comic' => $this->comicSerializer->serialize($comic, $user, false),
             ]);
         } catch (BadRequestHttpException $e) {
             return $this->json(['message' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
@@ -1011,36 +911,32 @@ class ComicController extends AbstractController
         }
 
         // Always look for the comic in the user's directory first
-        $comicsDirectory = $this->getParameter('comics_directory');
         $owner = $comic->getOwner();
-        $userDirectory = $comicsDirectory . '/' . $owner->getId();
-        $filePath = $userDirectory . '/' . $comic->getFilePath();
-        
+        $relativePath = basename((string) $comic->getFilePath());
+        $userDirectory = $this->comicsDirectory . '/' . $owner->getId();
+        $filePath = $userDirectory . '/' . $relativePath;
+
         // Fallback to old path if file doesn't exist in user directory
         if (!file_exists($filePath)) {
-            $filePath = $comicsDirectory . '/' . $comic->getFilePath();
-            
+            $legacyPath = $this->comicsDirectory . '/' . $relativePath;
+
             // If still not found, return error
-            if (!file_exists($filePath)) {
+            if (!file_exists($legacyPath)) {
                 return $this->json(['message' => 'Comic file not found'], Response::HTTP_NOT_FOUND);
             }
-            
-            // If found in the old location, move it to the user's directory for future access
-            try {
-                // Create user directory if it doesn't exist
-                if (!file_exists($userDirectory)) {
-                    mkdir($userDirectory, 0777, true);
+
+            // If found in the old location, copy it into the user's directory for future access
+            if (@mkdir($userDirectory, 0775, true) || is_dir($userDirectory)) {
+                if (@copy($legacyPath, $filePath)) {
+                    $legacyPath = $filePath;
                 }
-                
-                // Copy the file to the user's directory
-                copy($filePath, $userDirectory . '/' . $comic->getFilePath());
-                
-                // Update the file path to use the user's directory
-                $filePath = $userDirectory . '/' . $comic->getFilePath();
-            } catch (\Exception $e) {
-                // If there's an error moving the file, just continue using the old path
-                // We'll log this in a production environment
             }
+
+            if (!is_file($filePath)) {
+                $this->logger->info('Serving comic page from the legacy storage location.', ['comic_id' => $comic->getId()]);
+            }
+
+            $filePath = $legacyPath;
         }
 
         // Open CBZ file

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -797,7 +797,15 @@ class ComicController extends AbstractController
             if ($currentUsage + $totalSize > $this->uploadUserQuotaBytes) {
                 return $this->json(['message' => 'User storage quota exceeded'], Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
             }
-            
+
+            // Extract metadata. Only the title is required; the rest are optional
+            // and may legitimately be absent from the init payload.
+            $comicMetadata = is_array($metadata['metadata'] ?? null) ? $metadata['metadata'] : [];
+            $title = trim((string) ($comicMetadata['title'] ?? ''));
+            if ($title === '') {
+                return $this->json(['message' => 'Title is required'], Response::HTTP_BAD_REQUEST);
+            }
+
             // Combine chunks into final file
             // The client filename is metadata only. Always assemble into a
             // server-controlled path so valid punctuation and Unicode never
@@ -827,14 +835,6 @@ class ComicController extends AbstractController
                 null,
                 true // Test mode to avoid moving the file
             );
-            
-            // Extract metadata. Only the title is required; the rest are optional
-            // and may legitimately be absent from the init payload.
-            $comicMetadata = is_array($metadata['metadata'] ?? null) ? $metadata['metadata'] : [];
-            $title = trim((string) ($comicMetadata['title'] ?? ''));
-            if ($title === '') {
-                return $this->json(['message' => 'Title is required'], Response::HTTP_BAD_REQUEST);
-            }
 
             // Create comic in database
             $comic = $comicService->uploadComic(
@@ -855,9 +855,17 @@ class ComicController extends AbstractController
                 'comic' => $this->comicSerializer->serialize($comic, $user, false),
             ]);
         } catch (BadRequestHttpException $e) {
+            // Clean up if assembly has already occurred
+            if (isset($userChunkDir) && file_exists($userChunkDir)) {
+                $this->cleanupTempDirectory($userChunkDir);
+            }
             return $this->json(['message' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
         } catch (\Exception $e) {
             $this->logger->warning('Error completing upload.', ['user_id' => $user->getId(), 'exception' => $e]);
+            // Clean up if assembly has already occurred
+            if (isset($userChunkDir) && file_exists($userChunkDir)) {
+                $this->cleanupTempDirectory($userChunkDir);
+            }
             return $this->json(['message' => 'Failed to complete upload'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -799,10 +799,14 @@ class ComicController extends AbstractController
             }
 
             // Extract metadata. Only the title is required; the rest are optional
-            // and may legitimately be absent from the init payload.
+            // and may legitimately be absent from the init payload. Validate before
+            // assembling so a rejected upload never leaves staged files behind: the
+            // title comes from the init payload, so retrying can never succeed.
             $comicMetadata = is_array($metadata['metadata'] ?? null) ? $metadata['metadata'] : [];
             $title = trim((string) ($comicMetadata['title'] ?? ''));
             if ($title === '') {
+                $this->cleanupTempDirectory($userChunkDir);
+
                 return $this->json(['message' => 'Title is required'], Response::HTTP_BAD_REQUEST);
             }
 
@@ -1024,6 +1028,18 @@ class ComicController extends AbstractController
         $currentPage = (int) $data['currentPage'];
         $completed = isset($data['completed']) ? (bool) $data['completed'] : false;
 
+        // Optional so older clients keep working; when present it orders saves
+        // that the reader fired in quick succession and that may arrive swapped.
+        // Revisions start at 1: 0 is the stored value for progress that predates
+        // this, so a save numbered 0 could never win the comparison below.
+        $revision = null;
+        if (isset($data['revision'])) {
+            if (!is_numeric($data['revision']) || $data['revision'] < 1) {
+                return $this->json(['message' => 'Invalid revision'], Response::HTTP_BAD_REQUEST);
+            }
+            $revision = (int) $data['revision'];
+        }
+
         if ($isAdminReadingAnotherUsersComic) {
             return $this->json([
                 'message' => 'Admin read-only progress ignored',
@@ -1031,19 +1047,21 @@ class ComicController extends AbstractController
                     'currentPage' => $currentPage,
                     'lastReadAt' => (new \DateTimeImmutable())->format('c'),
                     'completed' => $completed,
+                    'revision' => $revision ?? 0,
                 ],
             ]);
         }
 
         // Update reading progress
-        $progress = $this->updateReadingProgress($user, $comic, $currentPage, $entityManager, $completed);
+        $progress = $this->updateReadingProgress($user, $comic, $currentPage, $entityManager, $completed, $revision);
 
         return $this->json([
             'message' => 'Reading progress updated',
             'progress' => [
                 'currentPage' => $progress->getCurrentPage(),
                 'lastReadAt' => $progress->getLastReadAt()->format('c'),
-                'completed' => $progress->isCompleted()
+                'completed' => $progress->isCompleted(),
+                'revision' => $progress->getRevision(),
             ]
         ]);
     }
@@ -1054,15 +1072,49 @@ class ComicController extends AbstractController
      * Update reading progress for a user and comic
      */
     private function updateReadingProgress(
-        User $user, 
-        Comic $comic, 
-        int $currentPage, 
+        User $user,
+        Comic $comic,
+        int $currentPage,
         EntityManagerInterface $entityManager,
-        bool $completed = false
+        bool $completed = false,
+        ?int $revision = null
     ): ComicReadingProgress {
         // Get existing progress or create new one
         $progress = $entityManager->getRepository(ComicReadingProgress::class)
             ->findOneBy(['comic' => $comic, 'user' => $user]);
+
+        // Mark as completed if specified or if on the last page. Completion is
+        // never taken back here, only granted.
+        $isCompleted = $completed || ($comic->getPageCount() !== null && $currentPage >= $comic->getPageCount());
+
+        if ($progress && $revision !== null) {
+            // Conditional update so the comparison and the write are a single
+            // statement: a save that lost the race leaves the stored page alone.
+            $applied = (int) $entityManager->createQuery(
+                'UPDATE ' . ComicReadingProgress::class . ' p
+                 SET p.currentPage = :currentPage, p.completed = :completed, p.lastReadAt = :lastReadAt, p.revision = :revision
+                 WHERE p.id = :id AND p.revision < :revision'
+            )
+                ->setParameter('currentPage', $currentPage)
+                ->setParameter('completed', $isCompleted || $progress->isCompleted())
+                ->setParameter('lastReadAt', new \DateTimeImmutable())
+                ->setParameter('revision', $revision)
+                ->setParameter('id', $progress->getId())
+                ->execute();
+
+            // A DQL update bypasses the unit of work, so the managed entity is
+            // stale either way: refreshed, it reports whichever save won.
+            $entityManager->refresh($progress);
+
+            if ($applied === 0) {
+                $this->logger->debug('Ignored a superseded reading progress save.', [
+                    'comic_id' => $comic->getId(),
+                    'revision' => $revision,
+                ]);
+            }
+
+            return $progress;
+        }
 
         if (!$progress) {
             $progress = new ComicReadingProgress();
@@ -1073,9 +1125,11 @@ class ComicController extends AbstractController
 
         // Update progress
         $progress->setCurrentPage($currentPage);
-        
-        // Mark as completed if specified or if on the last page
-        if ($completed || ($comic->getPageCount() !== null && $currentPage >= $comic->getPageCount())) {
+        if ($revision !== null) {
+            $progress->setRevision($revision);
+        }
+
+        if ($isCompleted) {
             $progress->setCompleted(true);
         }
 

--- a/backend/src/Controller/DropboxController.php
+++ b/backend/src/Controller/DropboxController.php
@@ -3,9 +3,8 @@
 namespace App\Controller;
 
 use App\Entity\User;
-use App\Entity\Comic;
-use App\Service\ComicService;
 use App\Service\DropboxClientFactory;
+use App\Service\DropboxImportService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -14,48 +13,29 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[Route('/api/dropbox')]
 class DropboxController extends AbstractController
 {
-    private string $dropboxAppKey;
-    private string $dropboxAppSecret;
-    private string $dropboxRedirectUri;
     private SessionInterface $session;
-    private HttpClientInterface $httpClient;
-    private LoggerInterface $logger;
-    private string $frontendBaseUrl;
-    private string $comicsDirectory;
-    private string $dropboxAppFolder;
-    private DropboxClientFactory $dropboxClientFactory;
 
     public function __construct(
-        string $dropboxAppKey,
-        string $dropboxAppSecret,
-        string $dropboxRedirectUri,
+        private readonly string $dropboxAppKey,
+        private readonly string $dropboxAppSecret,
+        private readonly string $dropboxRedirectUri,
         RequestStack $requestStack,
-        HttpClientInterface $httpClient,
-        LoggerInterface $logger,
-        string $frontendBaseUrl,
-        string $comicsDirectory,
-        string $dropboxAppFolder,
-        DropboxClientFactory $dropboxClientFactory
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+        private readonly string $frontendBaseUrl,
+        private readonly DropboxClientFactory $dropboxClientFactory,
+        private readonly DropboxImportService $dropboxImport,
+        private readonly int $dropboxSyncLimit
     ) {
-        $this->dropboxAppKey = $dropboxAppKey;
-        $this->dropboxAppSecret = $dropboxAppSecret;
-        $this->dropboxRedirectUri = $dropboxRedirectUri;
         $this->session = $requestStack->getSession();
-        $this->httpClient = $httpClient;
-        $this->logger = $logger;
-        $this->frontendBaseUrl = $frontendBaseUrl;
-        $this->comicsDirectory = $comicsDirectory;
-        $this->dropboxAppFolder = $dropboxAppFolder;
-        $this->dropboxClientFactory = $dropboxClientFactory;
     }
 
     #[Route('/connect', name: 'dropbox_connect', methods: ['GET'])]
@@ -65,24 +45,21 @@ class DropboxController extends AbstractController
             return $this->json(['error' => 'User not authenticated'], Response::HTTP_UNAUTHORIZED);
         }
 
-        // 1. Generate a secure random state for CSRF protection
-        $state = bin2hex(random_bytes(16)); // 16 bytes = 32 hex characters
+        // Random state, echoed back by Dropbox, to protect the callback from CSRF.
+        $state = bin2hex(random_bytes(16));
         $this->session->set('dropbox_oauth2_state', $state);
         $this->logger->debug('Dropbox OAuth state created.', ['session_id' => hash('sha256', $this->session->getId())]);
 
-        // 2. Manually construct the Dropbox authorization URL
         $authUrlParams = http_build_query([
             'client_id' => $this->dropboxAppKey,
             'redirect_uri' => $this->dropboxRedirectUri,
             'response_type' => 'code',
             'token_access_type' => 'offline', // To get a refresh token
             'state' => $state,
-            'scope' => 'files.content.read files.content.write account_info.read', // Required scopes for file operations
+            'scope' => 'files.content.read files.content.write account_info.read',
         ]);
 
-        $authUrl = 'https://www.dropbox.com/oauth2/authorize?' . $authUrlParams;
-
-        return new RedirectResponse($authUrl);
+        return new RedirectResponse('https://www.dropbox.com/oauth2/authorize?' . $authUrlParams);
     }
 
     #[Route('/callback', name: 'dropbox_callback', methods: ['GET'])]
@@ -95,89 +72,51 @@ class DropboxController extends AbstractController
         $code = $request->query->get('code');
         $returnedState = $request->query->get('state');
         $savedState = $this->session->get('dropbox_oauth2_state');
+        $this->session->remove('dropbox_oauth2_state');
 
-        if (empty($returnedState) || $returnedState !== $savedState) {
-            $this->session->remove('dropbox_oauth2_state');
+        if (empty($returnedState) || !is_string($savedState) || !hash_equals($savedState, $returnedState)) {
             $this->logger->warning('Dropbox OAuth state mismatch.', ['user_id' => $user->getId()]);
             return $this->json(['error' => 'Invalid OAuth state. CSRF attack suspected or session expired.'], Response::HTTP_UNAUTHORIZED);
         }
-        $this->session->remove('dropbox_oauth2_state'); // State is valid, remove it
 
         if (!$code) {
             return $this->json(['error' => 'Dropbox authorization denied or failed. No code received.'], Response::HTTP_BAD_REQUEST);
         }
 
         try {
-            // --- Manual Token Exchange using Symfony HttpClient ---
-            $tokenUrl = 'https://api.dropboxapi.com/oauth2/token';
-            $requestBody = [
-                'grant_type' => 'authorization_code',
-                'code' => $code,
-                'redirect_uri' => $this->dropboxRedirectUri,
-                'client_id' => $this->dropboxAppKey,
-                'client_secret' => $this->dropboxAppSecret,
-            ];
+            $response = $this->httpClient->request('POST', 'https://api.dropboxapi.com/oauth2/token', [
+                'body' => [
+                    'grant_type' => 'authorization_code',
+                    'code' => $code,
+                    'redirect_uri' => $this->dropboxRedirectUri,
+                    'client_id' => $this->dropboxAppKey,
+                    'client_secret' => $this->dropboxAppSecret,
+                ],
+            ]);
 
-            try {
-                $response = $this->httpClient->request('POST', $tokenUrl, [
-                    'body' => $requestBody,
-                ]);
-
-                $statusCode = $response->getStatusCode();
-
-                if ($statusCode === 200) {
-                    $tokenData = $response->toArray(); // Decodes JSON response
-
-                    $accessToken = $tokenData['access_token'] ?? null;
-                    $refreshToken = $tokenData['refresh_token'] ?? null;
-                    // Potentially also: $tokenData['uid'], $tokenData['account_id'], $tokenData['expires_in']
-
-                    if (!$accessToken) {
-                        // Log error: Dropbox response did not contain an access token despite 200 OK.
-                        // $this->get('logger')->error('Dropbox OAuth: No access token in 200 OK response.', ['response_data' => $tokenData]);
-                        return $this->json(['error' => 'Dropbox connection succeeded but no access token was found in the response.'], Response::HTTP_INTERNAL_SERVER_ERROR);
-                    }
-
-                    $user->setDropboxAccessToken($accessToken);
-                    $user->setDropboxRefreshToken($refreshToken);
-                    $entityManager->persist($user);
-                    $entityManager->flush();
-
-                    // Redirect to the frontend Dropbox sync page with a success indicator
-                    $frontendSuccessUrl = rtrim($this->frontendBaseUrl, '/') . '/dropbox-sync?status=connected';
-                    return new RedirectResponse($frontendSuccessUrl);
-
-                } else {
-                    $this->logger->warning('Dropbox OAuth token exchange failed.', ['status_code' => $statusCode]);
-                    return $this->json(['error' => 'Failed to obtain Dropbox token.'], Response::HTTP_BAD_GATEWAY);
-                }
-
-            } catch (\Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface $e) {
-                // Log error: $this->get('logger')->error('Dropbox OAuth Transport Exception: ' . $e->getMessage());
-                return $this->json(['error' => 'Network error while connecting to Dropbox: ' . $e->getMessage()], Response::HTTP_SERVICE_UNAVAILABLE);
-            } catch (\Throwable $e) { // Catch any other generic error during the process
-                // Log error: $this->get('logger')->error('Dropbox OAuth Generic Exception: ' . $e->getMessage());
-                return $this->json(['error' => 'An unexpected error occurred during Dropbox connection: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            if ($response->getStatusCode() !== 200) {
+                $this->logger->warning('Dropbox OAuth token exchange failed.', ['status_code' => $response->getStatusCode()]);
+                return $this->json(['error' => 'Failed to obtain Dropbox token.'], Response::HTTP_BAD_GATEWAY);
             }
 
-            $refreshToken = $tokenData['refresh_token'] ?? null; 
-            // $userId = $tokenData['uid']; // Dropbox user ID
-            // $accountId = $tokenData['account_id'];
+            $tokenData = $response->toArray();
+            $accessToken = $tokenData['access_token'] ?? null;
+            if (!$accessToken) {
+                $this->logger->error('Dropbox OAuth succeeded but returned no access token.');
+                return $this->json(['error' => 'Dropbox connection succeeded but no access token was found in the response.'], Response::HTTP_INTERNAL_SERVER_ERROR);
+            }
 
             $user->setDropboxAccessToken($accessToken);
-            $user->setDropboxRefreshToken($refreshToken);
-            $entityManager->persist($user);
+            $user->setDropboxRefreshToken($tokenData['refresh_token'] ?? null);
             $entityManager->flush();
 
-            // Redirect to a frontend page indicating success
-            // This URL should be configurable or a known route in your frontend app
-            $frontendSuccessUrl = $this->getParameter('app.frontend_url') . '/dropbox-success'; // Example
-            // return new RedirectResponse($frontendSuccessUrl);
-            return $this->json(['message' => 'Dropbox connected successfully!']);
-
-        } catch (\Exception $e) {
-            // Log error: $this->get('logger')->error('Dropbox OAuth Error: ' . $e->getMessage());
-            return $this->json(['error' => 'Failed to connect Dropbox: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return new RedirectResponse(rtrim($this->frontendBaseUrl, '/') . '/dropbox-sync?status=connected');
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->warning('Network error during Dropbox token exchange.', ['exception' => $e]);
+            return $this->json(['error' => 'Network error while connecting to Dropbox.'], Response::HTTP_SERVICE_UNAVAILABLE);
+        } catch (\Throwable $e) {
+            $this->logger->error('Dropbox connection failed.', ['user_id' => $user->getId(), 'exception' => $e]);
+            return $this->json(['error' => 'Failed to connect Dropbox.'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -194,13 +133,15 @@ class DropboxController extends AbstractController
 
         if ($connected) {
             try {
-                $client = $this->dropboxClientFactory->createForUser($user);
-                $account = $client->getAccountInfo();
+                $account = $this->dropboxClientFactory->createForUser($user)->getAccountInfo();
                 $dropboxUser = $account['name']['display_name'] ?? $account['email'] ?? 'Unknown';
-                
                 $lastSync = $user->getDropboxLastSyncedAt()?->format('c');
-            } catch (\Exception $e) {
-                // Token might be expired or invalid
+            } catch (\Throwable $e) {
+                // Token expired or revoked: report as disconnected so the UI offers to reconnect.
+                $this->logger->info('Dropbox status check failed, treating account as disconnected.', [
+                    'user_id' => $user->getId(),
+                    'exception' => $e,
+                ]);
                 $connected = false;
             }
         }
@@ -208,7 +149,7 @@ class DropboxController extends AbstractController
         return $this->json([
             'connected' => $connected,
             'user' => $dropboxUser,
-            'lastSync' => $lastSync
+            'lastSync' => $lastSync,
         ]);
     }
 
@@ -221,14 +162,13 @@ class DropboxController extends AbstractController
 
         $user->setDropboxAccessToken(null);
         $user->setDropboxRefreshToken(null);
-        $entityManager->persist($user);
         $entityManager->flush();
 
         return $this->json(['message' => 'Dropbox disconnected successfully']);
     }
 
     #[Route('/files', name: 'dropbox_files', methods: ['GET'])]
-    public function files(#[CurrentUser] ?User $user, EntityManagerInterface $entityManager): Response
+    public function files(#[CurrentUser] ?User $user): Response
     {
         if (!$user) {
             return $this->json(['error' => 'User not authenticated'], Response::HTTP_UNAUTHORIZED);
@@ -240,46 +180,29 @@ class DropboxController extends AbstractController
 
         try {
             $client = $this->dropboxClientFactory->createForUser($user);
-            
-            // Get existing comics for this user to check what's already synced
-            $existingComics = $entityManager->getRepository(Comic::class)->findBy(['owner' => $user]);
-            
-            // Create a more robust way to check if files are synced
-            // We'll check both filename and title similarity
-            $existingFiles = array_map(function($comic) {
-                return basename($comic->getFilePath());
-            }, $existingComics);
-            
-            $existingTitles = array_map(function($comic) {
-                return $comic->getTitle();
-            }, $existingComics);
+            $importedIndex = $this->dropboxImport->getImportedIndex($user);
 
-            // Get all files recursively with folder structure from the configured app folder
-            $allFiles = $this->getAllDropboxFiles($client, $this->dropboxAppFolder);
             $files = [];
-
-            foreach ($allFiles as $fileInfo) {
-                // Check if file is synced using multiple methods
-                $isSynced = $this->isDropboxFileSynced($fileInfo['name'], $existingFiles, $existingTitles);
-                
+            foreach ($this->dropboxImport->listCbzFiles($client) as $fileInfo) {
                 $files[] = [
                     'name' => $fileInfo['name'],
                     'path' => $fileInfo['path'],
-                    'size' => $this->formatFileSize($fileInfo['size']),
+                    'size' => $this->dropboxImport->formatFileSize($fileInfo['size']),
                     'modified' => $fileInfo['modified'],
                     'tags' => $fileInfo['tags'],
-                    'synced' => $isSynced
+                    'synced' => $this->dropboxImport->isImported($fileInfo, $importedIndex),
                 ];
             }
 
             return $this->json(['files' => $files]);
-        } catch (\Exception $e) {
-            return $this->json(['error' => 'Failed to fetch Dropbox files: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to list Dropbox files.', ['user_id' => $user->getId(), 'exception' => $e]);
+            return $this->json(['error' => 'Failed to fetch Dropbox files.'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
     #[Route('/import', name: 'dropbox_import_single', methods: ['POST'])]
-    public function importSingle(Request $request, #[CurrentUser] ?User $user, EntityManagerInterface $entityManager, ComicService $comicService): Response
+    public function importSingle(Request $request, #[CurrentUser] ?User $user, EntityManagerInterface $entityManager): Response
     {
         if (!$user) {
             return $this->json(['error' => 'User not authenticated'], Response::HTTP_UNAUTHORIZED);
@@ -290,32 +213,17 @@ class DropboxController extends AbstractController
         }
 
         $data = json_decode($request->getContent(), true);
-        $fileName = $data['fileName'] ?? null;
-
-        if (!$fileName) {
+        $fileName = is_array($data) ? ($data['fileName'] ?? null) : null;
+        if (!is_string($fileName) || $fileName === '') {
             return $this->json(['error' => 'fileName is required'], Response::HTTP_BAD_REQUEST);
         }
 
         try {
             $client = $this->dropboxClientFactory->createForUser($user);
-            
-            // Get existing comics for this user
-            $existingComics = $entityManager->getRepository(Comic::class)->findBy(['owner' => $user]);
-            $existingFiles = array_map(function($comic) {
-                return basename($comic->getFilePath());
-            }, $existingComics);
 
-            // Check if file is already imported
-            if (in_array($fileName, $existingFiles)) {
-                return $this->json(['error' => 'Comic is already imported'], Response::HTTP_BAD_REQUEST);
-            }
-
-            // Find the specific file in Dropbox
-            $allFiles = $this->getAllDropboxFiles($client, $this->dropboxAppFolder);
             $targetFile = null;
-            
-            foreach ($allFiles as $fileInfo) {
-                if (basename($fileInfo['path']) === $fileName) {
+            foreach ($this->dropboxImport->listCbzFiles($client) as $fileInfo) {
+                if ($fileInfo['name'] === $fileName) {
                     $targetFile = $fileInfo;
                     break;
                 }
@@ -325,65 +233,11 @@ class DropboxController extends AbstractController
                 return $this->json(['error' => 'File not found in Dropbox'], Response::HTTP_NOT_FOUND);
             }
 
-            $userDirectory = $this->comicsDirectory . '/' . $user->getId();
-            
-            // Ensure user directory exists
-            if (!file_exists($userDirectory)) {
-                mkdir($userDirectory, 0777, true);
+            if ($this->dropboxImport->isImported($targetFile, $this->dropboxImport->getImportedIndex($user))) {
+                return $this->json(['error' => 'Comic is already imported'], Response::HTTP_BAD_REQUEST);
             }
 
-            // Create dropbox subdirectory
-            $dropboxDirectory = $userDirectory . '/dropbox';
-            if (!file_exists($dropboxDirectory)) {
-                mkdir($dropboxDirectory, 0777, true);
-            }
-
-            $originalPath = $targetFile['path'];
-            
-            try {
-                // Get temporary link first
-                $tempLink = $client->getTemporaryLink($originalPath);
-                
-                // Download using regular HTTP client
-                $httpClient = \Symfony\Component\HttpClient\HttpClient::create();
-                $response = $httpClient->request('GET', $tempLink);
-                $fileContent = $response->getContent();
-            } catch (\Exception $e) {
-                // Fallback to original direct download attempt
-                $fileContent = $client->download($originalPath);
-            }
-            
-            // Save to dropbox subdirectory
-            $localPath = $dropboxDirectory . '/' . $fileName;
-            file_put_contents($localPath, $fileContent);
-            
-            // Create a temporary UploadedFile object for the ComicService
-            $tempFile = new UploadedFile(
-                $localPath,
-                $fileName,
-                'application/zip',
-                null,
-                true // Test mode
-            );
-            
-            // Extract title from filename
-            $title = pathinfo($fileName, PATHINFO_FILENAME);
-            $title = str_replace(['_', '-'], ' ', $title);
-            $title = ucwords($title);
-            
-            // Create tags from folder structure + Dropbox tag
-            $tags = array_merge(['Dropbox'], $targetFile['tags']);
-            
-            // Create comic entry
-            $comic = $comicService->uploadComic(
-                $tempFile,
-                $user,
-                $title,
-                null, // author
-                null, // publisher
-                'Synced from Dropbox', // description
-                $tags
-            );
+            $comic = $this->dropboxImport->import($client, $user, $targetFile);
 
             $user->setDropboxLastSyncedAt(new \DateTimeImmutable());
             $entityManager->flush();
@@ -393,19 +247,17 @@ class DropboxController extends AbstractController
                 'comic' => [
                     'id' => $comic->getId(),
                     'title' => $comic->getTitle(),
-                    'tags' => $tags
-                ]
+                    'tags' => array_merge([DropboxImportService::IMPORT_TAG], $targetFile['tags']),
+                ],
             ]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logger->error('Dropbox import failed.', ['user_id' => $user->getId(), 'exception' => $e]);
-            return $this->json([
-                'error' => 'Import failed.'
-            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->json(['error' => 'Import failed.'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
     #[Route('/sync', name: 'dropbox_sync', methods: ['POST'])]
-    public function sync(#[CurrentUser] ?User $user, EntityManagerInterface $entityManager, ComicService $comicService): Response
+    public function sync(#[CurrentUser] ?User $user, EntityManagerInterface $entityManager): Response
     {
         if (!$user) {
             return $this->json(['error' => 'User not authenticated'], Response::HTTP_UNAUTHORIZED);
@@ -417,70 +269,31 @@ class DropboxController extends AbstractController
 
         try {
             $client = $this->dropboxClientFactory->createForUser($user);
-            
-            // Get existing comics for this user
-            $existingComics = $entityManager->getRepository(Comic::class)->findBy(['owner' => $user]);
-            $existingFiles = array_map(function($comic) {
-                return basename($comic->getFilePath());
-            }, $existingComics);
+            $importedIndex = $this->dropboxImport->getImportedIndex($user);
 
             $newFiles = 0;
-            $userDirectory = $this->comicsDirectory . '/' . $user->getId();
-            
-            // Ensure user directory exists
-            if (!file_exists($userDirectory)) {
-                mkdir($userDirectory, 0777, true);
-            }
+            $failed = 0;
+            foreach ($this->dropboxImport->listCbzFiles($client) as $fileInfo) {
+                if ($this->dropboxImport->isImported($fileInfo, $importedIndex)) {
+                    continue;
+                }
 
-            // Create dropbox subdirectory
-            $dropboxDirectory = $userDirectory . '/dropbox';
-            if (!file_exists($dropboxDirectory)) {
-                mkdir($dropboxDirectory, 0777, true);
-            }
+                // Bound the work a single request can do, matching the CLI sync.
+                if ($newFiles + $failed >= $this->dropboxSyncLimit) {
+                    break;
+                }
 
-            // Get all files and folders recursively from the configured app folder
-            $allFiles = $this->getAllDropboxFiles($client, $this->dropboxAppFolder);
-            
-            foreach ($allFiles as $fileInfo) {
-                $fileName = basename($fileInfo['path']);
-                
-                if (!in_array($fileName, $existingFiles)) {
-                    // Download the file from Dropbox
-                    $fileContent = $client->download($fileInfo['path']);
-                    
-                    // Save to dropbox subdirectory
-                    $localPath = $dropboxDirectory . '/' . $fileName;
-                    file_put_contents($localPath, $fileContent);
-                    
-                    // Create a temporary UploadedFile object for the ComicService
-                    $tempFile = new UploadedFile(
-                        $localPath,
-                        $fileName,
-                        'application/zip',
-                        null,
-                        true // Test mode
-                    );
-                    
-                    // Extract title from filename
-                    $title = pathinfo($fileName, PATHINFO_FILENAME);
-                    $title = str_replace(['_', '-'], ' ', $title);
-                    $title = ucwords($title);
-                    
-                    // Create tags from folder structure + Dropbox tag
-                    $tags = array_merge(['Dropbox'], $fileInfo['tags']);
-                    
-                    // Create comic entry
-                    $comic = $comicService->uploadComic(
-                        $tempFile,
-                        $user,
-                        $title,
-                        null, // author
-                        null, // publisher
-                        'Synced from Dropbox', // description
-                        $tags
-                    );
-                    
+                try {
+                    $this->dropboxImport->import($client, $user, $fileInfo);
+                    $importedIndex['paths'][mb_strtolower($fileInfo['path'])] = true;
                     $newFiles++;
+                } catch (\Throwable $e) {
+                    $this->logger->warning('Failed to import a Dropbox file during sync.', [
+                        'user_id' => $user->getId(),
+                        'path' => $fileInfo['path'],
+                        'exception' => $e,
+                    ]);
+                    $failed++;
                 }
             }
 
@@ -489,178 +302,12 @@ class DropboxController extends AbstractController
 
             return $this->json([
                 'message' => 'Sync completed successfully',
-                'newFiles' => $newFiles
+                'newFiles' => $newFiles,
+                'failedFiles' => $failed,
             ]);
-        } catch (\Exception $e) {
-            return $this->json(['error' => 'Sync failed: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        } catch (\Throwable $e) {
+            $this->logger->error('Dropbox sync failed.', ['user_id' => $user->getId(), 'exception' => $e]);
+            return $this->json(['error' => 'Sync failed.'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
-    }
-
-    private function formatFileSize(int $bytes): string
-    {
-        $units = ['B', 'KB', 'MB', 'GB'];
-        $bytes = max($bytes, 0);
-        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
-        $pow = min($pow, count($units) - 1);
-        
-        $bytes /= (1 << (10 * $pow));
-        
-        return round($bytes, 2) . ' ' . $units[$pow];
-    }
-
-    /**
-     * Recursively get all CBZ files from Dropbox with their folder structure
-     */
-    private function getAllDropboxFiles($client, string $path = '/'): array
-    {
-        $allFiles = [];
-        
-        try {
-            $response = $client->listFolder($path);
-            
-            foreach ($response['entries'] as $entry) {
-                if ($entry['.tag'] === 'file' && strtolower(pathinfo($entry['name'], PATHINFO_EXTENSION)) === 'cbz') {
-                    // Extract folder path and convert to tags
-                    $folderPath = trim(dirname($entry['path_display']), '/');
-                    $tags = $this->convertPathToTags($folderPath);
-                    
-                    $allFiles[] = [
-                        'path' => $entry['path_display'],
-                        'path_lower' => $entry['path_lower'] ?? $entry['path_display'],
-                        'name' => $entry['name'],
-                        'size' => $entry['size'],
-                        'modified' => $entry['client_modified'],
-                        'tags' => $tags
-                    ];
-                } elseif ($entry['.tag'] === 'folder') {
-                    // Recursively get files from subfolders
-                    $subFiles = $this->getAllDropboxFiles($client, $entry['path_display']);
-                    $allFiles = array_merge($allFiles, $subFiles);
-                }
-            }
-        } catch (\Exception $e) {
-            // Handle pagination or other errors
-            $this->logger->warning('Error listing Dropbox folder.', ['exception' => $e]);
-        }
-        
-        return $allFiles;
-    }
-
-    /**
-     * Convert folder path to tags
-     * Examples:
-     * - "/Applications/StarbugStoneComics/superHero" -> ["Super Hero"]
-     * - "/Applications/StarbugStoneComics/Manga/Anime" -> ["Manga", "Anime"]
-     * - "/Applications/StarbugStoneComics/sci-fi/space_opera" -> ["Sci Fi", "Space Opera"]
-     */
-    private function convertPathToTags(string $path): array
-    {
-        if (empty($path) || $path === '.') {
-            return [];
-        }
-        
-        // Remove the app folder prefix from the path to get only the user's folder structure
-        $appFolderPrefix = trim($this->dropboxAppFolder, '/') . '/';
-        $relativePath = ltrim($path, '/');
-        
-        if (str_starts_with($relativePath, $appFolderPrefix)) {
-            $relativePath = substr($relativePath, strlen($appFolderPrefix));
-        }
-        
-        if (empty($relativePath)) {
-            return [];
-        }
-        
-        $folders = explode('/', $relativePath);
-        $tags = [];
-        
-        foreach ($folders as $folder) {
-            if (!empty($folder)) {
-                // Convert camelCase and snake_case to readable format
-                $tag = $this->formatFolderName($folder);
-                if (!empty($tag)) {
-                    $tags[] = $tag;
-                }
-            }
-        }
-        
-        return $tags;
-    }
-
-    /**
-     * Format folder name to readable tag
-     * Examples:
-     * - "superHero" -> "Super Hero"
-     * - "sci-fi" -> "Sci Fi"
-     * - "space_opera" -> "Space Opera"
-     * - "MANGA" -> "Manga"
-     */
-    private function formatFolderName(string $folderName): string
-    {
-        // Replace underscores and hyphens with spaces
-        $formatted = str_replace(['_', '-'], ' ', $folderName);
-        
-        // Split camelCase
-        $formatted = preg_replace('/([a-z])([A-Z])/', '$1 $2', $formatted);
-        
-        // Clean up multiple spaces
-        $formatted = preg_replace('/\s+/', ' ', $formatted);
-        
-        // Trim and convert to title case
-        $formatted = trim($formatted);
-        $formatted = ucwords(strtolower($formatted));
-        
-        return $formatted;
-    }
-
-    /**
-     * Check if a Dropbox file has already been synced/imported
-     * Uses multiple methods: exact filename match and title similarity
-     */
-    private function isDropboxFileSynced(string $dropboxFileName, array $existingFiles, array $existingTitles): bool
-    {
-        // Method 1: Exact filename match (for backwards compatibility)
-        if (in_array($dropboxFileName, $existingFiles)) {
-            return true;
-        }
-        
-        // Method 2: Check if a comic with similar title exists
-        // Extract title from Dropbox filename (remove extension and clean up)
-        $dropboxTitle = pathinfo($dropboxFileName, PATHINFO_FILENAME);
-        $dropboxTitle = str_replace(['_', '-'], ' ', $dropboxTitle);
-        $dropboxTitle = ucwords(strtolower($dropboxTitle));
-        
-        // Normalize titles for comparison
-        $normalizedDropboxTitle = $this->normalizeTitle($dropboxTitle);
-        
-        foreach ($existingTitles as $existingTitle) {
-            $normalizedExistingTitle = $this->normalizeTitle($existingTitle);
-            
-            // Check for high similarity (allowing for minor differences)
-            $similarity = 0;
-            similar_text($normalizedDropboxTitle, $normalizedExistingTitle, $similarity);
-            
-            if ($similarity > 85) { // 85% similarity threshold
-                return true;
-            }
-        }
-        
-        return false;
-    }
-
-    /**
-     * Normalize title for comparison by removing special characters and extra spaces
-     */
-    private function normalizeTitle(string $title): string
-    {
-        // Convert to lowercase
-        $normalized = strtolower($title);
-        
-        // Remove special characters and extra spaces
-        $normalized = preg_replace('/[^a-z0-9\s]/', '', $normalized);
-        $normalized = preg_replace('/\s+/', ' ', $normalized);
-        $normalized = trim($normalized);
-        
-        return $normalized;
     }
 }

--- a/backend/src/Controller/DropboxController.php
+++ b/backend/src/Controller/DropboxController.php
@@ -213,9 +213,13 @@ class DropboxController extends AbstractController
         }
 
         $data = json_decode($request->getContent(), true);
+        $filePath = is_array($data) ? ($data['path'] ?? null) : null;
         $fileName = is_array($data) ? ($data['fileName'] ?? null) : null;
-        if (!is_string($fileName) || $fileName === '') {
-            return $this->json(['error' => 'fileName is required'], Response::HTTP_BAD_REQUEST);
+        $filePath = is_string($filePath) && $filePath !== '' ? $filePath : null;
+        $fileName = is_string($fileName) && $fileName !== '' ? $fileName : null;
+
+        if ($filePath === null && $fileName === null) {
+            return $this->json(['error' => 'path is required'], Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -223,7 +227,10 @@ class DropboxController extends AbstractController
 
             $targetFile = null;
             foreach ($this->dropboxImport->listCbzFiles($client) as $fileInfo) {
-                if ($fileInfo['name'] === $fileName) {
+                // Match on the full path: the same file name can appear in
+                // several folders, and the folder is what the tags come from.
+                // The name is only a fallback for clients that predate this.
+                if ($filePath !== null ? $fileInfo['path'] === $filePath : $fileInfo['name'] === $fileName) {
                     $targetFile = $fileInfo;
                     break;
                 }
@@ -269,41 +276,18 @@ class DropboxController extends AbstractController
 
         try {
             $client = $this->dropboxClientFactory->createForUser($user);
-            $importedIndex = $this->dropboxImport->getImportedIndex($user);
 
-            $newFiles = 0;
-            $failed = 0;
-            foreach ($this->dropboxImport->listCbzFiles($client) as $fileInfo) {
-                if ($this->dropboxImport->isImported($fileInfo, $importedIndex)) {
-                    continue;
-                }
-
-                // Bound the work a single request can do, matching the CLI sync.
-                if ($newFiles + $failed >= $this->dropboxSyncLimit) {
-                    break;
-                }
-
-                try {
-                    $this->dropboxImport->import($client, $user, $fileInfo);
-                    $importedIndex['paths'][mb_strtolower($fileInfo['path'])] = true;
-                    $newFiles++;
-                } catch (\Throwable $e) {
-                    $this->logger->warning('Failed to import a Dropbox file during sync.', [
-                        'user_id' => $user->getId(),
-                        'path' => $fileInfo['path'],
-                        'exception' => $e,
-                    ]);
-                    $failed++;
-                }
-            }
+            // The limit bounds the work a single request can do; the CLI sync
+            // runs the same loop with its own limit.
+            $result = $this->dropboxImport->syncUser($client, $user, $this->dropboxSyncLimit);
 
             $user->setDropboxLastSyncedAt(new \DateTimeImmutable());
             $entityManager->flush();
 
             return $this->json([
                 'message' => 'Sync completed successfully',
-                'newFiles' => $newFiles,
-                'failedFiles' => $failed,
+                'newFiles' => $result['newFiles'],
+                'failedFiles' => $result['failed'],
             ]);
         } catch (\Throwable $e) {
             $this->logger->error('Dropbox sync failed.', ['user_id' => $user->getId(), 'exception' => $e]);

--- a/backend/src/Controller/FrontendController.php
+++ b/backend/src/Controller/FrontendController.php
@@ -4,7 +4,7 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Controller to serve the React frontend application

--- a/backend/src/Controller/FrontendController.php
+++ b/backend/src/Controller/FrontendController.php
@@ -14,9 +14,8 @@ class FrontendController extends AbstractController
     /**
      * Serves the React application for any non-API routes
      * This allows React Router to handle client-side routing
-     * 
-     * @Route("/{reactRouting}", requirements={"reactRouting"="^(?!api|_wdt|_profiler).+"}, defaults={"reactRouting"=""}, name="frontend_index")
      */
+    #[Route('/{reactRouting}', requirements: ['reactRouting' => '^(?!api|_wdt|_profiler).+'], defaults: ['reactRouting' => ''], name: 'frontend_index')]
     public function index(string $reactRouting = ''): Response
     {
         // Return the index.html file that loads the React app

--- a/backend/src/Controller/ShareController.php
+++ b/backend/src/Controller/ShareController.php
@@ -224,10 +224,10 @@ class ShareController extends AbstractController
                     $sharedCoverPath = $this->publicSharesDirectory . '/' . $sharedCoverFilename;
 
                     // Copy the cover to the public shares directory
-                    copy($coverPath, $sharedCoverPath);
-
-                    // Store the public path in the token
-                    $shareToken->setPublicCoverPath('shared/' . $sharedCoverFilename);
+                    if (copy($coverPath, $sharedCoverPath)) {
+                        // Store the public path in the token
+                        $shareToken->setPublicCoverPath('shared/' . $sharedCoverFilename);
+                    }
                 }
             }
 

--- a/backend/src/Controller/ShareController.php
+++ b/backend/src/Controller/ShareController.php
@@ -223,10 +223,14 @@ class ShareController extends AbstractController
                     $sharedCoverFilename = 'share_' . $shareToken->getToken() . '_' . basename($comic->getCoverImagePath());
                     $sharedCoverPath = $this->publicSharesDirectory . '/' . $sharedCoverFilename;
 
-                    // Copy the cover to the public shares directory
+                    // Copy the cover to the public shares directory. Only record the
+                    // public path once the copy succeeds, otherwise the share would
+                    // point at a file that was never written.
                     if (copy($coverPath, $sharedCoverPath)) {
-                        // Store the public path in the token
                         $shareToken->setPublicCoverPath('shared/' . $sharedCoverFilename);
+                    } else {
+                        // Share without a cover rather than failing the whole request
+                        $this->logger->error("Failed to copy cover image from {$coverPath} to {$sharedCoverPath}");
                     }
                 }
             }

--- a/backend/src/Controller/ShareController.php
+++ b/backend/src/Controller/ShareController.php
@@ -6,43 +6,75 @@ use App\Entity\Comic;
 use App\Entity\ShareToken;
 use App\Entity\User;
 use App\Repository\ShareTokenRepository;
+use App\Service\ComicService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
-use App\Repository\ComicRepository;
 use App\Repository\TagRepository;
 use App\Entity\Tag;
-use Symfony\Component\String\Slugger\SluggerInterface;
 use Psr\Log\LoggerInterface; // For logging cover copy errors
 
 #[Route('/api/share')]
 class ShareController extends AbstractController
 {
-    private string $comicsDirectory;
-    private string $frontendUrl;
     private string $publicSharesDirectory;
 
-    public function __construct(string $comicsDirectory, string $frontendUrl, string $publicSharesDirectory = null)
-    {
-        $this->comicsDirectory = $comicsDirectory;
-        $this->frontendUrl = $frontendUrl;
+    public function __construct(
+        private readonly string $comicsDirectory,
+        private readonly string $frontendUrl,
+        private readonly string $mailerFromAddress,
+        private readonly string $mailerFromName,
+        private readonly LoggerInterface $logger,
+        ?string $publicSharesDirectory = null
+    ) {
         // If not explicitly provided, use a subdirectory of the comics directory
         $this->publicSharesDirectory = $publicSharesDirectory ?? $comicsDirectory . '/public_shares';
-        
-        // Ensure the public shares directory exists
-        if (!file_exists($this->publicSharesDirectory)) {
-            mkdir($this->publicSharesDirectory, 0775, true);
+    }
+
+    /**
+     * Created on demand rather than in the constructor, so sharing a comic is
+     * what touches the filesystem instead of every request to this controller.
+     */
+    private function ensurePublicSharesDirectory(): void
+    {
+        if (!is_dir($this->publicSharesDirectory)
+            && !mkdir($this->publicSharesDirectory, 0775, true)
+            && !is_dir($this->publicSharesDirectory)
+        ) {
+            throw new \RuntimeException('Failed to create the public shares directory.');
         }
     }
-    
+
+    /**
+     * Resolve a path stored in the database against a user's comic directory.
+     *
+     * basename() is used rather than stripping "../" sequences: filtering can be
+     * defeated by nested payloads such as "....//", while basename() cannot
+     * produce a path outside the directory at all.
+     */
+    private function resolveUserFile(int $userId, string $storedPath, bool $keepCoverPrefix = false): string
+    {
+        $base = $this->comicsDirectory . '/' . $userId;
+
+        if (!$keepCoverPrefix) {
+            return $base . '/' . basename($storedPath);
+        }
+
+        // Cover paths are stored as "covers/{comicId}/{file}"; rebuild them from
+        // their own components so no segment can escape the directory.
+        $segments = array_map('basename', array_filter(explode('/', $storedPath), static fn ($s) => $s !== ''));
+
+        return $base . '/' . implode('/', $segments);
+    }
+
     #[Route('/pending', name: 'app_share_pending', methods: ['GET'])]
     public function getPendingShares(
         ShareTokenRepository $shareTokenRepository,
@@ -131,7 +163,6 @@ class ShareController extends AbstractController
         MailerInterface $mailer,
         Environment $twig,
         ShareTokenRepository $shareTokenRepository,
-        ValidatorInterface $validator,
         int $comicId,
         #[CurrentUser] ?User $currentUser
     ): JsonResponse {
@@ -183,17 +214,18 @@ class ShareController extends AbstractController
             
             // Copy the comic cover to the public shares directory if it exists
             if ($comic->getCoverImagePath()) {
-                $userId = $currentUser->getId();
-                $coverPath = $this->comicsDirectory . '/' . $userId . '/' . $comic->getCoverImagePath();
-                
+                $coverPath = $this->resolveUserFile($currentUser->getId(), $comic->getCoverImagePath(), true);
+
                 if (file_exists($coverPath)) {
+                    $this->ensurePublicSharesDirectory();
+
                     // Create a unique filename for the shared cover
                     $sharedCoverFilename = 'share_' . $shareToken->getToken() . '_' . basename($comic->getCoverImagePath());
                     $sharedCoverPath = $this->publicSharesDirectory . '/' . $sharedCoverFilename;
-                    
+
                     // Copy the cover to the public shares directory
                     copy($coverPath, $sharedCoverPath);
-                    
+
                     // Store the public path in the token
                     $shareToken->setPublicCoverPath('shared/' . $sharedCoverFilename);
                 }
@@ -209,7 +241,6 @@ class ShareController extends AbstractController
             // Get the user's name and email for the email template
             $userName = $currentUser->getName();
             $userEmail = $currentUser->getEmail();
-            $systemFromAddress = 'noreply@comicreader.example.com'; // Use a system email as the sender
 
             // Render the email template
             $emailBody = $twig->render('emails/share_comic.html.twig', [
@@ -219,9 +250,10 @@ class ShareController extends AbstractController
                 'expiresAt' => $shareToken->getExpiresAt(),
             ]);
 
-            // Send the email
+            // Send the email from the configured application address, with the
+            // sharing user reachable via reply-to.
             $email = (new Email())
-                ->from($systemFromAddress)
+                ->from(new Address($this->mailerFromAddress, $this->mailerFromName))
                 ->replyTo($userEmail)
                 ->to($recipientEmail)
                 ->subject($userName . ' shared a comic with you!')
@@ -233,8 +265,9 @@ class ShareController extends AbstractController
                 'message' => 'Comic shared successfully',
                 'shareToken' => $shareToken->getToken(),
             ]);
-        } catch (\Exception $e) {
-            return new JsonResponse(['error' => 'Failed to share comic: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to share comic.', ['comic_id' => $comicId, 'exception' => $e]);
+            return new JsonResponse(['error' => 'Failed to share comic.'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -244,9 +277,8 @@ class ShareController extends AbstractController
         #[CurrentUser] ?User $currentUser,
         EntityManagerInterface $entityManager,
         ShareTokenRepository $shareTokenRepository,
-        // ComicRepository $comicRepository, // Not directly used, original comic from token
         TagRepository $tagRepository,
-        SluggerInterface $slugger,
+        ComicService $comicService,
         LoggerInterface $logger // For logging non-critical errors
     ): JsonResponse {
         if (!$currentUser) {
@@ -274,14 +306,31 @@ class ShareController extends AbstractController
             return new JsonResponse(['error' => 'Share link not intended for this account'], Response::HTTP_FORBIDDEN);
         }
 
+        $originalComic = $shareToken->getComic();
+        if (!$originalComic) { // Should not happen if DB integrity is maintained
+            return new JsonResponse(['error' => 'Original comic not found for this token'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $sharerId = $shareToken->getSharedByUser()->getId();
+        $originalComicPath = $this->resolveUserFile($sharerId, (string) $originalComic->getFilePath());
+
+        if (!is_file($originalComicPath)) {
+            return new JsonResponse(['error' => 'The shared comic file is no longer available'], Response::HTTP_GONE);
+        }
+
+        // An accepted share is a full copy on disk, so it has to be charged
+        // against the recipient's quota just like an upload would be.
+        $incomingSize = (int) (filesize($originalComicPath) ?: 0);
+        if ($comicService->wouldExceedQuota($currentUser, $incomingSize)) {
+            return new JsonResponse(
+                ['error' => 'Accepting this comic would exceed your storage quota'],
+                Response::HTTP_REQUEST_ENTITY_TOO_LARGE
+            );
+        }
+
         $entityManager->beginTransaction();
 
         try {
-            $originalComic = $shareToken->getComic();
-            if (!$originalComic) { // Should not happen if DB integrity is maintained
-                 return new JsonResponse(['error' => 'Original comic not found for this token'], Response::HTTP_INTERNAL_SERVER_ERROR);
-            }
-
             $newComic = new Comic();
             $newComic->setTitle($originalComic->getTitle());
             $newComic->setDescription($originalComic->getDescription());
@@ -294,30 +343,15 @@ class ShareController extends AbstractController
             $newComic->setUpdatedAt(new \DateTimeImmutable());
 
             // Copy Comic File (CBZ)
-            $sharerId = $shareToken->getSharedByUser()->getId();
-            $originalComicRelativePath = $originalComic->getFilePath(); // e.g., "comic-file.cbz" or "subfolder/comic-file.cbz" if owner organises them
-            
-            // Prevent path traversal by removing any directory traversal sequences
-            $sanitizedPath = str_replace(['../', '..\\', './'], '', $originalComicRelativePath);
-            
-            // The full path should be $this->comicsDirectory . '/' . $sharerId . '/' . $originalComic->getFilePath()
-            $originalComicPath = $this->comicsDirectory . '/' . $sharerId . '/' . $sanitizedPath;
+            $recipientComicDir = $this->comicsDirectory . '/' . $currentUser->getId();
 
-
-            $recipientId = $currentUser->getId();
-            $recipientComicDir = $this->comicsDirectory . '/' . $recipientId;
-
-            if (!file_exists($recipientComicDir)) {
-                if (!mkdir($recipientComicDir, 0775, true)) {
-                    throw new \RuntimeException('Failed to create recipient comic directory.');
-                }
-                // Ensure proper permissions are set
-                chmod($recipientComicDir, 0775);
+            if (!is_dir($recipientComicDir) && !mkdir($recipientComicDir, 0775, true) && !is_dir($recipientComicDir)) {
+                throw new \RuntimeException('Failed to create recipient comic directory.');
             }
 
             // Get the file extension from the original comic
-            $extension = pathinfo($originalComicRelativePath, PATHINFO_EXTENSION);
-            
+            $extension = pathinfo((string) $originalComic->getFilePath(), PATHINFO_EXTENSION);
+
             // Use a UUID for shared comics to distinguish them from original uploads
             $uuid = bin2hex(random_bytes(16)); // Generate a UUID
             $newComicFilename = $uuid . '.' . $extension;
@@ -327,6 +361,8 @@ class ShareController extends AbstractController
                 throw new \RuntimeException('Failed to copy comic file.');
             }
             $newComic->setFilePath($newComicFilename); // Store relative path to recipient's comic dir
+            // Without this the copy is invisible to quota accounting, which sums fileSize.
+            $newComic->setFileSize((int) (filesize($newComicPath) ?: $incomingSize));
 
             // Persist newComic to get its ID for cover path
             $entityManager->persist($newComic);
@@ -336,80 +372,53 @@ class ShareController extends AbstractController
 
             // Copy Cover Image
             if ($originalComic->getCoverImagePath()) {
-                // originalCoverImagePath is relative to sharer's comic directory, e.g., "covers/comic_id/cover.jpg"
-                $originalCoverRelativePath = $originalComic->getCoverImagePath(); 
-                // Prevent path traversal by removing any directory traversal sequences
-                $sanitizedCoverPath = str_replace(['../', '..\\', './'], '', $originalCoverRelativePath);
-                $originalCoverPath = $this->comicsDirectory . '/' . $sharerId . '/' . $sanitizedCoverPath;
-
+                // Cover paths are relative to the sharer's comic directory, e.g. "covers/{comicId}/cover.jpg"
+                $originalCoverRelativePath = $originalComic->getCoverImagePath();
+                $originalCoverPath = $this->resolveUserFile($sharerId, $originalCoverRelativePath, true);
 
                 if (file_exists($originalCoverPath)) {
-                    $originalCoverFilenameWithoutExt = pathinfo($originalCoverRelativePath, PATHINFO_FILENAME);
                     $newCoverExtension = pathinfo($originalCoverRelativePath, PATHINFO_EXTENSION);
-
                     $newCoverDir = $recipientComicDir . '/covers/' . $newComicId;
-                    if (!file_exists($newCoverDir)) {
-                        if (!mkdir($newCoverDir, 0775, true)) {
-                            $logger->error("Failed to create cover directory for new comic ID {$newComicId}");
-                            // Continue without cover image rather than failing the entire operation
-                        } else {
-                            chmod($newCoverDir, 0775);
-                        }
-                    }
-                    
-                    if (file_exists($newCoverDir)) {
+
+                    if (is_dir($newCoverDir) || mkdir($newCoverDir, 0775, true) || is_dir($newCoverDir)) {
                         // Use the same UUID as the comic file for consistency
                         $newCoverFilename = $uuid . '.' . $newCoverExtension;
                         $newCoverPath = $newCoverDir . '/' . $newCoverFilename;
-                        
+
                         if (copy($originalCoverPath, $newCoverPath)) {
                             // Store the relative path from the user's comic directory
                             $newComic->setCoverImagePath('covers/' . $newComicId . '/' . $newCoverFilename);
                         } else {
+                            // Continue without a cover rather than failing the whole acceptance
                             $logger->error("Failed to copy cover image from {$originalCoverPath} to {$newCoverPath}");
-                            // Continue without cover image rather than failing the entire operation
                         }
+                    } else {
+                        $logger->error("Failed to create cover directory for new comic ID {$newComicId}");
                     }
                 }
             }
 
-            // Copy Tags
-            $originalTags = $originalComic->getTags();
-            foreach ($originalTags as $originalTag) {
+            // Copy Tags. Everything here stays inside the surrounding transaction:
+            // flushing inside a try/catch per tag would close the EntityManager on
+            // the first constraint violation and break every later operation.
+            $existingTags = [];
+            foreach ($tagRepository->findBy(['creator' => $currentUser]) as $tag) {
+                $existingTags[mb_strtolower($tag->getName())] = $tag;
+            }
+
+            foreach ($originalComic->getTags() as $originalTag) {
                 $tagName = $originalTag->getName();
-                
-                try {
-                    // Check if the user already has this tag
-                    $existingTag = $tagRepository->findOneBy([
-                        'name' => $tagName,
-                        'creator' => $currentUser
-                    ]);
-                    
-                    if (!$existingTag) {
-                        // Create a new tag for the user
-                        $newTag = new Tag();
-                        $newTag->setName($tagName);
-                        $newTag->setCreator($currentUser);
-                        $entityManager->persist($newTag);
-                        $entityManager->flush(); // Flush immediately to catch any constraint violations
-                        $newComic->addTag($newTag);
-                    } else {
-                        // Use the existing tag
-                        $newComic->addTag($existingTag);
-                    }
-                } catch (\Exception $e) {
-                    // Log the error but continue with the process
-                    $logger->warning(sprintf('Could not add tag "%s": %s', $tagName, $e->getMessage()));
-                    // If there was an error, try to find the tag again (it might have been created in a race condition)
-                    $existingTag = $tagRepository->findOneBy([
-                        'name' => $tagName,
-                        'creator' => $currentUser
-                    ]);
-                    
-                    if ($existingTag) {
-                        $newComic->addTag($existingTag);
-                    }
+                $tagKey = mb_strtolower($tagName);
+
+                if (!isset($existingTags[$tagKey])) {
+                    $newTag = new Tag();
+                    $newTag->setName($tagName);
+                    $newTag->setCreator($currentUser);
+                    $entityManager->persist($newTag);
+                    $existingTags[$tagKey] = $newTag;
                 }
+
+                $newComic->addTag($existingTags[$tagKey]);
             }
 
             // Mark the share token as used
@@ -438,10 +447,12 @@ class ShareController extends AbstractController
                     'coverImagePath' => $newComic->getCoverImagePath(),
                 ]
             ]);
-        } catch (\Exception $e) {
-            $entityManager->rollback();
-            $logger->error('Error accepting shared comic: ' . $e->getMessage());
-            return new JsonResponse(['error' => 'Failed to accept shared comic: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        } catch (\Throwable $e) {
+            if ($entityManager->getConnection()->isTransactionActive()) {
+                $entityManager->rollback();
+            }
+            $logger->error('Error accepting shared comic.', ['token' => $token, 'exception' => $e]);
+            return new JsonResponse(['error' => 'Failed to accept shared comic.'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/backend/src/Controller/TagController.php
+++ b/backend/src/Controller/TagController.php
@@ -74,7 +74,7 @@ class TagController extends AbstractController
         }
 
         // Check if this user already has the tag
-        $conflict = $this->findConflictingTag($entityManager, $tagName, $user, null);
+        $conflict = $this->conflictResponse($entityManager, $tagName, $user, null, 'Tag already exists');
         if ($conflict) {
             return $conflict;
         }
@@ -84,7 +84,7 @@ class TagController extends AbstractController
         $tag->setName($tagName);
         $tag->setCreator($user);
 
-        $violations = $this->validateTag($validator, $tag);
+        $violations = $this->validationErrorResponse($validator, $tag);
         if ($violations) {
             return $violations;
         }
@@ -111,7 +111,9 @@ class TagController extends AbstractController
             return $this->json(['message' => 'Invalid JSON payload'], Response::HTTP_BAD_REQUEST);
         }
 
-        if (!is_array($data) || !isset($data['name']) || !is_string($data['name'])) {
+        // Only a string name is acceptable. Casting instead would turn numbers,
+        // booleans and arrays into nonsense tag names such as "1" or "Array".
+        if (!is_array($data) || !is_string($data['name'] ?? null)) {
             return $this->json(['message' => 'Tag name is required'], Response::HTTP_BAD_REQUEST);
         }
 
@@ -127,11 +129,12 @@ class TagController extends AbstractController
      * A tag name must be unique per creator. Returns the conflict response when
      * a different tag already claims the name, otherwise null.
      */
-    private function findConflictingTag(
+    private function conflictResponse(
         EntityManagerInterface $entityManager,
         string $tagName,
         UserInterface $creator,
-        ?Tag $ignoredTag
+        ?Tag $ignoredTag,
+        string $message
     ): ?JsonResponse {
         $existingTag = $entityManager->getRepository(Tag::class)->findOneBy([
             'name' => $tagName,
@@ -143,12 +146,12 @@ class TagController extends AbstractController
         }
 
         return $this->json([
-            'message' => $ignoredTag ? 'Tag name already exists' : 'Tag already exists',
+            'message' => $message,
             'tag' => $this->serializeTag($existingTag),
         ], Response::HTTP_CONFLICT);
     }
 
-    private function validateTag(ValidatorInterface $validator, Tag $tag): ?JsonResponse
+    private function validationErrorResponse(ValidatorInterface $validator, Tag $tag): ?JsonResponse
     {
         $violations = $validator->validate($tag);
         if (count($violations) === 0) {
@@ -201,7 +204,7 @@ class TagController extends AbstractController
         }
 
         // Check if tag name already exists for this creator (excluding current tag)
-        $conflict = $this->findConflictingTag($entityManager, $tagName, $tag->getCreator(), $tag);
+        $conflict = $this->conflictResponse($entityManager, $tagName, $tag->getCreator(), $tag, 'Tag name already exists');
         if ($conflict) {
             return $conflict;
         }
@@ -209,7 +212,7 @@ class TagController extends AbstractController
         // Update tag
         $tag->setName($tagName);
 
-        $violations = $this->validateTag($validator, $tag);
+        $violations = $this->validationErrorResponse($validator, $tag);
         if ($violations) {
             return $violations;
         }

--- a/backend/src/Controller/TagController.php
+++ b/backend/src/Controller/TagController.php
@@ -111,7 +111,11 @@ class TagController extends AbstractController
             return $this->json(['message' => 'Invalid JSON payload'], Response::HTTP_BAD_REQUEST);
         }
 
-        $tagName = is_array($data) ? trim((string) ($data['name'] ?? '')) : '';
+        if (!is_array($data) || !isset($data['name']) || !is_string($data['name'])) {
+            return $this->json(['message' => 'Tag name is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $tagName = trim($data['name']);
         if ($tagName === '') {
             return $this->json(['message' => 'Tag name is required'], Response::HTTP_BAD_REQUEST);
         }

--- a/backend/src/Controller/TagController.php
+++ b/backend/src/Controller/TagController.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[Route('/api/tags', name: 'api_tags_')]
@@ -67,32 +68,15 @@ class TagController extends AbstractController
             return $this->json(['message' => 'User not authenticated'], Response::HTTP_UNAUTHORIZED);
         }
 
-        // Get data from request
-        $data = json_decode($request->getContent(), true);
-        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
-            return $this->json(['message' => 'Invalid JSON payload'], Response::HTTP_BAD_REQUEST);
+        $tagName = $this->readTagName($request);
+        if ($tagName instanceof JsonResponse) {
+            return $tagName;
         }
-
-        // Validate tag name
-        if (!isset($data['name']) || empty(trim($data['name']))) {
-            return $this->json(['message' => 'Tag name is required'], Response::HTTP_BAD_REQUEST);
-        }
-
-        $tagName = trim($data['name']);
 
         // Check if this user already has the tag
-        $existingTag = $entityManager->getRepository(Tag::class)->findOneBy([
-            'name' => $tagName,
-            'creator' => $user,
-        ]);
-        if ($existingTag) {
-            return $this->json([
-                'message' => 'Tag already exists',
-                'tag' => [
-                    'id' => $existingTag->getId(),
-                    'name' => $existingTag->getName()
-                ]
-            ], Response::HTTP_CONFLICT);
+        $conflict = $this->findConflictingTag($entityManager, $tagName, $user, null);
+        if ($conflict) {
+            return $conflict;
         }
 
         // Create new tag
@@ -100,14 +84,9 @@ class TagController extends AbstractController
         $tag->setName($tagName);
         $tag->setCreator($user);
 
-        // Validate tag
-        $violations = $validator->validate($tag);
-        if (count($violations) > 0) {
-            $errors = [];
-            foreach ($violations as $violation) {
-                $errors[] = $violation->getMessage();
-            }
-            return $this->json(['message' => 'Validation failed', 'errors' => $errors], Response::HTTP_BAD_REQUEST);
+        $violations = $this->validateTag($validator, $tag);
+        if ($violations) {
+            return $violations;
         }
 
         // Save tag
@@ -116,11 +95,76 @@ class TagController extends AbstractController
 
         return $this->json([
             'message' => 'Tag created successfully',
-            'tag' => [
-                'id' => $tag->getId(),
-                'name' => $tag->getName()
-            ]
+            'tag' => $this->serializeTag($tag),
         ], Response::HTTP_CREATED);
+    }
+
+    /**
+     * Read and validate the tag name from the request body.
+     *
+     * @return string|JsonResponse The trimmed name, or the error response to return.
+     */
+    private function readTagName(Request $request): string|JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            return $this->json(['message' => 'Invalid JSON payload'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $tagName = is_array($data) ? trim((string) ($data['name'] ?? '')) : '';
+        if ($tagName === '') {
+            return $this->json(['message' => 'Tag name is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        return $tagName;
+    }
+
+    /**
+     * A tag name must be unique per creator. Returns the conflict response when
+     * a different tag already claims the name, otherwise null.
+     */
+    private function findConflictingTag(
+        EntityManagerInterface $entityManager,
+        string $tagName,
+        UserInterface $creator,
+        ?Tag $ignoredTag
+    ): ?JsonResponse {
+        $existingTag = $entityManager->getRepository(Tag::class)->findOneBy([
+            'name' => $tagName,
+            'creator' => $creator,
+        ]);
+
+        if (!$existingTag || ($ignoredTag && $existingTag->getId() === $ignoredTag->getId())) {
+            return null;
+        }
+
+        return $this->json([
+            'message' => $ignoredTag ? 'Tag name already exists' : 'Tag already exists',
+            'tag' => $this->serializeTag($existingTag),
+        ], Response::HTTP_CONFLICT);
+    }
+
+    private function validateTag(ValidatorInterface $validator, Tag $tag): ?JsonResponse
+    {
+        $violations = $validator->validate($tag);
+        if (count($violations) === 0) {
+            return null;
+        }
+
+        $errors = [];
+        foreach ($violations as $violation) {
+            $errors[] = $violation->getMessage();
+        }
+
+        return $this->json(['message' => 'Validation failed', 'errors' => $errors], Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @return array{id: ?int, name: ?string}
+     */
+    private function serializeTag(Tag $tag): array
+    {
+        return ['id' => $tag->getId(), 'name' => $tag->getName()];
     }
 
     #[Route('/{id}', name: 'update', methods: ['PUT', 'PATCH'])]
@@ -147,45 +191,23 @@ class TagController extends AbstractController
             return $this->json(['message' => 'You are not authorized to update this tag'], Response::HTTP_FORBIDDEN);
         }
 
-        // Get data from request
-        $data = json_decode($request->getContent(), true);
-        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
-            return $this->json(['message' => 'Invalid JSON payload'], Response::HTTP_BAD_REQUEST);
+        $tagName = $this->readTagName($request);
+        if ($tagName instanceof JsonResponse) {
+            return $tagName;
         }
-
-        // Validate tag name
-        if (!isset($data['name']) || empty(trim($data['name']))) {
-            return $this->json(['message' => 'Tag name is required'], Response::HTTP_BAD_REQUEST);
-        }
-
-        $tagName = trim($data['name']);
 
         // Check if tag name already exists for this creator (excluding current tag)
-        $existingTag = $entityManager->getRepository(Tag::class)->findOneBy([
-            'name' => $tagName,
-            'creator' => $tag->getCreator(),
-        ]);
-        if ($existingTag && $existingTag->getId() !== $tag->getId()) {
-            return $this->json([
-                'message' => 'Tag name already exists',
-                'tag' => [
-                    'id' => $existingTag->getId(),
-                    'name' => $existingTag->getName()
-                ]
-            ], Response::HTTP_CONFLICT);
+        $conflict = $this->findConflictingTag($entityManager, $tagName, $tag->getCreator(), $tag);
+        if ($conflict) {
+            return $conflict;
         }
 
         // Update tag
         $tag->setName($tagName);
 
-        // Validate tag
-        $violations = $validator->validate($tag);
-        if (count($violations) > 0) {
-            $errors = [];
-            foreach ($violations as $violation) {
-                $errors[] = $violation->getMessage();
-            }
-            return $this->json(['message' => 'Validation failed', 'errors' => $errors], Response::HTTP_BAD_REQUEST);
+        $violations = $this->validateTag($validator, $tag);
+        if ($violations) {
+            return $violations;
         }
 
         // Save changes
@@ -193,10 +215,7 @@ class TagController extends AbstractController
 
         return $this->json([
             'message' => 'Tag updated successfully',
-            'tag' => [
-                'id' => $tag->getId(),
-                'name' => $tag->getName()
-            ]
+            'tag' => $this->serializeTag($tag),
         ]);
     }
 

--- a/backend/src/Entity/Comic.php
+++ b/backend/src/Entity/Comic.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ComicRepository::class)]
+#[ORM\Index(name: 'IDX_comic_owner_dropbox_path', columns: ['owner_id', 'dropbox_path'])]
 #[ORM\HasLifecycleCallbacks]
 class Comic
 {
@@ -59,6 +60,16 @@ class Comic
     
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $publisher = null;
+
+    /**
+     * Source path in the owner's Dropbox, set only for comics pulled in by the
+     * Dropbox integration. Used to skip files that have already been imported.
+     *
+     * Kept at 500 characters so (owner_id, dropbox_path) fits inside MySQL's
+     * utf8mb4 index key limit; real Dropbox paths are far shorter.
+     */
+    #[ORM\Column(length: 500, nullable: true)]
+    private ?string $dropboxPath = null;
 
     public function __construct()
     {
@@ -224,7 +235,19 @@ class Comic
 
         return $this;
     }
-    
+
+    public function getDropboxPath(): ?string
+    {
+        return $this->dropboxPath;
+    }
+
+    public function setDropboxPath(?string $dropboxPath): static
+    {
+        $this->dropboxPath = $dropboxPath;
+
+        return $this;
+    }
+
     /**
      * @return Collection<int, ComicReadingProgress>
      */
@@ -253,33 +276,5 @@ class Comic
         }
 
         return $this;
-    }
-    
-    /**
-     * Convert the Comic entity to an array representation
-     * 
-     * @return array The comic data as an array
-     */
-    public function toArray(): array
-    {
-        $tagNames = [];
-        foreach ($this->tags as $tag) {
-            $tagNames[] = $tag->getName();
-        }
-        
-        return [
-            'id' => $this->id,
-            'title' => $this->title,
-            'filePath' => $this->filePath,
-            'coverImagePath' => $this->coverImagePath,
-            'pageCount' => $this->pageCount,
-            'fileSize' => $this->fileSize,
-            'uploadedAt' => $this->uploadedAt ? $this->uploadedAt->format('c') : null,
-            'updatedAt' => $this->updatedAt ? $this->updatedAt->format('c') : null,
-            'author' => $this->author,
-            'publisher' => $this->publisher,
-            'description' => $this->description,
-            'tags' => $tagNames
-        ];
     }
 }

--- a/backend/src/Entity/ComicReadingProgress.php
+++ b/backend/src/Entity/ComicReadingProgress.php
@@ -32,6 +32,15 @@ class ComicReadingProgress
     #[ORM\Column]
     private ?bool $completed = null;
 
+    /**
+     * Counter supplied by the reader with each save. Saves for this comic can
+     * reach the server out of order, so an older one must not overwrite a newer
+     * page. The page number itself cannot serve as the counter because reading
+     * backwards is legitimate.
+     */
+    #[ORM\Column(options: ['default' => 0])]
+    private int $revision = 0;
+
     public function __construct()
     {
         $this->currentPage = 1;
@@ -106,6 +115,18 @@ class ComicReadingProgress
     public function setCompleted(bool $completed): static
     {
         $this->completed = $completed;
+
+        return $this;
+    }
+
+    public function getRevision(): int
+    {
+        return $this->revision;
+    }
+
+    public function setRevision(int $revision): static
+    {
+        $this->revision = $revision;
 
         return $this;
     }

--- a/backend/src/Repository/ComicReadingProgressRepository.php
+++ b/backend/src/Repository/ComicReadingProgressRepository.php
@@ -27,4 +27,34 @@ class ComicReadingProgressRepository extends ServiceEntityRepository
     {
         return $this->findOneBy(['user' => $user, 'comic' => $comic]);
     }
+
+    /**
+     * Load one user's progress across many comics in a single query, keyed by
+     * comic id. Serializing a library one comic at a time would otherwise cost
+     * a query per comic.
+     *
+     * @param list<Comic> $comics
+     * @return array<int, ComicReadingProgress>
+     */
+    public function findByUserIndexedByComic(User $user, array $comics): array
+    {
+        if ($comics === []) {
+            return [];
+        }
+
+        $progresses = $this->createQueryBuilder('p')
+            ->andWhere('p.user = :user')
+            ->andWhere('p.comic IN (:comics)')
+            ->setParameter('user', $user)
+            ->setParameter('comics', $comics)
+            ->getQuery()
+            ->getResult();
+
+        $indexed = [];
+        foreach ($progresses as $progress) {
+            $indexed[$progress->getComic()->getId()] = $progress;
+        }
+
+        return $indexed;
+    }
 }

--- a/backend/src/Service/ComicSerializer.php
+++ b/backend/src/Service/ComicSerializer.php
@@ -94,6 +94,9 @@ class ComicSerializer
                 'currentPage' => $progress->getCurrentPage(),
                 'lastReadAt' => $progress->getLastReadAt()?->format('c'),
                 'completed' => $progress->isCompleted(),
+                // Lets a reader continue the revision sequence across sessions
+                // instead of restarting below the stored value.
+                'revision' => $progress->getRevision(),
             ] : null,
         ];
 

--- a/backend/src/Service/ComicSerializer.php
+++ b/backend/src/Service/ComicSerializer.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Comic;
+use App\Entity\ComicReadingProgress;
+use App\Entity\User;
+use App\Repository\ComicReadingProgressRepository;
+
+/**
+ * Single source of truth for the shape of a comic in API responses.
+ *
+ * Every endpoint returning a comic goes through here so the payload cannot
+ * drift between list, detail and upload responses — and so internal storage
+ * paths never reach the client.
+ */
+class ComicSerializer
+{
+    public function __construct(
+        private readonly ComicReadingProgressRepository $progressRepository
+    ) {
+    }
+
+    /**
+     * @param list<Comic> $comics
+     * @return list<array<string, mixed>>
+     */
+    public function serializeMany(array $comics, User $viewer, bool $includeOwner = false): array
+    {
+        $progressByComicId = $this->progressRepository->findByUserIndexedByComic($viewer, $comics);
+
+        $serialized = [];
+        foreach ($comics as $comic) {
+            $serialized[] = $this->build(
+                $comic,
+                $progressByComicId[$comic->getId()] ?? null,
+                $includeOwner
+            );
+        }
+
+        return $serialized;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function serialize(Comic $comic, User $viewer, bool $includeOwner = true): array
+    {
+        return $this->build(
+            $comic,
+            $this->progressRepository->findByUserAndComic($viewer, $comic),
+            $includeOwner
+        );
+    }
+
+    /**
+     * Public URL for a comic cover, or null when it has none. Built by hand
+     * rather than through the router so internal container hostnames never leak
+     * into generated URLs.
+     */
+    public function coverUrl(Comic $comic): ?string
+    {
+        $coverPath = $comic->getCoverImagePath();
+        $ownerId = $comic->getOwner()?->getId();
+
+        if (!$coverPath || $ownerId === null) {
+            return null;
+        }
+
+        return sprintf('/api/comics/cover/%d/%d/%s', $ownerId, $comic->getId(), basename($coverPath));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function build(Comic $comic, ?ComicReadingProgress $progress, bool $includeOwner): array
+    {
+        $data = [
+            'id' => $comic->getId(),
+            'title' => $comic->getTitle(),
+            'author' => $comic->getAuthor(),
+            'publisher' => $comic->getPublisher(),
+            'description' => $comic->getDescription(),
+            'coverImagePath' => $this->coverUrl($comic),
+            'pageCount' => $comic->getPageCount(),
+            'fileSize' => $comic->getFileSize(),
+            'uploadedAt' => $comic->getUploadedAt()?->format('c'),
+            'updatedAt' => $comic->getUpdatedAt()?->format('c'),
+            'tags' => array_map(
+                static fn ($tag) => ['id' => $tag->getId(), 'name' => $tag->getName()],
+                $comic->getTags()->toArray()
+            ),
+            'readingProgress' => $progress ? [
+                'currentPage' => $progress->getCurrentPage(),
+                'lastReadAt' => $progress->getLastReadAt()?->format('c'),
+                'completed' => $progress->isCompleted(),
+            ] : null,
+        ];
+
+        if ($includeOwner) {
+            $owner = $comic->getOwner();
+            $data['owner'] = [
+                'id' => $owner?->getId(),
+                'email' => $owner?->getEmail(),
+                'name' => $owner?->getName(),
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/backend/src/Service/ComicService.php
+++ b/backend/src/Service/ComicService.php
@@ -54,7 +54,7 @@ class ComicService
             throw new \RuntimeException('Uploaded file is too large.');
         }
 
-        if ($this->getUserStorageBytes($user) + $incomingSize > $this->uploadUserQuotaBytes) {
+        if ($this->wouldExceedQuota($user, $incomingSize)) {
             throw new \RuntimeException('User storage quota exceeded.');
         }
 
@@ -273,7 +273,16 @@ class ComicService
         }
     }
 
-    private function getUserStorageBytes(User $user): int
+    /**
+     * Whether storing an extra $additionalBytes for this user would push them
+     * past their quota. Every path that adds a comic must consult this.
+     */
+    public function wouldExceedQuota(User $user, int $additionalBytes): bool
+    {
+        return $this->getUserStorageBytes($user) + $additionalBytes > $this->uploadUserQuotaBytes;
+    }
+
+    public function getUserStorageBytes(User $user): int
     {
         return (int) $this->entityManager->createQueryBuilder()
             ->select('COALESCE(SUM(c.fileSize), 0)')

--- a/backend/src/Service/ComicService.php
+++ b/backend/src/Service/ComicService.php
@@ -64,6 +64,8 @@ class ComicService
 
         $safeFilename = (string) $this->slugger->slug($originalFilename);
         $newFilename = $safeFilename . '-' . uniqid('', true) . '.cbz';
+        // TODO: Shard comic archives into nested directories before large
+        // libraries put enough files in one user directory to degrade OS/filesystem performance.
         $absolutePath = $userDirectory . '/' . $newFilename;
 
         try {

--- a/backend/src/Service/DropboxImportService.php
+++ b/backend/src/Service/DropboxImportService.php
@@ -43,7 +43,9 @@ class DropboxImportService
         try {
             $response = $client->listFolder($path);
 
-            do {
+            // Dropbox pages large folders. Stopping at the first page would
+            // silently hide every file past the page size from the sync.
+            while (true) {
                 foreach ($response['entries'] ?? [] as $entry) {
                     $tag = $entry['.tag'] ?? null;
 
@@ -65,15 +67,18 @@ class DropboxImportService
                     ];
                 }
 
-                // Continue fetching if there are more results
-                if (($response['has_more'] ?? false) && isset($response['cursor'])) {
-                    $response = $client->listFolderContinue($response['cursor']);
-                } else {
+                if (empty($response['has_more']) || !isset($response['cursor'])) {
                     break;
                 }
-            } while (true);
+
+                $response = $client->listFolderContinue((string) $response['cursor']);
+            }
         } catch (\Throwable $e) {
+            // Callers already handle failures. Swallowing here would report a
+            // partial listing as a complete one, so re-import decisions and the
+            // "already synced" flags would be made against missing files.
             $this->logger->error('Error listing Dropbox folder.', ['path' => $path, 'exception' => $e]);
+
             throw $e;
         }
 
@@ -145,7 +150,7 @@ class DropboxImportService
         }
 
         try {
-            file_put_contents($stagedPath, $this->downloadFile($client, $fileInfo['path']));
+            $this->downloadFile($client, $fileInfo['path'], $stagedPath);
 
             $comic = $this->comicService->uploadComic(
                 new UploadedFile($stagedPath, $fileInfo['name'], 'application/zip', null, true),
@@ -169,22 +174,124 @@ class DropboxImportService
     }
 
     /**
+     * Import every not-yet-imported CBZ for a user, up to $limit attempts.
+     *
+     * The HTTP endpoint and the CLI command both drive this; they differ only in
+     * how they report progress, which is what $report is for. Successes and
+     * failures alike count towards the limit, so one repeatedly failing file
+     * cannot make a sync run through the whole Dropbox account.
+     *
+     * @param callable(string, array<string, mixed>):void|null $report Receives
+     *        'listed', 'skipped', 'importing', 'imported' and 'failed' events.
+     *
+     * @return array{newFiles: int, failed: int}
+     */
+    public function syncUser(
+        DropboxClient $client,
+        User $user,
+        int $limit,
+        bool $dryRun = false,
+        ?callable $report = null
+    ): array {
+        $notify = $report ?? static function (string $event, array $context): void {
+        };
+
+        $files = $this->listCbzFiles($client);
+        $notify('listed', ['count' => count($files)]);
+
+        $importedIndex = $this->getImportedIndex($user);
+        $newFiles = 0;
+        $failed = 0;
+        $processed = 0;
+
+        foreach ($files as $fileInfo) {
+            if ($this->isImported($fileInfo, $importedIndex)) {
+                $notify('skipped', ['file' => $fileInfo]);
+                continue;
+            }
+
+            if ($processed >= $limit) {
+                $notify('limitReached', ['limit' => $limit]);
+                break;
+            }
+
+            $processed++;
+            $notify('importing', ['file' => $fileInfo, 'dryRun' => $dryRun]);
+
+            if ($dryRun) {
+                $newFiles++;
+                continue;
+            }
+
+            try {
+                $this->import($client, $user, $fileInfo);
+                $importedIndex['paths'][mb_strtolower($fileInfo['path'])] = true;
+                $newFiles++;
+                $notify('imported', ['file' => $fileInfo]);
+            } catch (\Throwable $e) {
+                $this->logger->warning('Failed to import a Dropbox file during sync.', [
+                    'user_id' => $user->getId(),
+                    'path' => $fileInfo['path'],
+                    'exception' => $e,
+                ]);
+                $failed++;
+                $notify('failed', ['file' => $fileInfo, 'exception' => $e]);
+            }
+        }
+
+        return ['newFiles' => $newFiles, 'failed' => $failed];
+    }
+
+    /**
      * Dropbox serves large files better through a temporary link, so prefer that
      * and fall back to the API download endpoint.
      *
-     * @return string|resource
+     * The archive is streamed into the staged file: a comic can be hundreds of
+     * megabytes, and holding one in a PHP string exhausts the memory limit long
+     * before the filesystem runs out of room.
      */
-    private function downloadFile(DropboxClient $client, string $path)
+    private function downloadFile(DropboxClient $client, string $path, string $stagedPath): void
     {
-        try {
-            return $this->httpClient->request('GET', $client->getTemporaryLink($path))->getContent();
-        } catch (\Throwable $e) {
-            $this->logger->debug('Dropbox temporary link download failed, falling back to direct download.', [
-                'path' => $path,
-                'exception' => $e,
-            ]);
+        $staged = fopen($stagedPath, 'wb');
+        if ($staged === false) {
+            throw new \RuntimeException('Could not open the staged Dropbox download for writing.');
+        }
 
-            return $client->download($path);
+        try {
+            try {
+                $response = $this->httpClient->request('GET', $client->getTemporaryLink($path));
+                foreach ($this->httpClient->stream($response) as $chunk) {
+                    fwrite($staged, $chunk->getContent());
+                }
+
+                return;
+            } catch (\Throwable $e) {
+                $this->logger->debug('Dropbox temporary link download failed, falling back to direct download.', [
+                    'path' => $path,
+                    'exception' => $e,
+                ]);
+            }
+
+            // The failed attempt may have written part of the archive already,
+            // so start the fallback from an empty file rather than appending to
+            // a corrupt prefix.
+            if (!ftruncate($staged, 0) || fseek($staged, 0) !== 0) {
+                throw new \RuntimeException('Could not reset the staged Dropbox download before retrying.');
+            }
+
+            $source = $client->download($path);
+
+            try {
+                if (stream_copy_to_stream($source, $staged) === false) {
+                    throw new \RuntimeException('Failed to stream the Dropbox download to disk.');
+                }
+            } finally {
+                if (is_resource($source)) {
+                    fclose($source);
+                }
+            }
+        } finally {
+            fclose($staged);
         }
     }
 

--- a/backend/src/Service/DropboxImportService.php
+++ b/backend/src/Service/DropboxImportService.php
@@ -43,28 +43,38 @@ class DropboxImportService
         try {
             $response = $client->listFolder($path);
 
-            foreach ($response['entries'] ?? [] as $entry) {
-                $tag = $entry['.tag'] ?? null;
+            do {
+                foreach ($response['entries'] ?? [] as $entry) {
+                    $tag = $entry['.tag'] ?? null;
 
-                if ($tag === 'folder') {
-                    array_push($files, ...$this->listCbzFiles($client, $entry['path_display']));
-                    continue;
+                    if ($tag === 'folder') {
+                        array_push($files, ...$this->listCbzFiles($client, $entry['path_display']));
+                        continue;
+                    }
+
+                    if ($tag !== 'file' || strtolower(pathinfo($entry['name'], PATHINFO_EXTENSION)) !== 'cbz') {
+                        continue;
+                    }
+
+                    $files[] = [
+                        'path' => $entry['path_display'],
+                        'name' => $entry['name'],
+                        'size' => (int) ($entry['size'] ?? 0),
+                        'modified' => $entry['client_modified'] ?? null,
+                        'tags' => $this->convertPathToTags(trim(dirname($entry['path_display']), '/')),
+                    ];
                 }
 
-                if ($tag !== 'file' || strtolower(pathinfo($entry['name'], PATHINFO_EXTENSION)) !== 'cbz') {
-                    continue;
+                // Continue fetching if there are more results
+                if (($response['has_more'] ?? false) && isset($response['cursor'])) {
+                    $response = $client->listFolderContinue($response['cursor']);
+                } else {
+                    break;
                 }
-
-                $files[] = [
-                    'path' => $entry['path_display'],
-                    'name' => $entry['name'],
-                    'size' => (int) ($entry['size'] ?? 0),
-                    'modified' => $entry['client_modified'] ?? null,
-                    'tags' => $this->convertPathToTags(trim(dirname($entry['path_display']), '/')),
-                ];
-            }
+            } while (true);
         } catch (\Throwable $e) {
-            $this->logger->warning('Error listing Dropbox folder.', ['path' => $path, 'exception' => $e]);
+            $this->logger->error('Error listing Dropbox folder.', ['path' => $path, 'exception' => $e]);
+            throw $e;
         }
 
         return $files;

--- a/backend/src/Service/DropboxImportService.php
+++ b/backend/src/Service/DropboxImportService.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Comic;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Spatie\Dropbox\Client as DropboxClient;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Dropbox listing and import logic shared by the HTTP controller and the CLI
+ * sync command. Both used to carry their own copy of this; keeping it in one
+ * place is what lets duplicate detection and temp-file cleanup stay correct.
+ */
+class DropboxImportService
+{
+    public const IMPORT_TAG = 'Dropbox';
+
+    private const IMPORT_DESCRIPTION = 'Synced from Dropbox';
+
+    public function __construct(
+        private readonly ComicService $comicService,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+        private readonly string $dropboxAppFolder
+    ) {
+    }
+
+    /**
+     * Recursively collect every CBZ under the configured app folder.
+     *
+     * @return list<array{path: string, name: string, size: int, modified: ?string, tags: list<string>}>
+     */
+    public function listCbzFiles(DropboxClient $client, ?string $path = null): array
+    {
+        $path = $path ?? $this->dropboxAppFolder;
+        $files = [];
+
+        try {
+            $response = $client->listFolder($path);
+
+            foreach ($response['entries'] ?? [] as $entry) {
+                $tag = $entry['.tag'] ?? null;
+
+                if ($tag === 'folder') {
+                    array_push($files, ...$this->listCbzFiles($client, $entry['path_display']));
+                    continue;
+                }
+
+                if ($tag !== 'file' || strtolower(pathinfo($entry['name'], PATHINFO_EXTENSION)) !== 'cbz') {
+                    continue;
+                }
+
+                $files[] = [
+                    'path' => $entry['path_display'],
+                    'name' => $entry['name'],
+                    'size' => (int) ($entry['size'] ?? 0),
+                    'modified' => $entry['client_modified'] ?? null,
+                    'tags' => $this->convertPathToTags(trim(dirname($entry['path_display']), '/')),
+                ];
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning('Error listing Dropbox folder.', ['path' => $path, 'exception' => $e]);
+        }
+
+        return $files;
+    }
+
+    /**
+     * Snapshot of what this user has already pulled in from Dropbox, used to
+     * decide which remote files still need importing.
+     *
+     * @return array{paths: array<string, true>, titles: array<string, true>}
+     */
+    public function getImportedIndex(User $user): array
+    {
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('c.dropboxPath', 'c.title')
+            ->from(Comic::class, 'c')
+            ->where('c.owner = :owner')
+            ->setParameter('owner', $user)
+            ->getQuery()
+            ->getArrayResult();
+
+        $paths = [];
+        $titles = [];
+        foreach ($rows as $row) {
+            if ($row['dropboxPath'] !== null && $row['dropboxPath'] !== '') {
+                $paths[mb_strtolower($row['dropboxPath'])] = true;
+            }
+            if ($row['title'] !== null && $row['title'] !== '') {
+                $titles[$this->normaliseTitle($row['title'])] = true;
+            }
+        }
+
+        return ['paths' => $paths, 'titles' => $titles];
+    }
+
+    /**
+     * @param array{path: string, name: string, ...} $fileInfo
+     * @param array{paths: array<string, true>, titles: array<string, true>} $index
+     */
+    public function isImported(array $fileInfo, array $index): bool
+    {
+        // Comics imported since dropbox_path was introduced record exactly where
+        // they came from, so this is an exact answer.
+        if (isset($index['paths'][mb_strtolower($fileInfo['path'])])) {
+            return true;
+        }
+
+        // Comics imported before then have no recorded path. Fall back to the
+        // title we would have generated for them, so an upgrade does not cause
+        // the whole library to be re-imported.
+        return isset($index['titles'][$this->normaliseTitle($this->titleFromFilename($fileInfo['name']))]);
+    }
+
+    /**
+     * Download a Dropbox file and register it as a comic.
+     *
+     * The download is staged in the system temp directory rather than under the
+     * comics directory: ComicService copies it to its final home, so anything
+     * left in the comics tree would be a permanent duplicate.
+     *
+     * @param array{path: string, name: string, tags: list<string>, ...} $fileInfo
+     */
+    public function import(DropboxClient $client, User $user, array $fileInfo): Comic
+    {
+        $stagedPath = tempnam(sys_get_temp_dir(), 'dropbox_import_');
+        if ($stagedPath === false) {
+            throw new \RuntimeException('Could not create a temporary file for the Dropbox download.');
+        }
+
+        try {
+            file_put_contents($stagedPath, $this->downloadFile($client, $fileInfo['path']));
+
+            $comic = $this->comicService->uploadComic(
+                new UploadedFile($stagedPath, $fileInfo['name'], 'application/zip', null, true),
+                $user,
+                $this->titleFromFilename($fileInfo['name']),
+                null,
+                null,
+                self::IMPORT_DESCRIPTION,
+                array_merge([self::IMPORT_TAG], $fileInfo['tags'])
+            );
+
+            $comic->setDropboxPath($fileInfo['path']);
+            $this->entityManager->flush();
+
+            return $comic;
+        } finally {
+            if (is_file($stagedPath)) {
+                unlink($stagedPath);
+            }
+        }
+    }
+
+    /**
+     * Dropbox serves large files better through a temporary link, so prefer that
+     * and fall back to the API download endpoint.
+     *
+     * @return string|resource
+     */
+    private function downloadFile(DropboxClient $client, string $path)
+    {
+        try {
+            return $this->httpClient->request('GET', $client->getTemporaryLink($path))->getContent();
+        } catch (\Throwable $e) {
+            $this->logger->debug('Dropbox temporary link download failed, falling back to direct download.', [
+                'path' => $path,
+                'exception' => $e,
+            ]);
+
+            return $client->download($path);
+        }
+    }
+
+    /**
+     * Derive a display title from a CBZ filename: "super_hero-01.cbz" -> "Super Hero 01".
+     */
+    public function titleFromFilename(string $filename): string
+    {
+        $title = str_replace(['_', '-'], ' ', pathinfo($filename, PATHINFO_FILENAME));
+
+        return ucwords(trim(preg_replace('/\s+/', ' ', $title)));
+    }
+
+    public function formatFileSize(int $bytes): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $bytes = max($bytes, 0);
+        $power = (int) min(floor(($bytes ? log($bytes) : 0) / log(1024)), count($units) - 1);
+
+        return round($bytes / (1024 ** $power), 2) . ' ' . $units[$power];
+    }
+
+    /**
+     * Turn the folder structure a file sits in into tags, relative to the app
+     * folder: ".../Manga/spaceOpera" -> ["Manga", "Space Opera"].
+     *
+     * @return list<string>
+     */
+    private function convertPathToTags(string $path): array
+    {
+        if ($path === '' || $path === '.') {
+            return [];
+        }
+
+        $relativePath = ltrim($path, '/');
+        $appFolderPrefix = trim($this->dropboxAppFolder, '/') . '/';
+        if (str_starts_with($relativePath, $appFolderPrefix)) {
+            $relativePath = substr($relativePath, strlen($appFolderPrefix));
+        }
+
+        $tags = [];
+        foreach (explode('/', $relativePath) as $folder) {
+            $tag = $this->formatFolderName($folder);
+            if ($tag !== '') {
+                $tags[] = $tag;
+            }
+        }
+
+        return $tags;
+    }
+
+    /**
+     * "superHero" -> "Super Hero", "sci-fi" -> "Sci Fi", "MANGA" -> "Manga".
+     */
+    private function formatFolderName(string $folderName): string
+    {
+        $formatted = str_replace(['_', '-'], ' ', $folderName);
+        $formatted = preg_replace('/([a-z])([A-Z])/', '$1 $2', $formatted);
+        $formatted = preg_replace('/\s+/', ' ', $formatted);
+
+        return ucwords(strtolower(trim($formatted)));
+    }
+
+    private function normaliseTitle(string $title): string
+    {
+        $normalised = preg_replace('/[^a-z0-9\s]/', '', strtolower($title));
+
+        return trim(preg_replace('/\s+/', ' ', $normalised));
+    }
+}

--- a/backend/tests/Unit/Service/DropboxImportServiceTest.php
+++ b/backend/tests/Unit/Service/DropboxImportServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\ComicService;
+use App\Service\DropboxImportService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class DropboxImportServiceTest extends TestCase
+{
+    private function service(string $appFolder = '/Apps/StarbugStoneComics'): DropboxImportService
+    {
+        return new DropboxImportService(
+            $this->createMock(ComicService::class),
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(HttpClientInterface::class),
+            new NullLogger(),
+            $appFolder
+        );
+    }
+
+    /**
+     * Regression: duplicate detection used to compare the Dropbox filename with
+     * the stored filename, which ComicService rewrites to "{slug}-{uniqid}.cbz".
+     * The two could never match, so every sync re-imported the whole library.
+     */
+    public function testRecognisesAFileAlreadyImportedFromTheSamePath(): void
+    {
+        $file = ['path' => '/Apps/StarbugStoneComics/Batman 01.cbz', 'name' => 'Batman 01.cbz'];
+        $index = ['paths' => ['/apps/starbugstonecomics/batman 01.cbz' => true], 'titles' => []];
+
+        self::assertTrue($this->service()->isImported($file, $index));
+    }
+
+    public function testTreatsAnUnknownPathAsNotImported(): void
+    {
+        $file = ['path' => '/Apps/StarbugStoneComics/Batman 02.cbz', 'name' => 'Batman 02.cbz'];
+        $index = ['paths' => ['/apps/starbugstonecomics/batman 01.cbz' => true], 'titles' => []];
+
+        self::assertFalse($this->service()->isImported($file, $index));
+    }
+
+    /**
+     * Comics imported before dropbox_path existed have no recorded path, so the
+     * derived title is used to avoid re-importing them after an upgrade.
+     */
+    public function testFallsBackToTheDerivedTitleForLegacyImports(): void
+    {
+        $file = ['path' => '/Apps/StarbugStoneComics/the_dark-knight.cbz', 'name' => 'the_dark-knight.cbz'];
+        $index = ['paths' => [], 'titles' => ['the dark knight' => true]];
+
+        self::assertTrue($this->service()->isImported($file, $index));
+    }
+
+    /**
+     * Distinct issues of the same series must stay distinct. The old
+     * similar_text() check scored these above its 85% threshold and wrongly
+     * reported unimported files as already synced.
+     */
+    public function testDoesNotConfuseNeighbouringIssuesOfTheSameSeries(): void
+    {
+        $file = ['path' => '/Apps/StarbugStoneComics/Batman 02.cbz', 'name' => 'Batman 02.cbz'];
+        $index = ['paths' => [], 'titles' => ['batman 01' => true]];
+
+        self::assertFalse($this->service()->isImported($file, $index));
+    }
+
+    /**
+     * @dataProvider titleProvider
+     */
+    public function testDerivesAReadableTitleFromTheFilename(string $filename, string $expected): void
+    {
+        self::assertSame($expected, $this->service()->titleFromFilename($filename));
+    }
+
+    public function titleProvider(): iterable
+    {
+        yield 'underscores and hyphens' => ['the_dark-knight.cbz', 'The Dark Knight'];
+        yield 'already readable' => ['Amazing Spider Man 12.cbz', 'Amazing Spider Man 12'];
+        yield 'collapses whitespace' => ['spaced__out--title.cbz', 'Spaced Out Title'];
+    }
+
+    /**
+     * @dataProvider fileSizeProvider
+     */
+    public function testFormatsFileSizes(int $bytes, string $expected): void
+    {
+        self::assertSame($expected, $this->service()->formatFileSize($bytes));
+    }
+
+    public function fileSizeProvider(): iterable
+    {
+        yield 'zero' => [0, '0 B'];
+        yield 'bytes' => [512, '512 B'];
+        yield 'kilobytes' => [1536, '1.5 KB'];
+        yield 'megabytes' => [1572864, '1.5 MB'];
+    }
+}

--- a/frontend/src/components/AdminAuditList.jsx
+++ b/frontend/src/components/AdminAuditList.jsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
-
-const formatDate = (value) => value ? new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value)) : "N/A";
+import { formatDateTime } from "@/lib/format";
 
 export function AdminAuditList() {
   const { toast } = useToast();
@@ -38,7 +37,7 @@ export function AdminAuditList() {
           <TableBody>
             {logs.length > 0 ? logs.map((log) => (
               <TableRow key={log.id}>
-                <TableCell>{formatDate(log.createdAt)}</TableCell>
+                <TableCell>{formatDateTime(log.createdAt)}</TableCell>
                 <TableCell>{log.admin?.name || log.admin?.email}</TableCell>
                 <TableCell>{log.action}</TableCell>
                 <TableCell>{log.targetType} {log.targetId || ""}</TableCell>

--- a/frontend/src/components/AdminComicsList.jsx
+++ b/frontend/src/components/AdminComicsList.jsx
@@ -10,6 +10,7 @@ import { useToast } from "@/hooks/use-toast";
 import { ComicEditDialog } from "@/components/ComicEditDialog";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { formatDate, matchesQuery } from "@/lib/format";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -51,24 +52,19 @@ export function AdminComicsList() {
     loadComics();
   }, [loadComics]);
   
-  const filteredComics = comics.filter(comic => 
-    comic.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    comic.author.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    (comic.owner && comic.owner.email && comic.owner.email.toLowerCase().includes(searchQuery.toLowerCase())) || // Adjusted for potential API structure
-    (comic.owner && comic.owner.username && comic.owner.username.toLowerCase().includes(searchQuery.toLowerCase())) ||
-    (comic.tags && comic.tags.some(tag => 
-      typeof tag === 'string' ? tag.toLowerCase().includes(searchQuery.toLowerCase()) : 
-      (tag.name && tag.name.toLowerCase().includes(searchQuery.toLowerCase()))
-    ))
+  // author, publisher and owner fields are all nullable in the API, so every
+  // comparison has to tolerate a missing value.
+  const query = searchQuery.toLowerCase();
+  const filteredComics = comics.filter(comic =>
+    matchesQuery(comic.title, query) ||
+    matchesQuery(comic.author, query) ||
+    matchesQuery(comic.owner?.email, query) ||
+    matchesQuery(comic.owner?.name, query) ||
+    (comic.tags || []).some(tag =>
+      matchesQuery(typeof tag === "string" ? tag : tag?.name, query)
+    )
   );
-  
-  const formatDate = (dateString) => {
-    const date = new Date(dateString);
-    return new Intl.DateTimeFormat('en-US', {
-      dateStyle: 'medium',
-    }).format(date);
-  };
-  
+
   const handleDeleteComic = async (comicId) => {
     try {
       await api.delete(`/api/comics/${comicId}`);

--- a/frontend/src/components/AdminDropbox.jsx
+++ b/frontend/src/components/AdminDropbox.jsx
@@ -3,8 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
-
-const formatDate = (value) => value ? new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value)) : "Never";
+import { formatDateTime } from "@/lib/format";
 
 export function AdminDropbox() {
   const { toast } = useToast();
@@ -62,7 +61,7 @@ export function AdminDropbox() {
             {users.length > 0 ? users.map((user) => (
               <TableRow key={user.id}>
                 <TableCell>{user.name || user.email}<div className="text-sm text-muted-foreground">{user.email}</div></TableCell>
-                <TableCell>{formatDate(user.lastSyncedAt)}</TableCell>
+                <TableCell>{formatDateTime(user.lastSyncedAt, "Never")}</TableCell>
                 <TableCell>{user.dropboxComicCount}</TableCell>
                 <TableCell className="text-right space-x-2">
                   <Button size="sm" variant="outline" disabled={busyUserId === user.id} onClick={() => runAction(user.id, "sync")}>Force sync</Button>

--- a/frontend/src/components/AdminOverview.jsx
+++ b/frontend/src/components/AdminOverview.jsx
@@ -4,15 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
-
-const formatBytes = (bytes = 0) => {
-  if (!bytes) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  return `${(bytes / Math.pow(1024, index)).toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
-};
-
-const formatDate = (value) => value ? new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value)) : "N/A";
+import { formatDateTime, formatFileSize } from "@/lib/format";
 
 export function AdminOverview() {
   const { toast } = useToast();
@@ -51,7 +43,7 @@ export function AdminOverview() {
         <Card><CardHeader><CardTitle>Total users</CardTitle></CardHeader><CardContent className="text-3xl font-bold">{stats?.totalUsers ?? 0}</CardContent></Card>
         <Card><CardHeader><CardTitle>Verified users</CardTitle></CardHeader><CardContent className="text-3xl font-bold">{stats?.verifiedUsers ?? 0}</CardContent></Card>
         <Card><CardHeader><CardTitle>Total comics</CardTitle></CardHeader><CardContent className="text-3xl font-bold">{stats?.totalComics ?? 0}</CardContent></Card>
-        <Card><CardHeader><CardTitle>Storage used</CardTitle></CardHeader><CardContent className="text-3xl font-bold">{formatBytes(stats?.storageUsed)}</CardContent></Card>
+        <Card><CardHeader><CardTitle>Storage used</CardTitle></CardHeader><CardContent className="text-3xl font-bold">{formatFileSize(stats?.storageUsed)}</CardContent></Card>
       </div>
 
       <Card>
@@ -64,7 +56,7 @@ export function AdminOverview() {
                 <TableRow key={user.id}>
                   <TableCell>{user.name || user.email}<div className="text-sm text-muted-foreground">{user.email}</div></TableCell>
                   <TableCell>{user.isEmailVerified ? "Yes" : "No"}</TableCell>
-                  <TableCell>{formatDate(user.createdAt)}</TableCell>
+                  <TableCell>{formatDateTime(user.createdAt)}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/frontend/src/components/AdminTagsList.jsx
+++ b/frontend/src/components/AdminTagsList.jsx
@@ -51,7 +51,8 @@ export function AdminTagsList() {
   const query = searchQuery.toLowerCase();
   const filteredTags = tags.filter(tag =>
     matchesQuery(tag.name, query) ||
-    matchesQuery(tag.creator?.name || tag.creator?.email, query)
+    matchesQuery(tag.creator?.name, query) ||
+    matchesQuery(tag.creator?.email, query)
   );
 
   const handleAddTag = async () => {

--- a/frontend/src/components/AdminTagsList.jsx
+++ b/frontend/src/components/AdminTagsList.jsx
@@ -7,6 +7,7 @@ import { Search, Plus, Trash, Edit } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { formatDate, matchesQuery } from "@/lib/format";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -47,19 +48,11 @@ export function AdminTagsList() {
     loadTags();
   }, [loadTags]);
 
+  const query = searchQuery.toLowerCase();
   const filteredTags = tags.filter(tag =>
-    tag.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    (tag.creator && (tag.creator.name || tag.creator.email) &&
-     (tag.creator.name || tag.creator.email).toLowerCase().includes(searchQuery.toLowerCase()))
+    matchesQuery(tag.name, query) ||
+    matchesQuery(tag.creator?.name || tag.creator?.email, query)
   );
-
-  const formatDate = (dateString) => {
-    if (!dateString) return 'N/A';
-    const date = new Date(dateString);
-    return new Intl.DateTimeFormat('en-US', {
-      dateStyle: 'medium',
-    }).format(date);
-  };
 
   const handleAddTag = async () => {
     if (!newTagName.trim()) {

--- a/frontend/src/components/AdminUsersList.jsx
+++ b/frontend/src/components/AdminUsersList.jsx
@@ -36,6 +36,7 @@ import { useAuth } from "@/hooks/use-auth"; // Import useAuth hook
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
 import { validatePassword } from "@/lib/password-policy";
+import { formatDateTime, matchesQuery } from "@/lib/format";
 
 export function AdminUsersList({ showOnlyUnverified = false }) {
   const { toast } = useToast();
@@ -81,21 +82,11 @@ export function AdminUsersList({ showOnlyUnverified = false }) {
     loadUsers();
   }, [loadUsers]);
   
-  const filteredUsers = users.filter(user => {
-    const query = searchQuery.toLowerCase();
-    const nameMatch = user.name && typeof user.name === 'string' && user.name.toLowerCase().includes(query);
-    const emailMatch = user.email && typeof user.email === 'string' && user.email.toLowerCase().includes(query);
-    return nameMatch || emailMatch;
-  });
-  
-  const formatDate = (dateString) => {
-    const date = new Date(dateString);
-    return new Intl.DateTimeFormat('en-US', {
-      dateStyle: 'medium',
-      timeStyle: 'short'
-    }).format(date);
-  };
-  
+  const query = searchQuery.toLowerCase();
+  const filteredUsers = users.filter(user =>
+    matchesQuery(user.name, query) || matchesQuery(user.email, query)
+  );
+
   const handleDeleteUser = async (userId) => {
     try {
       await api.delete(`/api/users/${userId}`);
@@ -316,8 +307,8 @@ export function AdminUsersList({ showOnlyUnverified = false }) {
                         <Badge variant="destructive">Pending</Badge>
                       )}
                     </TableCell>
-                    <TableCell>{formatDate(user.createdAt)}</TableCell>
-                    <TableCell>{user.lastLoginAt ? formatDate(user.lastLoginAt) : "Never"}</TableCell>
+                    <TableCell>{formatDateTime(user.createdAt)}</TableCell>
+                    <TableCell>{formatDateTime(user.lastLoginAt, "Never")}</TableCell>
                     <TableCell>{user.comicCount}</TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">

--- a/frontend/src/components/ComicTableView.jsx
+++ b/frontend/src/components/ComicTableView.jsx
@@ -10,6 +10,7 @@ import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { getComicProgressState } from "@/lib/comic-progress";
+import { formatDate } from "@/lib/format";
 
 export function ComicTableView({ comics, onEditComic, onBulkAddTag, onBulkDelete }) {
   const [selectedIds, setSelectedIds] = useState(() => new Set());
@@ -160,7 +161,7 @@ export function ComicTableView({ comics, onEditComic, onBulkAddTag, onBulkDelete
                       <Progress value={progress.percent} className={cn("h-2", progress.progressClass)} />
                     </div>
                   </TableCell>
-                  <TableCell>{new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(new Date(comic.uploadedAt))}</TableCell>
+                  <TableCell>{formatDate(comic.uploadedAt)}</TableCell>
                   <TableCell className="text-right">
                     <Button variant="ghost" size="icon" asChild>
                       <Link to={`/read/${comic.id}`} aria-label={`Read ${comic.title}`}><Eye className="h-4 w-4" /></Link>

--- a/frontend/src/lib/comic-upload.js
+++ b/frontend/src/lib/comic-upload.js
@@ -1,3 +1,5 @@
+export { formatFileSize } from "@/lib/format";
+
 export const CHUNK_SIZE_BYTES = 1024 * 1024;
 
 export function generateTitleFromFilename(filename) {
@@ -14,10 +16,4 @@ export function generateTitleFromFilename(filename) {
 
 export function isCbzFile(file) {
   return Boolean(file?.name?.toLowerCase().endsWith(".cbz"));
-}
-
-export function formatFileSize(bytes) {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/frontend/src/lib/cookies.js
+++ b/frontend/src/lib/cookies.js
@@ -31,11 +31,3 @@ export function getCookie(name) {
   }
   return null;
 }
-
-/**
- * Delete a cookie by name
- * @param {string} name - The name of the cookie to delete
- */
-export function deleteCookie(name) {
-  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
-}

--- a/frontend/src/lib/format.js
+++ b/frontend/src/lib/format.js
@@ -1,0 +1,56 @@
+/**
+ * Shared display formatters.
+ *
+ * These used to be redefined in almost every admin component, which let them
+ * drift apart. Import from here instead of writing a local copy.
+ */
+
+/**
+ * Format a date/time for display, e.g. "5 Aug 2026, 14:30".
+ * @param {string|Date|null|undefined} value
+ * @param {string} fallback Shown when there is no value.
+ */
+export function formatDateTime(value, fallback = "N/A") {
+  if (!value) return fallback;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+
+  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(date);
+}
+
+/**
+ * Format a date for display without the time, e.g. "5 Aug 2026".
+ * @param {string|Date|null|undefined} value
+ * @param {string} fallback Shown when there is no value.
+ */
+export function formatDate(value, fallback = "N/A") {
+  if (!value) return fallback;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+
+  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(date);
+}
+
+/**
+ * Format a byte count for display, e.g. "1.4 MB".
+ * @param {number|null|undefined} bytes
+ */
+export function formatFileSize(bytes) {
+  const value = Number(bytes) || 0;
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  if (value < 1024 * 1024 * 1024) return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(value / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+/**
+ * Case-insensitive "does this field contain the query" check that tolerates
+ * null/undefined fields, which most comic metadata columns are.
+ * @param {unknown} value
+ * @param {string} query Already lowercased.
+ */
+export function matchesQuery(value, query) {
+  return typeof value === "string" && value.toLowerCase().includes(query);
+}

--- a/frontend/src/lib/session-manager.js
+++ b/frontend/src/lib/session-manager.js
@@ -205,40 +205,8 @@ class SessionManager {
     return await this.checkSession(true);
   }
 
-  /**
-   * Get CSRF token from cookies
-   * @returns {string} CSRF token
-   */
-  getCsrfToken() {
-    try {
-      // More robust cookie parsing
-      const cookies = document.cookie.split(';').reduce((acc, cookie) => {
-        if (!cookie.trim()) return acc;
-        
-        const parts = cookie.trim().split('=');
-        if (parts.length < 2) return acc;
-        
-        const key = parts[0].trim();
-        const value = parts.slice(1).join('='); // Handle values that might contain =
-        
-        acc[key] = decodeURIComponent(value);
-        return acc;
-      }, {});
-      
-      // Look for XSRF-TOKEN or CSRF-TOKEN
-      const token = cookies['XSRF-TOKEN'] || cookies['CSRF-TOKEN'] || '';
-      
-      if (!token) {
-        logger.warn('No CSRF token found in cookies');
-      }
-      
-      return token;
-    } catch (error) {
-      logger.error('Error extracting CSRF token:', error);
-      return '';
-    }
-  }
-  
+  // CSRF tokens are read by lib/csrf.js, which lib/api.js applies to every
+  // mutating request. Do not add a second implementation here.
 }
 
 // Create a singleton instance

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -166,9 +166,10 @@ export default function ComicReader() {
     canvas.height = img.height;
     canvas.getContext('2d').drawImage(img, 0, 0);
 
-    // PNG keeps transparency and avoids re-compressing already-lossy pages.
+    // JPEG keeps the bounded page cache compact. Lossless PNG snapshots can
+    // expand photographic comic pages enough to exhaust memory on mobile.
     const cachedImg = new Image();
-    cachedImg.src = canvas.toDataURL('image/png');
+    cachedImg.src = canvas.toDataURL('image/jpeg', 0.92);
     return cachedImg;
   };
 

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -30,6 +30,7 @@ export default function ComicReader() {
   const loadQueueRef = useRef([]); // Queue of pages to load
   const isLoadingRef = useRef(false); // Flag to track if we're currently loading a page
   const isMountedRef = useRef(true); // Progress saves outlive the component; used to suppress late toasts
+  const progressRevisionRef = useRef(0); // Orders progress saves that may reach the server out of order
   
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -50,15 +51,25 @@ export default function ComicReader() {
     const controller = new AbortController();
     progressAbortController.current = controller;
 
+    // Aborting only stops the browser waiting for the reply; a superseded save
+    // may already be on its way to the server. The revision tells the server
+    // which save is newer, and page numbers cannot: reading backwards is normal.
+    const revision = ++progressRevisionRef.current;
+
     try {
       // keepalive lets the browser finish this request even if the reader is
       // being torn down (closing the tab, navigating away). Without it the
       // final page of a reading session is silently lost.
-      await api.post(
+      const response = await api.post(
         `/api/comics/${comicId}/progress`,
-        { currentPage: pageToSave },
+        { currentPage: pageToSave, revision },
         { signal: controller.signal, keepalive: true }
       );
+
+      const storedRevision = response?.progress?.revision;
+      if (typeof storedRevision === 'number' && storedRevision > progressRevisionRef.current) {
+        progressRevisionRef.current = storedRevision;
+      }
     } catch (error) {
       // A superseded save is expected, not a failure
       if (error.name === 'AbortError' || controller.signal.aborted) return;
@@ -111,6 +122,11 @@ export default function ComicReader() {
           setComicPages(
             Array.from({ length: data.comic.pageCount }, (_, i) => `/api/comics/${comicId}/pages/${i + 1}`)
           );
+          // Continue the server's revision sequence, otherwise a reopened
+          // reader would start below the stored value and every save would
+          // look stale.
+          progressRevisionRef.current = data.comic.readingProgress?.revision || 0;
+
           if (data.comic.readingProgress && data.comic.readingProgress.currentPage) {
             setCurrentPage(data.comic.readingProgress.currentPage - 1);
           } else {

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -29,23 +29,19 @@ export default function ComicReader() {
   const currentPageRef = useRef(0); // Ref to track current page for async operations
   const loadQueueRef = useRef([]); // Queue of pages to load
   const isLoadingRef = useRef(false); // Flag to track if we're currently loading a page
+  const isMountedRef = useRef(true); // Progress saves outlive the component; used to suppress late toasts
   
   const navigate = useNavigate();
   const { toast } = useToast();
 
   const CACHE_SIZE_FORWARD = 5;
   const CACHE_SIZE_BACKWARD = 5;
-  
-  // Debug function to log cache state - only used in debug panel
-  const logCacheState = useCallback(() => {
-    // Cache state info is displayed in the debug panel UI
-    // No console logging needed
-  }, []);
 
   const updateReadingProgress = useCallback(async (pageToSave) => {
     if (!comicId || !comic) return;
 
-    // Abort any in-progress update
+    // Supersede the previous save: only the latest page matters, so a rapid run
+    // of page turns collapses to one request rather than a queue of them.
     if (progressAbortController.current) {
       progressAbortController.current.abort();
     }
@@ -55,41 +51,51 @@ export default function ComicReader() {
     progressAbortController.current = controller;
 
     try {
-      // Check if component is still mounted before making the request
-      if (controller.signal.aborted) {
-        return;
-      }
-      
-      await api.post(`/api/comics/${comicId}/progress`, { currentPage: pageToSave }, { signal: controller.signal });
-
-      // If this request was aborted, just return silently
-      if (controller.signal.aborted) return;
-
-      // Optional: toast({ title: "Progress Saved", description: `Page ${pageToSave} saved.` });
+      // keepalive lets the browser finish this request even if the reader is
+      // being torn down (closing the tab, navigating away). Without it the
+      // final page of a reading session is silently lost.
+      await api.post(
+        `/api/comics/${comicId}/progress`,
+        { currentPage: pageToSave },
+        { signal: controller.signal, keepalive: true }
+      );
     } catch (error) {
-      // Don't show errors for aborted requests or network errors when component unmounts
+      // A superseded save is expected, not a failure
       if (error.name === 'AbortError' || controller.signal.aborted) return;
-      
+
       // Handle network errors more gracefully
       if (error.name === 'TypeError' && error.message.includes('Failed to fetch')) {
         logger.warn("Network error when saving reading progress - will retry on next page change");
         return; // Don't show toast for network errors, as they're often transient
       }
-      
+
       logger.error("Failed to save reading progress:", error);
+
+      // The reader may already be gone by the time a save fails; a toast about
+      // it would surface on whatever page the user moved on to.
+      if (!isMountedRef.current) return;
+
       toast({
         title: "Error Saving Progress",
         description: error.message || "Could not save your reading progress. Please try again.",
         variant: "destructive",
       });
     } finally {
-      // Only update state if this controller is still the current one
+      // Only clear the ref if this controller is still the current one
       if (progressAbortController.current === controller) {
         progressAbortController.current = null;
       }
     }
   }, [comicId, comic, toast]);
 
+  // Track mount state so an in-flight progress save that resolves after the
+  // reader closes does not try to toast onto the next screen.
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     const loadComic = async () => {
@@ -152,21 +158,20 @@ export default function ComicReader() {
            pageIndex <= Math.min(comicPages.length - 1, currentPageRef.current + CACHE_SIZE_FORWARD);
   }, [comicPages.length]);
 
-  // Function to convert an image to a data URL to avoid network requests
-  const imageToDataURL = (img) => {
-    // Create a canvas element
+  // Snapshot a loaded image into a detached, self-contained Image so that
+  // re-displaying a cached page never hits the network again.
+  const toCachedImage = (img) => {
     const canvas = document.createElement('canvas');
     canvas.width = img.width;
     canvas.height = img.height;
-    
-    // Draw the image on the canvas
-    const ctx = canvas.getContext('2d');
-    ctx.drawImage(img, 0, 0);
-    
-    // Convert the canvas to a data URL
-    return canvas.toDataURL('image/jpeg');
+    canvas.getContext('2d').drawImage(img, 0, 0);
+
+    // PNG keeps transparency and avoids re-compressing already-lossy pages.
+    const cachedImg = new Image();
+    cachedImg.src = canvas.toDataURL('image/png');
+    return cachedImg;
   };
-  
+
   // Object to track in-progress loads to prevent duplicate requests
   const loadingPagesRef = useRef({});
   
@@ -201,26 +206,15 @@ export default function ComicReader() {
       img.onload = () => {
         // Only update cache if this page is still in the cache window
         if (isInCacheWindow(pageIndex)) {
+          let cached;
           try {
-            // Convert the image to a data URL to prevent network requests
-            const dataUrl = imageToDataURL(img);
-            
-            // Create a new image with the data URL
-            const cachedImg = new Image();
-            cachedImg.src = dataUrl;
-            
-            setImageCache(prev => ({
-              ...prev,
-              [pageIndex]: cachedImg
-            }));
+            cached = toCachedImage(img);
           } catch {
-            // Error creating data URL, fallback to using the original image
-            setImageCache(prev => ({
-              ...prev,
-              [pageIndex]: img
-            }));
-            // Fallback successful
+            // Canvas snapshot failed; fall back to the original image
+            cached = img;
           }
+
+          setImageCache(prev => ({ ...prev, [pageIndex]: cached }));
         }
         // Remove from loading tracker
         delete loadingPagesRef.current[pageIndex];
@@ -320,18 +314,21 @@ export default function ComicReader() {
   // Function to clean up the cache (remove pages outside the window)
   const cleanupCache = useCallback(() => {
     setImageCache(prev => {
-      const newCache = { ...prev };
       const startPage = Math.max(0, currentPageRef.current - CACHE_SIZE_BACKWARD);
       const endPage = Math.min(comicPages.length - 1, currentPageRef.current + CACHE_SIZE_FORWARD);
-      
-      // Remove pages outside the window
-      Object.keys(newCache).forEach(key => {
+
+      const stale = Object.keys(prev).filter(key => {
         const pageKey = parseInt(key, 10);
-        if (pageKey < startPage || pageKey > endPage) {
-          delete newCache[pageKey];
-        }
+        return pageKey < startPage || pageKey > endPage;
       });
-      
+
+      // Returning a new object when nothing was evicted would change the cache
+      // identity, re-run the effect that schedules this cleanup, and spin the
+      // component in a permanent 2-second loop. Keep the same reference instead.
+      if (stale.length === 0) return prev;
+
+      const newCache = { ...prev };
+      stale.forEach(key => delete newCache[key]);
       return newCache;
     });
   }, [comicPages.length]);
@@ -392,61 +389,55 @@ export default function ComicReader() {
     // Schedule cache cleanup after a delay
     const cleanupTimer = setTimeout(() => {
       cleanupCache();
-      logCacheState();
     }, 2000); // Delay cleanup to avoid unnecessary operations
-    
+
     return () => {
       clearTimeout(cleanupTimer);
     };
-  // Include loadPageIntoCache but not imageCache to prevent infinite loop
-  }, [currentPage, comicPages, imageCache, queuePagesToLoad, cleanupCache, logCacheState, loadPageIntoCache]);
+  }, [currentPage, comicPages, imageCache, queuePagesToLoad, cleanupCache, loadPageIntoCache]);
 
 
 
   // Effect to save reading progress when currentPage changes
   // We don't need to run this on every render, only when the page changes
   const lastSavedPage = useRef(null);
-  
+
   useEffect(() => {
     // Only update if the page has actually changed and we have all the required data
-    if (comic && comicId && typeof currentPage === 'number' && currentPage >= 0 && 
+    if (comic && comicId && typeof currentPage === 'number' && currentPage >= 0 &&
         comicPages.length > 0 && lastSavedPage.current !== currentPage) {
       // We add 1 because currentPage is 0-indexed, but backend expects 1-indexed.
       lastSavedPage.current = currentPage;
       updateReadingProgress(currentPage + 1);
     }
-    
-    // Cleanup function to abort any in-progress requests when component unmounts
-    // or when dependencies change
-    return () => {
-      if (progressAbortController.current) {
-        progressAbortController.current.abort();
-        progressAbortController.current = null;
-      }
-    };
+
+    // Deliberately no cleanup here. Aborting on unmount would cancel the save
+    // for the page the user just finished on, losing it; and aborting when
+    // currentPage changes is unnecessary because updateReadingProgress already
+    // supersedes its own previous request.
   }, [currentPage, comic, comicId, comicPages.length, updateReadingProgress]);
 
+  // Move by one page, priming the loading state from the cache so an already
+  // cached page renders without a skeleton flash.
+  const goToPage = useCallback((newPage) => {
+    if (newPage < 0 || newPage > comicPages.length - 1) return;
+
+    const cachedImage = imageCache[newPage];
+    const isCached = cachedImage && cachedImage !== 'loading' && cachedImage !== 'failed';
+    setIsPageImageLoading(!isCached);
+    setImageLoadedSuccessfully(Boolean(isCached));
+
+    setCurrentPage(newPage);
+  }, [imageCache, comicPages.length]);
+
   const handlePreviousPage = useCallback(() => {
-    if (currentPage > 0) {
-      const newPage = currentPage - 1;
-      
-      // Check if the page is already cached - if so, update UI immediately
-      const cachedImage = imageCache[newPage];
-      if (cachedImage && cachedImage !== 'loading' && cachedImage !== 'failed') {
-        // Update UI state before changing page to ensure immediate display
-        setIsPageImageLoading(false);
-        setImageLoadedSuccessfully(true);
-      } else {
-        // Not in cache, will need to load
-        setIsPageImageLoading(true);
-        setImageLoadedSuccessfully(false);
-      }
-      
-      // Update page
-      setCurrentPage(newPage);
-    }
-  }, [currentPage, imageCache]);
-  
+    goToPage(currentPage - 1);
+  }, [goToPage, currentPage]);
+
+  const handleNextPage = useCallback(() => {
+    goToPage(currentPage + 1);
+  }, [goToPage, currentPage]);
+
   // Function to force reload the current page from the server
   const handleForceReload = useCallback(() => {
     if (comicPages.length === 0 || currentPage < 0 || currentPage >= comicPages.length) {
@@ -516,21 +507,11 @@ export default function ComicReader() {
               return;
             }
             
-            // Convert to data URL to prevent network requests
-            const canvas = document.createElement('canvas');
-            canvas.width = img.width;
-            canvas.height = img.height;
-            const ctx = canvas.getContext('2d');
-            ctx.drawImage(img, 0, 0);
-            const dataUrl = canvas.toDataURL('image/jpeg');
-            
+            const cachedImg = toCachedImage(img);
+
             // Free the blob URL
             URL.revokeObjectURL(blobUrl);
-            
-            // Create a new image with the data URL
-            const cachedImg = new Image();
-            cachedImg.src = dataUrl;
-            
+
             // Update cache with the new image
             setImageCache(prev => ({
               ...prev,
@@ -623,27 +604,6 @@ export default function ComicReader() {
       });
   }, [comicPages, currentPage, toast]);
   
-  const handleNextPage = useCallback(() => {
-    if (currentPage < comicPages.length - 1) {
-      const newPage = currentPage + 1;
-      
-      // Check if the page is already cached - if so, update UI immediately
-      const cachedImage = imageCache[newPage];
-      if (cachedImage && cachedImage !== 'loading' && cachedImage !== 'failed') {
-        // Update UI state before changing page to ensure immediate display
-        setIsPageImageLoading(false);
-        setImageLoadedSuccessfully(true);
-      } else {
-        // Not in cache, will need to load
-        setIsPageImageLoading(true);
-        setImageLoadedSuccessfully(false);
-      }
-      
-      // Update page
-      setCurrentPage(newPage);
-    }
-  }, [currentPage, imageCache, comicPages.length]);
-
   const handleScreenNavClick = (direction) => {
     if (direction === 'left') {
       handlePreviousPage();
@@ -652,6 +612,8 @@ export default function ComicReader() {
     }
   };
 
+  // One listener on window covers both normal and fullscreen mode, since the
+  // reader keeps focus in the document either way.
   useEffect(() => {
     const handleKeyPress = (event) => {
       switch (event.key) {
@@ -668,7 +630,7 @@ export default function ComicReader() {
 
     window.addEventListener("keydown", handleKeyPress);
     return () => window.removeEventListener("keydown", handleKeyPress);
-  }, [currentPage, comicPages.length, handlePreviousPage, handleNextPage]);
+  }, [handlePreviousPage, handleNextPage]);
 
   // Handle fullscreen change events
   useEffect(() => {
@@ -688,33 +650,6 @@ export default function ComicReader() {
       document.removeEventListener('fullscreenchange', handleFullscreenChange);
     };
   }, [isZoomed]);
-  
-  // Ensure page navigation works in fullscreen mode
-  useEffect(() => {
-    const handleFullscreenKeyPress = (event) => {
-      if (isFullscreen) {
-        switch (event.key) {
-          case "ArrowLeft":
-            handlePreviousPage();
-            break;
-          case "ArrowRight":
-            handleNextPage();
-            break;
-          default:
-            break;
-        }
-      }
-    };
-
-    if (isFullscreen) {
-      window.addEventListener("keydown", handleFullscreenKeyPress);
-    }
-    
-    return () => {
-      // Always remove the event listener on cleanup, even if isFullscreen changed
-      window.removeEventListener("keydown", handleFullscreenKeyPress);
-    };
-  }, [isFullscreen, handlePreviousPage, handleNextPage]);
   
   // Handle zoom wheel events
   const handleWheel = useCallback((e) => {
@@ -918,10 +853,7 @@ export default function ComicReader() {
               variant="outline" 
               size="icon"
               className="opacity-80 hover:opacity-100 bg-card/80"
-              onClick={() => {
-                setShowDebug(!showDebug);
-                logCacheState();
-              }}
+              onClick={() => setShowDebug(!showDebug)}
               title="Debug info"
             >
               <Info className="h-4 w-4" />
@@ -935,7 +867,7 @@ export default function ComicReader() {
               <p>Total pages: {comicPages.length}</p>
               <p>Loading: {isPageImageLoading ? 'Yes' : 'No'}</p>
               <p>Cached pages: {Object.keys(imageCache).length}</p>
-              <p>Cache window: {Math.max(0, currentPage - CACHE_SIZE_BACKWARD) + 1} - {Math.min(comicPages.length, currentPage + CACHE_SIZE_FORWARD) + 1}</p>
+              <p>Cache window: {Math.max(0, currentPage - CACHE_SIZE_BACKWARD) + 1} - {Math.min(comicPages.length - 1, currentPage + CACHE_SIZE_FORWARD) + 1}</p>
               {isZoomed && (
                 <p>Zoom level: {Math.round(zoomLevel * 100)}%</p>
               )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -13,6 +13,7 @@ import { ShareComicModal } from "@/components/ShareComicModal.jsx";
 import { PendingSharesAlert } from "@/components/PendingSharesAlert.jsx";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { getComicProgressState } from "@/lib/comic-progress";
 
 export default function Dashboard() {
   const [comics, setComics] = useState([]);
@@ -236,10 +237,20 @@ export default function Dashboard() {
     }
   };
 
-  // Filters now operate on the 'comics' state directly
-  const inProgressComics = comics.filter(comic => comic.lastReadPage !== undefined && comic.lastReadPage > 0);
-  const unreadComics = comics.filter(comic => comic.lastReadPage === undefined || comic.lastReadPage === 0);
+  // Filters now operate on the 'comics' state directly. A finished comic is no
+  // longer "currently reading", so it is classified by its progress state
+  // rather than by page number alone.
+  const isCompleted = (comic) => getComicProgressState(comic).label === "Fully read";
+  const inProgressComics = comics.filter(comic => comic.lastReadPage > 0 && !isCompleted(comic));
+  const unreadComics = comics.filter(comic => !comic.lastReadPage);
   const dropboxComics = comics.filter(comic => comic.tags && comic.tags.includes('Dropbox'));
+
+  const comicTabs = [
+    { value: "all", label: "All Comics", items: comics, alwaysShown: true },
+    { value: "dropbox", label: "Dropbox", items: dropboxComics },
+    { value: "reading", label: "Currently Reading", items: inProgressComics },
+    { value: "unread", label: "Not Started", items: unreadComics },
+  ];
 
   // Handlers for ShareComicModal
   const handleOpenShareModal = (comicId, comicTitle) => {
@@ -340,91 +351,41 @@ export default function Dashboard() {
       ) : (
         <Tabs defaultValue="all" className="space-y-6">
           <TabsList>
-            <TabsTrigger value="all">All Comics ({comics.length})</TabsTrigger>
-            {dropboxComics.length > 0 && (
-              <TabsTrigger value="dropbox">
-                Dropbox ({dropboxComics.length})
-              </TabsTrigger>
-            )}
-            {inProgressComics.length > 0 && (
-              <TabsTrigger value="reading">
-                Currently Reading ({inProgressComics.length})
-              </TabsTrigger>
-            )}
-            {unreadComics.length > 0 && (
-              <TabsTrigger value="unread">
-                Not Started ({unreadComics.length})
-              </TabsTrigger>
-            )}
+            {comicTabs.map(({ value, label, items, alwaysShown }) => (
+              (alwaysShown || items.length > 0) && (
+                <TabsTrigger key={value} value={value}>
+                  {label} ({items.length})
+                </TabsTrigger>
+              )
+            ))}
           </TabsList>
 
-          <TabsContent value="all">
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-              {comics.map((comic) => (
-                <ComicCard 
-                  key={comic.id} 
-                  comic={comic} 
-                  onResetProgress={resetReadingProgress}
-                  onEditComic={handleEditComic}
-                  onDeleteComic={deleteComic}
-                  onShareClick={handleOpenShareModal} // Added onShareClick prop
-                />
-              ))}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="dropbox">
-            <div className="mb-4 p-4 bg-muted rounded-lg">
-              <p className="text-sm text-muted-foreground">
-                Comics synced from your Dropbox account. 
-                <Link to="/dropbox-sync" className="text-primary hover:underline ml-1">
-                  Manage Dropbox sync →
-                </Link>
-              </p>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-              {dropboxComics.map((comic) => (
-                <ComicCard 
-                  key={comic.id} 
-                  comic={comic} 
-                  onResetProgress={resetReadingProgress}
-                  onEditComic={handleEditComic}
-                  onDeleteComic={deleteComic}
-                  onShareClick={handleOpenShareModal}
-                />
-              ))}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="reading">
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-              {inProgressComics.map((comic) => (
-                <ComicCard 
-                  key={comic.id} 
-                  comic={comic} 
-                  onResetProgress={resetReadingProgress}
-                  onEditComic={handleEditComic}
-                  onDeleteComic={deleteComic}
-                  onShareClick={handleOpenShareModal} // Added onShareClick prop
-                />
-              ))}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="unread">
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-              {unreadComics.map((comic) => (
-                <ComicCard 
-                  key={comic.id} 
-                  comic={comic} 
-                  onResetProgress={resetReadingProgress}
-                  onEditComic={handleEditComic}
-                  onDeleteComic={deleteComic}
-                  onShareClick={handleOpenShareModal} // Added onShareClick prop
-                />
-              ))}
-            </div>
-          </TabsContent>
+          {comicTabs.map(({ value, items }) => (
+            <TabsContent key={value} value={value}>
+              {value === "dropbox" && (
+                <div className="mb-4 p-4 bg-muted rounded-lg">
+                  <p className="text-sm text-muted-foreground">
+                    Comics synced from your Dropbox account.
+                    <Link to="/dropbox-sync" className="text-primary hover:underline ml-1">
+                      Manage Dropbox sync →
+                    </Link>
+                  </p>
+                </div>
+              )}
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+                {items.map((comic) => (
+                  <ComicCard
+                    key={comic.id}
+                    comic={comic}
+                    onResetProgress={resetReadingProgress}
+                    onEditComic={handleEditComic}
+                    onDeleteComic={deleteComic}
+                    onShareClick={handleOpenShareModal}
+                  />
+                ))}
+              </div>
+            </TabsContent>
+          ))}
         </Tabs>
       )}
       

--- a/frontend/src/pages/DropboxSyncPage.jsx
+++ b/frontend/src/pages/DropboxSyncPage.jsx
@@ -266,11 +266,14 @@ function DropboxSyncPage() {
     }
   };
 
-  const handleImportSingle = async (fileName) => {
-    setImportingFiles(prev => new Set([...prev, fileName]));
-    
+  // Keyed on the path rather than the name: the same file name can appear in
+  // several Dropbox folders, and each is a separate row here.
+  const handleImportSingle = async (file) => {
+    const { name: fileName, path } = file;
+    setImportingFiles(prev => new Set([...prev, path]));
+
     try {
-      const data = await api.post('/api/dropbox/import', { fileName });
+      const data = await api.post('/api/dropbox/import', { path, fileName });
       toast({
         title: "Import Successful",
         description: `${data.comic?.title || fileName} has been imported successfully.`,
@@ -285,7 +288,7 @@ function DropboxSyncPage() {
     } finally {
       setImportingFiles(prev => {
         const newSet = new Set(prev);
-        newSet.delete(fileName);
+        newSet.delete(path);
         return newSet;
       });
     }
@@ -462,11 +465,11 @@ function DropboxSyncPage() {
                             <Button
                               size="sm"
                               variant="outline"
-                              onClick={() => handleImportSingle(file.name)}
-                              disabled={importingFiles.has(file.name)}
+                              onClick={() => handleImportSingle(file)}
+                              disabled={importingFiles.has(file.path)}
                               className="ml-3 text-blue-600 border-blue-600 hover:bg-blue-50"
                             >
-                              {importingFiles.has(file.name) ? (
+                              {importingFiles.has(file.path) ? (
                                 <>
                                   <Loader2 className="w-3 h-3 mr-1 animate-spin" />
                                   Importing...


### PR DESCRIPTION
Fixes a set of bugs found while auditing the codebase, and removes the duplication that caused the worst of them. Net **-1456 / +1268** across 34 files.

## Bugs

**Dropbox sync re-imported the whole library on every run.** All three duplicate checks compared the Dropbox filename against the stored filename, which `ComicService` rewrites to `{slug}-{uniqid}.cbz` — so they could never match. Comics now record the Dropbox path they came from (new `dropbox_path` column), with a derived-title fallback so comics imported *before* this change aren't re-pulled on upgrade.

**Dropbox downloads leaked.** Files were staged inside the comics directory and never removed, leaving a permanent second copy of every import that also escaped quota accounting. They now stage in the system temp dir with cleanup in a `finally`.

**The admin comics list crashed on load** for any comic without an author — `comic.author` is nullable but was dereferenced directly. Filtering is now null-safe. The owner filter also checked `owner.username`, which the API never returns; it now checks `owner.name`, so that search actually works.

**Accepted shares bypassed the storage quota.** `fileSize` was never set, so shared comics counted as zero bytes forever. Size is now recorded and checked against the quota before accepting.

**The reader span in a permanent 2-second render loop** whenever the current page failed to load: `cleanupCache` always returned a new object, changing the cache identity and re-arming the effect that schedules it. It now returns the previous object when nothing was evicted.

**Share emails** went out from a hardcoded `noreply@comicreader.example.com` instead of the configured `mailer_from_address` — likely to be spam-filtered.

**The chunked-upload response** leaked the internal `filePath` and returned a cover path in a different shape from every other endpoint.

**Closing the reader lost the last page.** The unmount cleanup aborted the in-flight save for the page you stopped on. The abort is gone, and the request uses `keepalive` so it survives page teardown.

## Deduplication

- Dropbox listing, tag derivation and import logic existed **twice verbatim** (controller + CLI command), and the import sequence **three times**. All of it moves to `DropboxImportService`, shared by both callers — which is also where the two Dropbox bugs above get fixed once instead of three times.
- Comic serialization existed in **three incompatible forms**; all responses now go through `ComicSerializer`. Library loads were N+1 on reading progress, now a single indexed query.
- `formatDate` was defined **six times** and `formatFileSize` twice; both now live in `lib/format.js`. The dashboard's four identical tab bodies collapse into one mapped block, and a finished comic no longer counts as "Currently Reading".
- Dead code removed: an unreachable block in the Dropbox OAuth callback, a duplicate unused CSRF reader in `SessionManager`, unused `formatFileSize` in `DropboxSyncCommand`, an empty `logCacheState`, a redundant second keydown listener, `deleteCookie`, plus several unused imports and injected-but-unused constructor/action arguments.

## Consistency and hardening

- `mkdir` uses `0775` everywhere instead of a mix of `0777` and `0775`.
- `ShareController` path handling uses `basename()` rather than stripping `../` sequences, which nested payloads like `....//` defeat.
- Tag copying on share acceptance no longer flushes inside a `try`/`catch` within a transaction — that closed the EntityManager on the first constraint violation, so the "continue anyway" recovery could never work.
- Deprecated `Routing\Annotation\Route` imports replaced with `Attribute\Route`.
- Directory creation moved out of controller constructors, so it no longer runs on every request.
- Added an optional `TRUSTED_PROXIES` setting. Behind a reverse proxy or CDN, the per-IP rate limiters currently see every visitor as one address, making the login limiter global. **Defaults to empty, preserving current behaviour** — set it if production sits behind Cloudflare or similar.

## Verification

| Check | Result |
| --- | --- |
| PHPUnit | 86 passed (11 new, covering the duplicate-detection regression) |
| `lint:container` | all services inject compatible types |
| `doctrine:schema:validate` | mapping correct, schema in sync |
| Migration down → up | clean round-trip, 14 migrations |
| ESLint / Vitest / `vite build` | all pass |

## Note for deploying

This adds a migration, so `doctrine:migrations:migrate` needs to run on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Dropbox imports with path-based duplicate detection, folder tags, import limits, and clearer failure reporting.
  * Added consistent comic details, cover links, and reading progress across the app.
  * Enhanced sharing with configured sender details, storage-quota checks, and safer file handling.
  * Reading progress now preserves save order during navigation and across devices.
* **Bug Fixes**
  * Improved comic uploads, legacy file access, reader navigation, caching, and progress saving.
  * Fully read comics are excluded from “Currently Reading.”
  * Improved administration filtering and date, time, and file-size displays.
* **Security**
  * Restricted upload directory permissions and improved reverse-proxy client address handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->