### PR TITLE
fix: make side-click page turns work in fullscreen

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -87,8 +87,10 @@
     @apply fixed bottom-0 left-0 right-0 bg-gradient-to-t from-background/90 to-transparent p-4 opacity-100 flex justify-between items-center;
   }
   
+  /* Sits above .fullscreen-container (z-50), which otherwise paints its opaque
+     background over these controls and swallows their clicks. */
   .reader-controls-fullscreen {
-    @apply fixed bottom-0 left-0 right-0 bg-gradient-to-t from-background/90 to-transparent p-4 opacity-0 transition-opacity duration-300 hover:opacity-100 flex justify-between items-center;
+    @apply fixed bottom-0 left-0 right-0 z-[60] bg-gradient-to-t from-background/90 to-transparent p-4 opacity-0 transition-opacity duration-300 hover:opacity-100 flex justify-between items-center;
   }
 
   .page-navigation {

--- a/frontend/src/lib/fullscreen.js
+++ b/frontend/src/lib/fullscreen.js
@@ -1,0 +1,34 @@
+// The reader's overlays - the left/right click-to-turn zones, the header and
+// the bottom controls - are siblings of the page image, not descendants of it.
+// A fullscreen element only renders its own subtree, so putting just the image
+// container fullscreen leaves every one of those overlays behind: invisible and
+// unclickable. The document element is the common ancestor of all of them, so
+// that is what the reader takes fullscreen.
+export function getFullscreenTarget(doc) {
+  return doc?.documentElement ?? null;
+}
+
+export function isFullscreenActive(doc) {
+  return Boolean(doc?.fullscreenElement);
+}
+
+// Returns the fullscreen state the caller asked for, or the unchanged current
+// state when the browser has no fullscreen API. The real state still arrives
+// via the `fullscreenchange` event; this return value is only a hint.
+export function toggleFullscreen(doc) {
+  const active = isFullscreenActive(doc);
+
+  if (active) {
+    if (typeof doc?.exitFullscreen !== "function") return true;
+    // A rejected request leaves us in the state we were already in, and the
+    // fullscreenchange event is the source of truth regardless.
+    Promise.resolve(doc.exitFullscreen()).catch(() => {});
+    return false;
+  }
+
+  const target = getFullscreenTarget(doc);
+  if (typeof target?.requestFullscreen !== "function") return false;
+
+  Promise.resolve(target.requestFullscreen()).catch(() => {});
+  return true;
+}

--- a/frontend/src/lib/fullscreen.test.js
+++ b/frontend/src/lib/fullscreen.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { getFullscreenTarget, isFullscreenActive, toggleFullscreen } from "@/lib/fullscreen";
+
+function fakeDocument({ fullscreenElement = null } = {}) {
+  const documentElement = { requestFullscreen: vi.fn(() => Promise.resolve()) };
+  return {
+    documentElement,
+    fullscreenElement,
+    exitFullscreen: vi.fn(() => Promise.resolve()),
+  };
+}
+
+describe("reader fullscreen", () => {
+  it("takes the document element fullscreen so the side navigation zones come along", () => {
+    const doc = fakeDocument();
+
+    expect(getFullscreenTarget(doc)).toBe(doc.documentElement);
+    expect(toggleFullscreen(doc)).toBe(true);
+    expect(doc.documentElement.requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(doc.exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("exits when already fullscreen", () => {
+    const doc = fakeDocument({ fullscreenElement: {} });
+
+    expect(isFullscreenActive(doc)).toBe(true);
+    expect(toggleFullscreen(doc)).toBe(false);
+    expect(doc.exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(doc.documentElement.requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("reports no change when the browser has no fullscreen API", () => {
+    expect(toggleFullscreen({ documentElement: {} })).toBe(false);
+    expect(toggleFullscreen({ documentElement: {}, fullscreenElement: {} })).toBe(true);
+    expect(isFullscreenActive(undefined)).toBe(false);
+    expect(getFullscreenTarget(undefined)).toBe(null);
+  });
+
+  it("swallows a rejected fullscreen request instead of leaving an unhandled rejection", async () => {
+    const doc = fakeDocument();
+    doc.documentElement.requestFullscreen = vi.fn(() => Promise.reject(new Error("denied")));
+
+    expect(() => toggleFullscreen(doc)).not.toThrow();
+    await Promise.resolve();
+  });
+
+  it("tolerates a fullscreen API that returns nothing instead of a promise", () => {
+    const doc = fakeDocument();
+    doc.documentElement.requestFullscreen = vi.fn(() => undefined);
+
+    expect(() => toggleFullscreen(doc)).not.toThrow();
+  });
+});

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast.js";
 import { Skeleton } from "@/components/ui/skeleton.jsx";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { toggleFullscreen } from "@/lib/fullscreen";
 
 export default function ComicReader() {
   const { comicId } = useParams();
@@ -798,13 +799,7 @@ export default function ComicReader() {
               variant="outline" 
               size="icon"
               className="opacity-80 hover:opacity-100 bg-card/80"
-              onClick={() => {
-                if (isFullscreen) {
-                  document.exitFullscreen();
-                } else if (imageContainerRef.current) {
-                  imageContainerRef.current.requestFullscreen();
-                }
-              }}
+              onClick={() => toggleFullscreen(document)}
               title="Toggle fullscreen"
             >
               <Maximize className="h-4 w-4" />


### PR DESCRIPTION
Fixes #33

## The bug

In fullscreen, clicking the left/right sides of the screen did nothing. Only the small arrow buttons overlaid on the image could turn a page.

## Root cause

Fullscreen was requested on the image container:

```js
imageContainerRef.current.requestFullscreen();
```

A fullscreen element renders **only its own subtree**. The two `.page-navigation` click zones are siblings higher up the tree, not descendants of that container — so in fullscreen they were dropped from the screen entirely. The same applied to the `Header`'s fullscreen "Back to Library" bar and the bottom `.reader-controls-fullscreen` bar, which is why the in-container arrow buttons were the only survivors.

## The fix

- New `frontend/src/lib/fullscreen.js` targets `document.documentElement`, the common ancestor of every reader overlay, so the whole reader UI comes along into fullscreen. It also guards against browsers with no fullscreen API and swallows rejected requests — the existing `fullscreenchange` listener remains the source of truth for state.
- `ComicReader.jsx`'s toggle button now calls that helper.
- `.reader-controls-fullscreen` gains `z-[60]`. It had no z-index at all, so the `z-50` `.fullscreen-container` painted its opaque background over the bottom Previous/Next bar and swallowed its clicks. The side zones already carried a `z-[55]` that had been waiting for this.

Resulting layering in fullscreen: image `z-50` → side click zones `z-55` → header and controls `z-60`.

## Verification

- `npm test` — 21 passed across 5 files, including 5 new cases in `frontend/src/lib/fullscreen.test.js`
- `npm run lint` — clean
- `npm run build` — succeeds; built CSS confirms `.z-\[55\]{z-index:55}` and `z-index:60` on `.reader-controls-fullscreen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fullscreen support for the comic reader, including entering and exiting fullscreen mode.
  * Gracefully handles browsers that do not support fullscreen functionality.

* **Bug Fixes**
  * Ensured fullscreen controls remain visible and clickable above the fullscreen reading area.

* **Tests**
  * Added coverage for entering, exiting, unsupported browsers, and failed fullscreen requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->