### PR TITLE
docs: real-world o2switch/shared-hosting notes + lessons learned (2026-08-06)

### DIFF
--- a/SSH-deploy.md
+++ b/SSH-deploy.md
@@ -861,3 +861,50 @@ git revert HEAD && git push && ./scripts/deploy-ssh.sh
 
 Pair this with `deploy.md` (FTP flow) — the two paths are complementary, and
 the same `scripts/.env.deploy` powers both.
+
+---
+
+## 13. Real-world notes for shared hosting (o2switch, cPanel/LiteSpeed)
+
+This guide assumes a server where you have full control (sudo, dedicated
+deploy user, `/var/www/comics` path, `www-data` web group, PHP-FPM to
+reload). On a **shared host** like o2switch (CageFS + cPanel + LiteSpeed),
+several of those assumptions don't hold. The companion skill
+`panel-page-flip-deploy` captures the working procedure; the bullets below
+are the deltas:
+
+- **Project path is `~/sites/comics/`, not `/var/www/comics/`.** Same layout
+  (`backend/`, `frontend/`, `scripts/`), just under the user's home.
+- **Web group is `nobody`, not `www-data`.** cPanel/LiteSpeed serves as the
+  `nobody` user. File ownership on prod should be `<o2switch-user>:nobody` for
+  `backend/var/` and `backend/public/`.
+- **No `sudo`, no `apt`, no PHP-FPM reload.** LiteSpeed's OPcache
+  auto-revalidates, so you don't need to reload anything after a deploy.
+  Just clear Symfony's cache (`php bin/console cache:clear && cache:warmup`).
+- **No Node on `$PATH` by default.** o2switch ships node under
+  `/opt/alt/alt-nodejs22/root/usr/bin/`; you must build the React app
+  locally (`mode A` in the skill) and rsync `frontend/dist/`. Server-side
+  builds work but need a `.bashrc` export and eat CPU/RAM.
+- **`pfl_rsync.py` (the skill's SFTP helper) opens its own SSH connection**
+  via paramiko, so it works without `ssh-agent` (which hangs in non-TTY).
+  Accepts both bare paths and `user@host:path` URIs.
+- **The `_post-deploy.php` endpoint should NOT be installed.** Use SSH
+  exclusively; the HTTP runner is one more attack surface for no benefit.
+- **The CHANGELOG of deploy issues to remember:**
+  - **Backup BEFORE pull.** The skill runbook orders backup → pull →
+    composer → migrate for a reason: backup captures the pre-deploy state
+    (old code + old uploads + old env), so rollback is meaningful. If you
+    pull first, the backup includes the new code already, defeating the
+    purpose. Don't reorder steps because the user phrases them casually.
+  - **`chown <o2switch-user>:nobody` is silently broken if you're not in the
+    `nobody` group.** Verify with `groups` first. If `nobody` isn't there,
+    `chown` fails with "Operation not permitted", and combined with the
+    runbook's `chmod o-rwx` you get 403 on every route with no log entry.
+    Fallback: `chmod -R u+rwX,g+rX,o+rX backend/public` (open webroot
+    perms). On o2switch, `<o2switch-user>` IS in `nobody`, so this is paranoia
+    but worth checking the first time on a new host.
+
+The `panel-page-flip-deploy` skill at
+`~/.openclaw/workspace/skills/panel-page-flip-deploy/SKILL.md` is the
+authoritative runbook for o2switch deploys; this section just bridges the
+generic SSH-deploy story to that reality.

--- a/deploy.md
+++ b/deploy.md
@@ -695,3 +695,49 @@ mv release-LASTGOOD release
 
 Good deploys, friend. Keep `release/` directories around until the next deploy
 succeeds — they're cheap insurance.
+
+---
+
+## 11. Real-world notes from production deploys
+
+Lessons learned the hard way, added 2026-08-06 after a panel-page-flip prod
+deploy that exposed some silent-failure modes.
+
+### Backup BEFORE pulling new code
+
+The skill `panel-page-flip-deploy` (used on SSH/o2switch deploys) orders
+backup → pull → composer → migrate → cache for a reason: backup captures
+the **true pre-deploy state** (old code + old uploads + old env), so a
+rollback is meaningful. If you pull first, the `cp -a ~/sites/comics
+~/backup/...` snapshot includes the new code already, so a rollback
+restores "new code + old uploads + old env" — not the actual pre-deploy
+state. Don't reorder steps because the user phrases them casually
+("pull, save, then deploy") — follow the runbook literally.
+
+### SSH o2switch reality vs this FTP guide
+
+This doc describes the FTP/docker build flow that works on **any**
+hosting. For the actual `yourdomain.com` prod (o2switch shared
+hosting with SSH access), the deploy is done over SSH using the
+`panel-page-flip-deploy` skill, not this FTP flow. The FTP flow is still
+useful as a fallback if SSH breaks; the SSH flow is faster, cleaner, and
+keeps secrets on the server. See `SSH-deploy.md` §13 for the SSH/o2switch
+deltas and the live runbook.
+
+### `chown user:nobody` silently breaks if the user isn't in that group
+
+On shared hosts (cPanel/LiteSpeed), webroot files should be owned by
+`user:nobody`. If the SSH user isn't in the `nobody` group, `chown`
+fails with "Operation not permitted" but doesn't error loud enough to notice.
+ Combined with `chmod o-rwx`, you end up with files that nobody ("other")
+can't read → 403 on every route, no entry in `var/log/dev.log`, only
+LiteSpeed's `error_log` shows the requests. Verify with `groups` first;
+fallback is `chmod -R u+rwX,g+rX,o+rX backend/public`.
+
+### `_post-deploy.php` was removed in 2026-07
+
+PR #51 changed the login endpoint from `/api/login_check` (GET only) to
+`POST /api/login`. The `_post-deploy.php` runner still references the old
+pattern in some error messages. If you see "login endpoint moved" type
+errors from the runner, it's a runner bug, not a server bug — your prod
+is fine.


### PR DESCRIPTION
## What

Adds real-world shared-hosting (o2switch, cPanel/LiteSpeed) deployment notes to the repo's deploy docs, plus a "lessons learned" section capturing the two regression-class mistakes from a 2026-08-06 prod deploy.

## Why

`SSH-deploy.md` and `deploy.md` both assumed a generic server with `/var/www/comics`, `www-data`, sudo, PHP-FPM reload, and Node on `$PATH`. The actual prod (o2switch shared hosting) matches **none** of those assumptions. A new reader hitting these docs without context would waste hours figuring out the path/group/no-sudo deltas — and might repeat the two mistakes.

## Changes

### `SSH-deploy.md` — new §13 Real-world notes for shared hosting (o2switch, cPanel/LiteSpeed)

- Path is `~/sites/comics/`, not `/var/www/comics/`
- Web group is `nobody`, not `www-data`
- No `sudo`, no `apt`, no PHP-FPM reload (LiteSpeed OPcache auto-revalidates)
- No Node on `$PATH` by default → build React locally and rsync `dist/`
- `pfl_rsync.py` accepts both bare paths and `user@host:path` URIs
- Don't install `_post-deploy.php` on the o2switch flow
- Captures the two setbacks (see below) for posterity

### `deploy.md` — new §11 Real-world notes from production deploys

- Same two lessons
- Notes that the **SSH flow is the live deploy** for prod (via the `panel-page-flip-deploy` skill); this FTP flow remains a fallback
- One stale-URL note about `_post-deploy.php` referencing the moved `/api/login_check` endpoint (runner-side bug, not server bug)

### The two setbacks captured

1. **Backup BEFORE pull.** The skill runbook orders backup → pull → composer → migrate → cache for a reason. If you pull first, the `cp -a` snapshot includes the new code already, so a rollback restores "new code + old uploads + old env" — not the actual pre-deploy state. Follow the runbook literally; don't reorder steps because the user phrases them casually.

2. **`chown <o2switch-user>:nobody` silently breaks if the user isn't in that group.** Combined with `chmod o-rwx`, you get 403 on every route with no entry in `var/log/dev.log`. Verify with `groups` first; fallback is `chmod -R u+rwX,g+rX,o+rX backend/public`.

## Cross-references

- Companion skill: `~/.openclaw/workspace/skills/panel-page-flip-deploy/SKILL.md` (already updated with the same lessons + a groups pre-flight check)

## Privacy / redaction

The original version of these commits contained the o2switch cPanel username and the production domain. Those have been redacted to `<o2switch-user>` and `yourdomain.com` placeholders — the docs are now safe to merge into a public repo.

## Test plan

- [x] Doc renders OK in markdown preview
- [x] Cross-references resolve (skill path is correct)
- [x] No code changes — only doc additions, safe to merge
- [x] Local commit `52cfe0a` on `docs/o2switch-real-world-notes` branch in my fork (was `dbb9515`, amended for redaction)