### PR TITLE
fix: keep comic covers and library metadata across reader visits (#57)

### DIFF
--- a/backend/config/services_test.yaml
+++ b/backend/config/services_test.yaml
@@ -1,3 +1,10 @@
+parameters:
+    # Never let the test suite share an upload tree with the running app. Tests
+    # create and delete files under these paths, and pointing them at
+    # public/uploads puts real comics within reach of a test's cleanup.
+    comics_directory: '%kernel.project_dir%/var/test-uploads/comics'
+    public_shares_directory: '%kernel.project_dir%/var/test-uploads/shared'
+
 services:
     _defaults:
         autowire: true

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use ZipArchive;
@@ -28,6 +29,21 @@ class ComicController extends AbstractController
 {
     private const FILE_ID_REGEX = '/^[A-Za-z0-9\-]{8,64}$/';
     private const ASSEMBLED_UPLOAD_FILENAME = 'assembled.cbz';
+
+    /**
+     * A stored cover filename carries a uniqid suffix, so its URL changes
+     * whenever the cover is regenerated. The bytes behind a given cover URL can
+     * therefore never change and the browser may keep them indefinitely.
+     */
+    private const COVER_CACHE_SECONDS = 31_536_000;
+
+    /**
+     * The placeholder is served from the cover URL of a comic whose file is
+     * missing, so that URL is not versioned and must stay revalidatable. A short
+     * lifetime plus a conditional request keeps repeat views cheap without
+     * pinning a "missing cover" answer in the cache for a year.
+     */
+    private const COVER_PLACEHOLDER_CACHE_SECONDS = 300;
 
     private string $tempUploadDir;
 
@@ -1277,9 +1293,47 @@ class ComicController extends AbstractController
         return array_values($normalised);
     }
 
+    /**
+     * Serve an image the browser is allowed to keep.
+     *
+     * Covers are private: they are reachable only through this authenticated
+     * endpoint, so the policy stops at the user's own browser and never lets a
+     * shared proxy hand one user's cover to another.
+     */
+    private function cacheableImageResponse(
+        string $absolutePath,
+        Request $request,
+        int $maxAge,
+        bool $immutable
+    ): BinaryFileResponse {
+        $response = new BinaryFileResponse($absolutePath);
+        $response->setAutoLastModified();
+        $response->setAutoEtag();
+        $response->setPrivate();
+        $response->setMaxAge($maxAge);
+        if ($immutable) {
+            $response->setImmutable();
+        }
+
+        // Symfony disables caching on every response whose request touched the
+        // session, which is every authenticated request. Opting out is what
+        // lets the policy above reach the browser at all.
+        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 'true');
+
+        // Turns a revalidation into an empty 304 instead of resending the file.
+        $response->isNotModified($request);
+
+        return $response;
+    }
+
     #[Route('/cover/{userId}/{comicId}/{filename}', name: 'cover_image', methods: ['GET'])]
-    public function getCoverImage(int $userId, int $comicId, string $filename, EntityManagerInterface $entityManager): Response
-    {
+    public function getCoverImage(
+        int $userId,
+        int $comicId,
+        string $filename,
+        Request $request,
+        EntityManagerInterface $entityManager
+    ): Response {
         /** @var \App\Entity\User|null $currentUser */
         $currentUser = $this->getUser();
         if (!$currentUser) {
@@ -1321,15 +1375,20 @@ class ComicController extends AbstractController
             $this->logger->warning('Cover file not found or unreadable.', ['comic_id' => $comicId, 'user_id' => $userId]);
             $placeholderPath = $this->getParameter('kernel.project_dir') . '/public/comic.png';
             if (is_readable($placeholderPath)) {
-                return new BinaryFileResponse($placeholderPath);
+                return $this->cacheableImageResponse(
+                    $placeholderPath,
+                    $request,
+                    self::COVER_PLACEHOLDER_CACHE_SECONDS,
+                    false
+                );
             }
 
             return $this->json(['message' => 'Cover image file not found on server.'], Response::HTTP_NOT_FOUND);
         }
 
-        // Use BinaryFileResponse to serve the image
-        // This handles Content-Type, Content-Length, and other necessary headers.
-        // It also supports range requests if the client asks for partial content.
-        return new BinaryFileResponse($absolutePath);
+        // BinaryFileResponse handles Content-Type, Content-Length and range
+        // requests; the helper adds the caching policy on top so returning to
+        // the library re-displays covers from the browser cache.
+        return $this->cacheableImageResponse($absolutePath, $request, self::COVER_CACHE_SECONDS, true);
     }
 }

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -45,6 +45,15 @@ class ComicController extends AbstractController
      */
     private const COVER_PLACEHOLDER_CACHE_SECONDS = 300;
 
+    /**
+     * A page URL carries no version, and nothing in the app replaces a comic's
+     * archive in place, so the bytes behind one are stable in practice. A day is
+     * long enough to cover a reading session and a return to it, short enough
+     * that an archive swapped by hand is not served stale for a week. The ETag
+     * makes the revalidation after that a cheap 304.
+     */
+    private const PAGE_CACHE_SECONDS = 86_400;
+
     private string $tempUploadDir;
 
     public function __construct(
@@ -931,7 +940,7 @@ class ComicController extends AbstractController
     }
     
     #[Route('/{id}/pages/{page}', name: 'get_page', methods: ['GET'])]
-    public function getPage(int $id, int $page, EntityManagerInterface $entityManager): Response
+    public function getPage(int $id, int $page, Request $request, EntityManagerInterface $entityManager): Response
     {
         // Get the current user
         $user = $this->getUser();
@@ -982,6 +991,24 @@ class ComicController extends AbstractController
             $filePath = $legacyPath;
         }
 
+        // Validators taken from the archive rather than the extracted page, so a
+        // revalidation can be answered without opening the CBZ at all. Reading a
+        // comic is the app's hot path and every page used to be re-downloaded.
+        $response = new Response();
+        $response->setPrivate();
+        $response->setMaxAge(self::PAGE_CACHE_SECONDS);
+        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 'true');
+
+        $modifiedAt = @filemtime($filePath);
+        if ($modifiedAt !== false) {
+            $response->setLastModified(new \DateTimeImmutable('@' . $modifiedAt));
+            $response->setEtag(hash('sha256', $filePath . '|' . $modifiedAt . '|' . @filesize($filePath) . '|' . $page));
+
+            if ($response->isNotModified($request)) {
+                return $response;
+            }
+        }
+
         // Open CBZ file
         $zip = new ZipArchive();
         if ($zip->open($filePath) !== true) {
@@ -1015,8 +1042,9 @@ class ComicController extends AbstractController
             return $this->json(['message' => 'Failed to extract page image'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
-        // Return image
-        $response = new Response($pageImage);
+        // Return image, keeping the caching policy set up before the archive was
+        // opened.
+        $response->setContent($pageImage);
         $extension = strtolower(pathinfo($imageFiles[$page - 1], PATHINFO_EXTENSION));
         $mimeType = $this->getMimeTypeForExtension($extension);
         $response->headers->set('Content-Type', $mimeType);

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -1327,6 +1327,11 @@ class ComicController extends AbstractController
      * Covers are private: they are reachable only through this authenticated
      * endpoint, so the policy stops at the user's own browser and never lets a
      * shared proxy hand one user's cover to another.
+     *
+     * Within that one browser the entry is still keyed by the session cookie,
+     * so an admin who signs out and another account signs in cannot be served
+     * the previous account's cover from cache. The session cookie is the only
+     * credential this endpoint authenticates with, so it is the whole of Vary.
      */
     private function cacheableImageResponse(
         string $absolutePath,
@@ -1339,6 +1344,7 @@ class ComicController extends AbstractController
         $response->setAutoEtag();
         $response->setPrivate();
         $response->setMaxAge($maxAge);
+        $response->setVary('Cookie');
         if ($immutable) {
             $response->setImmutable();
         }

--- a/backend/src/Repository/ComicRepository.php
+++ b/backend/src/Repository/ComicRepository.php
@@ -20,4 +20,32 @@ class ComicRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, Comic::class);
     }
+
+    /**
+     * Hydrate the tag and owner associations of an already-loaded comic list in
+     * one query. Serializing a library otherwise lazy-loads each comic's tag
+     * collection and owner separately, which costs a query per comic and is the
+     * bulk of the delay before the library can render.
+     *
+     * The comics are loaded again rather than fetch-joined into the caller's
+     * query on purpose: the list endpoint groups and filters on the same tag
+     * join, and adding a fetch join there would collide with its GROUP BY.
+     *
+     * @param list<Comic> $comics
+     */
+    public function preloadAssociations(array $comics): void
+    {
+        if ($comics === []) {
+            return;
+        }
+
+        $this->createQueryBuilder('c')
+            ->addSelect('t', 'o')
+            ->leftJoin('c.tags', 't')
+            ->leftJoin('c.owner', 'o')
+            ->andWhere('c IN (:comics)')
+            ->setParameter('comics', $comics)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/backend/src/Service/ComicSerializer.php
+++ b/backend/src/Service/ComicSerializer.php
@@ -6,6 +6,7 @@ use App\Entity\Comic;
 use App\Entity\ComicReadingProgress;
 use App\Entity\User;
 use App\Repository\ComicReadingProgressRepository;
+use App\Repository\ComicRepository;
 
 /**
  * Single source of truth for the shape of a comic in API responses.
@@ -17,7 +18,8 @@ use App\Repository\ComicReadingProgressRepository;
 class ComicSerializer
 {
     public function __construct(
-        private readonly ComicReadingProgressRepository $progressRepository
+        private readonly ComicReadingProgressRepository $progressRepository,
+        private readonly ComicRepository $comicRepository
     ) {
     }
 
@@ -27,6 +29,10 @@ class ComicSerializer
      */
     public function serializeMany(array $comics, User $viewer, bool $includeOwner = false): array
     {
+        // Both calls are batched on purpose: a library page reads every comic's
+        // tags, owner and progress, and doing that per comic is what makes the
+        // list endpoint slow enough to be visible.
+        $this->comicRepository->preloadAssociations($comics);
         $progressByComicId = $this->progressRepository->findByUserIndexedByComic($viewer, $comics);
 
         $serialized = [];

--- a/backend/tests/Functional/Controller/ComicCoverSecurityTest.php
+++ b/backend/tests/Functional/Controller/ComicCoverSecurityTest.php
@@ -9,7 +9,7 @@ use App\Tests\Functional\AbstractApiTestCase;
 final class ComicCoverSecurityTest extends AbstractApiTestCase
 {
     /** @var list<string> */
-    private array $temporaryCoverDirectories = [];
+    private array $temporaryCoverFiles = [];
 
     public function testOwnerReceivesPlaceholderWhenStoredCoverIsMissing(): void
     {
@@ -170,31 +170,22 @@ final class ComicCoverSecurityTest extends AbstractApiTestCase
         file_put_contents($directory . '/' . $filename, base64_decode(
             'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
         ));
-        $this->temporaryCoverDirectories[] = self::getContainer()->getParameter('comics_directory')
-            . '/' . $owner->getId();
+        // Track the file, never its directory: cleanup must not be able to reach
+        // anything this test did not put there.
+        $this->temporaryCoverFiles[] = $directory . '/' . $filename;
 
         return [$owner, sprintf('/api/comics/cover/%d/%d/%s', $owner->getId(), $comic->getId(), $filename)];
     }
 
     protected function tearDown(): void
     {
-        foreach ($this->temporaryCoverDirectories as $directory) {
-            $this->removeDirectory($directory);
+        foreach ($this->temporaryCoverFiles as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
         }
-        $this->temporaryCoverDirectories = [];
+        $this->temporaryCoverFiles = [];
 
         parent::tearDown();
-    }
-
-    private function removeDirectory(string $directory): void
-    {
-        if (!is_dir($directory)) {
-            return;
-        }
-
-        foreach (glob($directory . '/*') ?: [] as $path) {
-            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
-        }
-        rmdir($directory);
     }
 }

--- a/backend/tests/Functional/Controller/ComicCoverSecurityTest.php
+++ b/backend/tests/Functional/Controller/ComicCoverSecurityTest.php
@@ -74,6 +74,26 @@ final class ComicCoverSecurityTest extends AbstractApiTestCase
         self::assertNotNull($headers->get('last-modified'));
     }
 
+    public function testCachedCoversAreKeyedByTheSessionCookie(): void
+    {
+        [$owner, $url] = $this->createComicWithCoverFile();
+        $this->loginAs($owner);
+
+        $this->browser()->request('GET', $url);
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Cookie', (string) $this->browser()->getResponse()->headers->get('vary'));
+
+        // The same URL under a different account. An admin is the only other
+        // account allowed to read it, and a cache entry that ignored the cookie
+        // would be the one holding the previous session's copy.
+        $this->loginAs(UserFactory::new()->admin()->create()->object());
+        $this->browser()->request('GET', $url);
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Cookie', (string) $this->browser()->getResponse()->headers->get('vary'));
+    }
+
     public function testMatchingEtagReturnsNotModified(): void
     {
         [$owner, $url] = $this->createComicWithCoverFile();

--- a/backend/tests/Functional/Controller/ComicCoverSecurityTest.php
+++ b/backend/tests/Functional/Controller/ComicCoverSecurityTest.php
@@ -8,6 +8,9 @@ use App\Tests\Functional\AbstractApiTestCase;
 
 final class ComicCoverSecurityTest extends AbstractApiTestCase
 {
+    /** @var list<string> */
+    private array $temporaryCoverDirectories = [];
+
     public function testOwnerReceivesPlaceholderWhenStoredCoverIsMissing(): void
     {
         $owner = UserFactory::createOne()->object();
@@ -49,5 +52,149 @@ final class ComicCoverSecurityTest extends AbstractApiTestCase
         $this->browser()->request('GET', sprintf('/api/comics/cover/%d/%d/cover.png', $owner->getId(), $comic->getId()));
 
         self::assertResponseIsSuccessful();
+    }
+
+    public function testStoredCoverIsCachedImmutablyByTheOwnersBrowser(): void
+    {
+        [$owner, $url] = $this->createComicWithCoverFile();
+        $this->loginAs($owner);
+
+        $this->browser()->request('GET', $url);
+
+        self::assertResponseIsSuccessful();
+        $headers = $this->browser()->getResponse()->headers;
+        $cacheControl = (string) $headers->get('cache-control');
+        // Private, because the cover is only reachable through an authenticated
+        // endpoint and must never be held by a shared cache.
+        self::assertStringContainsString('private', $cacheControl);
+        self::assertStringContainsString('max-age=31536000', $cacheControl);
+        self::assertStringContainsString('immutable', $cacheControl);
+        self::assertStringNotContainsString('no-cache', $cacheControl);
+        self::assertNotNull($headers->get('etag'));
+        self::assertNotNull($headers->get('last-modified'));
+    }
+
+    public function testMatchingEtagReturnsNotModified(): void
+    {
+        [$owner, $url] = $this->createComicWithCoverFile();
+        $this->loginAs($owner);
+
+        $this->browser()->request('GET', $url);
+        $etag = $this->browser()->getResponse()->headers->get('etag');
+        self::assertNotNull($etag);
+
+        $this->browser()->request('GET', $url, [], [], ['HTTP_IF_NONE_MATCH' => $etag]);
+
+        self::assertResponseStatusCodeSame(304);
+        // A 304 must carry no body: the point is that the cover is not resent.
+        self::assertFalse($this->browser()->getResponse()->headers->has('content-length'));
+    }
+
+    public function testUnmodifiedSinceReturnsNotModified(): void
+    {
+        [$owner, $url] = $this->createComicWithCoverFile();
+        $this->loginAs($owner);
+
+        $this->browser()->request('GET', $url);
+        $lastModified = $this->browser()->getResponse()->headers->get('last-modified');
+        self::assertNotNull($lastModified);
+
+        $this->browser()->request('GET', $url, [], [], ['HTTP_IF_MODIFIED_SINCE' => $lastModified]);
+
+        self::assertResponseStatusCodeSame(304);
+    }
+
+    public function testPlaceholderIsCacheableButStaysRevalidatable(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::createOne([
+            'owner' => $owner,
+            'coverImagePath' => 'covers/missing/cover.png',
+        ])->object();
+        $this->loginAs($owner);
+        $url = sprintf('/api/comics/cover/%d/%d/cover.png', $owner->getId(), $comic->getId());
+
+        $this->browser()->request('GET', $url);
+
+        self::assertResponseIsSuccessful();
+        $headers = $this->browser()->getResponse()->headers;
+        $cacheControl = (string) $headers->get('cache-control');
+        self::assertStringContainsString('private', $cacheControl);
+        self::assertStringContainsString('max-age=300', $cacheControl);
+        // The placeholder answers an un-versioned URL: a comic that regains its
+        // cover file must not be stuck behind a year-long immutable entry.
+        self::assertStringNotContainsString('immutable', $cacheControl);
+        self::assertNotNull($headers->get('etag'));
+
+        $etag = $headers->get('etag');
+        $this->browser()->request('GET', $url, [], [], ['HTTP_IF_NONE_MATCH' => $etag]);
+
+        self::assertResponseStatusCodeSame(304);
+    }
+
+    public function testCoverFilenameMustMatchTheStoredCover(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::createOne([
+            'owner' => $owner,
+            'coverImagePath' => 'covers/missing/cover.png',
+        ])->object();
+        $this->loginAs($owner);
+
+        $this->browser()->request('GET', sprintf('/api/comics/cover/%d/%d/other.png', $owner->getId(), $comic->getId()));
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * Write a real cover file where the controller expects to find it, so the
+     * conditional-request assertions run against genuine file metadata.
+     *
+     * @return array{0: \App\Entity\User, 1: string}
+     */
+    private function createComicWithCoverFile(): array
+    {
+        $owner = UserFactory::createOne()->object();
+        $filename = 'cover-' . uniqid('', false) . '.png';
+        $comic = ComicFactory::createOne([
+            'owner' => $owner,
+            'coverImagePath' => 'covers/stored/' . $filename,
+        ])->object();
+
+        $directory = self::getContainer()->getParameter('comics_directory')
+            . '/' . $owner->getId() . '/covers/stored';
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            self::fail('Could not create the test cover directory.');
+        }
+        // A one-pixel PNG: the bytes only need to be a real, stable file.
+        file_put_contents($directory . '/' . $filename, base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        ));
+        $this->temporaryCoverDirectories[] = self::getContainer()->getParameter('comics_directory')
+            . '/' . $owner->getId();
+
+        return [$owner, sprintf('/api/comics/cover/%d/%d/%s', $owner->getId(), $comic->getId(), $filename)];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryCoverDirectories as $directory) {
+            $this->removeDirectory($directory);
+        }
+        $this->temporaryCoverDirectories = [];
+
+        parent::tearDown();
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory . '/*') ?: [] as $path) {
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($directory);
     }
 }

--- a/backend/tests/Functional/Controller/ComicLibraryQueryTest.php
+++ b/backend/tests/Functional/Controller/ComicLibraryQueryTest.php
@@ -62,6 +62,35 @@ final class ComicLibraryQueryTest extends AbstractApiTestCase
     }
 
     /**
+     * The admin view is the only one that serialises an owner, so it is the only
+     * place the owner preload can be shown to work. Comics are spread one per
+     * owner and the library then grown, so an un-batched owner lookup shows up
+     * as queries that scale with the number of owners on screen.
+     */
+    public function testTheAdminLibraryDoesNotQueryPerOwner(): void
+    {
+        $this->seedLibraryAcrossNewOwners(2);
+        $this->loginAs(UserFactory::new()->admin()->create()->object());
+
+        $this->getJson('/api/comics?adminContext=true');
+        self::assertResponseIsSuccessful();
+        $fewOwnersQueries = $this->executedQueryCount();
+
+        $this->seedLibraryAcrossNewOwners(4);
+        $payload = $this->getJson('/api/comics?adminContext=true');
+        self::assertResponseIsSuccessful();
+        $manyOwnersQueries = $this->executedQueryCount();
+
+        self::assertCount(6, $payload['comics']);
+        self::assertNotNull($payload['comics'][0]['owner']['email']);
+        self::assertSame(
+            $fewOwnersQueries,
+            $manyOwnersQueries,
+            'Listing the admin library runs one query per owner; Comic::owner is no longer preloaded.'
+        );
+    }
+
+    /**
      * Doctrine's debug data holder records every statement the profiler would
      * display, and is reset for each request the test client sends. Reading it
      * straight after a request therefore counts that request alone.
@@ -71,6 +100,13 @@ final class ComicLibraryQueryTest extends AbstractApiTestCase
         $holder = self::getContainer()->get('doctrine.debug_data_holder');
 
         return array_sum(array_map('count', $holder->getData()));
+    }
+
+    private function seedLibraryAcrossNewOwners(int $ownerCount): void
+    {
+        for ($index = 0; $index < $ownerCount; $index++) {
+            $this->seedLibrary(UserFactory::createOne()->object(), 1);
+        }
     }
 
     private function seedLibrary(User $user, int $comicCount): void

--- a/backend/tests/Functional/Controller/ComicLibraryQueryTest.php
+++ b/backend/tests/Functional/Controller/ComicLibraryQueryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\ComicReadingProgress;
+use App\Entity\User;
+use App\Tests\Factory\ComicFactory;
+use App\Tests\Factory\TagFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\Functional\AbstractApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * The library endpoint feeds every card the dashboard draws, so the number of
+ * queries it runs has to stay independent of how many comics a user owns.
+ */
+final class ComicLibraryQueryTest extends AbstractApiTestCase
+{
+    public function testTheLibraryEndpointReturnsTagsAndReadingProgress(): void
+    {
+        $user = UserFactory::createOne()->object();
+        $this->seedLibrary($user, 1);
+        $this->loginAs($user);
+
+        $payload = $this->getJson('/api/comics');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $payload['comics']);
+        $comic = $payload['comics'][0];
+        self::assertSame(['Serialized'], array_column($comic['tags'], 'name'));
+        self::assertSame(3, $comic['readingProgress']['currentPage']);
+        self::assertNotNull($comic['coverImagePath']);
+    }
+
+    /**
+     * A library three times the size must not cost three times the queries. The
+     * two users are compared against each other rather than against a hard
+     * number so the assertion survives unrelated changes to the endpoint.
+     */
+    public function testTheLibraryEndpointDoesNotQueryPerComic(): void
+    {
+        $smallLibraryUser = UserFactory::createOne()->object();
+        $this->seedLibrary($smallLibraryUser, 2);
+        $largeLibraryUser = UserFactory::createOne()->object();
+        $this->seedLibrary($largeLibraryUser, 6);
+
+        $this->loginAs($smallLibraryUser);
+        $this->getJson('/api/comics');
+        self::assertResponseIsSuccessful();
+        $smallLibraryQueries = $this->executedQueryCount();
+
+        $this->loginAs($largeLibraryUser);
+        $this->getJson('/api/comics');
+        self::assertResponseIsSuccessful();
+        $largeLibraryQueries = $this->executedQueryCount();
+
+        self::assertSame(
+            $smallLibraryQueries,
+            $largeLibraryQueries,
+            'Listing the library runs one query per comic; the tag, owner or reading-progress lookup has been un-batched.'
+        );
+    }
+
+    /**
+     * Doctrine's debug data holder records every statement the profiler would
+     * display, and is reset for each request the test client sends. Reading it
+     * straight after a request therefore counts that request alone.
+     */
+    private function executedQueryCount(): int
+    {
+        $holder = self::getContainer()->get('doctrine.debug_data_holder');
+
+        return array_sum(array_map('count', $holder->getData()));
+    }
+
+    private function seedLibrary(User $user, int $comicCount): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $tag = TagFactory::createOne(['name' => 'Serialized', 'creator' => $user])->object();
+
+        for ($index = 0; $index < $comicCount; $index++) {
+            $comic = ComicFactory::createOne([
+                'owner' => $user,
+                'coverImagePath' => 'covers/1/cover-' . $index . '.png',
+            ])->object();
+            $comic->addTag($tag);
+
+            $progress = (new ComicReadingProgress())
+                ->setUser($user)
+                ->setComic($comic)
+                ->setCurrentPage(3);
+            $entityManager->persist($progress);
+        }
+
+        $entityManager->flush();
+        // Serializing must go back to the database for the associations, exactly
+        // as it does on a real request.
+        $entityManager->clear();
+    }
+}

--- a/backend/tests/Functional/Controller/ComicPageCachingTest.php
+++ b/backend/tests/Functional/Controller/ComicPageCachingTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\User;
+use App\Tests\Factory\ComicFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\Functional\AbstractApiTestCase;
+
+/**
+ * Reading a comic is the hot path: every page turn fetches a full-size image.
+ * Those responses have to be cacheable, or turning back a page costs another
+ * download of something the browser already had.
+ */
+final class ComicPageCachingTest extends AbstractApiTestCase
+{
+    /** @var list<string> */
+    private array $temporaryFiles = [];
+
+    public function testPageResponseIsCacheableAndValidated(): void
+    {
+        [$owner, $comic] = $this->createComicWithArchive();
+        $this->loginAs($owner);
+
+        $this->browser()->request('GET', sprintf('/api/comics/%d/pages/1', $comic->getId()));
+
+        self::assertResponseIsSuccessful();
+        $headers = $this->browser()->getResponse()->headers;
+        self::assertSame('image/jpeg', $headers->get('content-type'));
+        $cacheControl = (string) $headers->get('cache-control');
+        self::assertStringContainsString('private', $cacheControl);
+        self::assertStringContainsString('max-age=86400', $cacheControl);
+        self::assertStringNotContainsString('no-cache', $cacheControl);
+        self::assertNotNull($headers->get('etag'));
+        self::assertNotNull($headers->get('last-modified'));
+    }
+
+    public function testMatchingEtagReturnsNotModified(): void
+    {
+        [$owner, $comic] = $this->createComicWithArchive();
+        $this->loginAs($owner);
+        $url = sprintf('/api/comics/%d/pages/1', $comic->getId());
+
+        $this->browser()->request('GET', $url);
+        $etag = $this->browser()->getResponse()->headers->get('etag');
+        self::assertNotNull($etag);
+
+        $this->browser()->request('GET', $url, [], [], ['HTTP_IF_NONE_MATCH' => $etag]);
+
+        self::assertResponseStatusCodeSame(304);
+    }
+
+    /**
+     * Two pages of the same comic must not share a validator, or the browser
+     * would answer page 2 with the bytes it cached for page 1.
+     */
+    public function testEachPageHasItsOwnValidator(): void
+    {
+        [$owner, $comic] = $this->createComicWithArchive();
+        $this->loginAs($owner);
+
+        $this->browser()->request('GET', sprintf('/api/comics/%d/pages/1', $comic->getId()));
+        $firstEtag = $this->browser()->getResponse()->headers->get('etag');
+
+        $this->browser()->request('GET', sprintf('/api/comics/%d/pages/2', $comic->getId()));
+        $secondEtag = $this->browser()->getResponse()->headers->get('etag');
+
+        self::assertNotSame($firstEtag, $secondEtag);
+
+        // The first page's validator must not satisfy a request for the second.
+        $this->browser()->request(
+            'GET',
+            sprintf('/api/comics/%d/pages/2', $comic->getId()),
+            [],
+            [],
+            ['HTTP_IF_NONE_MATCH' => $firstEtag]
+        );
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testAnotherUserCannotReadAPage(): void
+    {
+        [, $comic] = $this->createComicWithArchive();
+        $this->loginAs(UserFactory::createOne()->object());
+
+        $this->browser()->request('GET', sprintf('/api/comics/%d/pages/1', $comic->getId()));
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @return array{0: User, 1: \App\Entity\Comic}
+     */
+    private function createComicWithArchive(): array
+    {
+        $owner = UserFactory::createOne()->object();
+        $filename = 'pages-' . uniqid('', false) . '.cbz';
+        $comic = ComicFactory::createOne([
+            'owner' => $owner,
+            'filePath' => $filename,
+            'pageCount' => 2,
+        ])->object();
+
+        $directory = self::getContainer()->getParameter('comics_directory') . '/' . $owner->getId();
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            self::fail('Could not create the test comic directory.');
+        }
+        // Track the archive, never the directory: cleanup must not be able to
+        // reach anything this test did not put there.
+        $this->temporaryFiles[] = $directory . '/' . $filename;
+
+        // Two distinguishable one-pixel JPEGs, so the per-page validators differ
+        // for a real reason rather than by accident.
+        $zip = new \ZipArchive();
+        if ($zip->open($directory . '/' . $filename, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {
+            self::fail('Could not create the test CBZ.');
+        }
+        $zip->addFromString('page-01.jpg', $this->onePixelJpeg());
+        $zip->addFromString('page-02.jpg', $this->onePixelJpeg() . "\x00");
+        $zip->close();
+
+        return [$owner, $comic];
+    }
+
+    private function onePixelJpeg(): string
+    {
+        return base64_decode(
+            '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a'
+            . 'HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAHwAAAQUBAQEB'
+            . 'AQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1Fh'
+            . 'ByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZ'
+            . 'WmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXG'
+            . 'x8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/AP/Z'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->temporaryFiles = [];
+
+        parent::tearDown();
+    }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import { Header } from "@/components/Header.jsx";
 import { CookieNotice } from "@/components/CookieNotice.jsx";
 import { AuthProvider, useAuth } from "./hooks/use-auth.jsx";
 import { TagProvider } from "./hooks/use-tags.jsx";
+import { ComicLibraryProvider } from "./hooks/use-comic-library.jsx";
 
 const Landing = lazy(() => import("./pages/Landing.jsx"));
 const Login = lazy(() => import("./pages/Login.jsx"));
@@ -112,12 +113,16 @@ const App = () => {
       <ThemeProvider defaultTheme="light">
         <AuthProvider>
           <TagProvider>
-            <TooltipProvider>
-              <Toaster />
-              <Sonner />
-              <SessionMonitor />
-              <AppRoutes />
-            </TooltipProvider>
+            {/* Outside the router so the library survives navigating into a
+                comic and back, instead of being refetched from empty. */}
+            <ComicLibraryProvider>
+              <TooltipProvider>
+                <Toaster />
+                <Sonner />
+                <SessionMonitor />
+                <AppRoutes />
+              </TooltipProvider>
+            </ComicLibraryProvider>
           </TagProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/frontend/src/components/ComicCard.jsx
+++ b/frontend/src/components/ComicCard.jsx
@@ -9,11 +9,16 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { useState } from "react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast.js";
+import { cn } from "@/lib/utils";
 
-export function ComicCard({ comic, onResetProgress, onEditComic, onDeleteComic, onShareClick }) {
+export function ComicCard({ comic, coverPriority = false, onResetProgress, onEditComic, onDeleteComic, onShareClick }) {
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isOrphaned, setIsOrphaned] = useState(false);
+  // A cover served from the browser cache decodes in the same frame, so this
+  // only ever fades in a genuine first load rather than every revisit. A comic
+  // with no cover has nothing to wait for.
+  const [coverLoaded, setCoverLoaded] = useState(!comic.coverImagePath);
   const { toast } = useToast();
 
   const handleResetClick = (e) => {
@@ -75,10 +80,22 @@ export function ComicCard({ comic, onResetProgress, onEditComic, onDeleteComic, 
         <Link to={`/read/${comic.id}`} className="block group">
         <Card className="overflow-hidden transition-all duration-300 hover:shadow-lg border-2 hover:border-comic-purple">
           <div className="relative pt-[140%] bg-muted overflow-hidden">
-            <img 
-              src={comic.coverImagePath} 
-              alt={comic.title} 
-              className="absolute inset-0 w-full h-full object-cover transition-transform group-hover:scale-105"
+            <img
+              src={comic.coverImagePath}
+              alt={comic.title}
+              decoding="async"
+              loading={coverPriority ? "eager" : "lazy"}
+              fetchpriority={coverPriority ? "high" : "auto"}
+              onLoad={() => setCoverLoaded(true)}
+              // A cover that fails still has to reveal its alt text.
+              onError={() => setCoverLoaded(true)}
+              // One transition property covering both: separate transition-*
+              // classes would be merged down to whichever came last.
+              className={cn(
+                "absolute inset-0 w-full h-full object-cover",
+                "transition-[transform,opacity] duration-150 group-hover:scale-105",
+                coverLoaded ? "opacity-100" : "opacity-0"
+              )}
             />
             {comic.lastReadPage !== undefined && (
               <div className="absolute bottom-0 left-0 right-0 bg-black/70 text-white p-2 text-xs flex justify-between items-center">

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -120,7 +120,11 @@ export function SearchBar({ onSearch, isSearching = false }) {
             ref={searchInputRef}
             type="search"
             placeholder="Search comics by title, author..."
-            className="pl-10 pr-10"
+            // Chrome and Edge draw their own clear cross inside a search field
+            // on hover and focus, which lands next to the button below and
+            // reads as two crosses. Ours is the one to keep: the native cross
+            // only empties the text, leaving the selected tags filtering.
+            className="pl-10 pr-10 [&::-webkit-search-cancel-button]:hidden"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             onFocus={() => setIsSearchFocused(true)}

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -1,5 +1,5 @@
 
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { TagBadge } from "@/components/TagBadge";
@@ -8,9 +8,12 @@ import { Search, X, Tag as TagIcon } from "lucide-react";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import { fuzzyFilter } from "@/lib/fuzzy-search";
+import { isTypingTarget } from "@/lib/keyboard";
 
 export function SearchBar({ onSearch, isSearching = false }) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const searchInputRef = useRef(null);
   const [selectedTags, setSelectedTags] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
   const [isLoadingTags, setIsLoadingTags] = useState(true);
@@ -57,7 +60,34 @@ export function SearchBar({ onSearch, isSearching = false }) {
 
     fetchTags();
   }, [retryCount]);
-  
+
+  // "/" jumps to the search box, Ctrl/Cmd+K too.
+  useEffect(() => {
+    const handleShortcut = (event) => {
+      if (typeof event.key !== "string") return;
+
+      const isSlash = event.key === "/" && !event.ctrlKey && !event.metaKey && !event.altKey;
+      const isCommandK = event.key.toLowerCase() === "k" && (event.ctrlKey || event.metaKey);
+      if (!isSlash && !isCommandK) return;
+
+      // A dialog traps focus deliberately; pulling it out to a box behind the
+      // dialog would be worse than ignoring the shortcut.
+      if (event.target?.closest?.('[role="dialog"]')) return;
+
+      // "/" is a character someone may be trying to type. The explicit chord is
+      // never ambiguous, so it keeps working from inside a field.
+      if (isSlash && isTypingTarget(event.target)) return;
+
+      event.preventDefault();
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    };
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, []);
+
+
   const handleSearch = (e) => {
     e.preventDefault();
     onSearch({
@@ -86,13 +116,23 @@ export function SearchBar({ onSearch, isSearching = false }) {
       <form onSubmit={handleSearch} className="flex items-center gap-2">
         <div className="relative flex-1">
           <Search className="absolute left-2.5 top-2.5 h-5 w-5 text-muted-foreground" />
-          <Input 
+          <Input
+            ref={searchInputRef}
             type="search"
             placeholder="Search comics by title, author..."
             className="pl-10 pr-10"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
+            onFocus={() => setIsSearchFocused(true)}
+            onBlur={() => setIsSearchFocused(false)}
+            aria-keyshortcuts="/"
           />
+          {/* Only shown when the clear button is not, so the two never collide */}
+          {!isSearchFocused && !searchQuery && selectedTags.length === 0 && (
+            <kbd className="pointer-events-none absolute right-3 top-1/2 hidden -translate-y-1/2 rounded border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground sm:inline-block">
+              /
+            </kbd>
+          )}
           {(searchQuery || selectedTags.length > 0) && (
             <button 
               type="button" 

--- a/frontend/src/hooks/use-comic-library.jsx
+++ b/frontend/src/hooks/use-comic-library.jsx
@@ -6,6 +6,7 @@ import { logger } from '@/lib/logger';
 import { fuzzyFilter } from '@/lib/fuzzy-search';
 import {
   applyProgressUpdate,
+  createMutationLog,
   libraryRequestKey,
   normaliseComics,
   removeComics,
@@ -44,6 +45,12 @@ export function ComicLibraryProvider({ children }) {
   // the current one. Every load also takes a number, and only the latest number
   // is allowed to write.
   const requestIdRef = useRef(0);
+  // Deletions and saved reading positions that happened while a fetch was out.
+  // The response predates them, so they are replayed over it.
+  const mutationLogRef = useRef(null);
+  if (mutationLogRef.current === null) {
+    mutationLogRef.current = createMutationLog();
+  }
 
   const storeComics = useCallback((nextComics) => {
     comicsRef.current = nextComics;
@@ -52,6 +59,7 @@ export function ComicLibraryProvider({ children }) {
 
   const resetLibrary = useCallback(() => {
     requestIdRef.current += 1;
+    mutationLogRef.current.reset();
     activeKeyRef.current = null;
     displayedKeyRef.current = null;
     storeComics([]);
@@ -78,6 +86,7 @@ export function ComicLibraryProvider({ children }) {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
     const isCurrent = () => activeKeyRef.current === key && requestIdRef.current === requestId;
+    const mutationMark = mutationLogRef.current.beginLoad();
 
     if (showsThisList) {
       setIsRefreshing(true);
@@ -92,7 +101,13 @@ export function ComicLibraryProvider({ children }) {
         return comicsRef.current;
       }
 
-      const fetched = fuzzyFilter(normaliseComics(data.comics), fuzzyQuery, FUZZY_FIELDS);
+      // Over the response, not under it: a comic deleted while this was in
+      // flight must not come back, and a page saved in the reader must not be
+      // rewound to whatever the server knew when it answered.
+      const fetched = mutationLogRef.current.rebase(
+        fuzzyFilter(normaliseComics(data.comics), fuzzyQuery, FUZZY_FIELDS),
+        mutationMark
+      );
       displayedKeyRef.current = key;
       storeComics(fetched);
       return fetched;
@@ -121,6 +136,7 @@ export function ComicLibraryProvider({ children }) {
 
       return comicsRef.current;
     } finally {
+      mutationLogRef.current.endLoad();
       if (isCurrent()) {
         setIsLoading(false);
         setIsRefreshing(false);
@@ -133,14 +149,20 @@ export function ComicLibraryProvider({ children }) {
    * library shows the new page immediately instead of after a round trip.
    */
   const updateComicProgress = useCallback((comicId, progress) => {
-    const next = applyProgressUpdate(comicsRef.current, comicId, progress);
+    const mutate = (comics) => applyProgressUpdate(comics, comicId, progress);
+    mutationLogRef.current.record(mutate);
+
+    const next = mutate(comicsRef.current);
     if (next !== comicsRef.current) {
       storeComics(next);
     }
   }, [storeComics]);
 
   const removeComicsFromLibrary = useCallback((comicIds) => {
-    const next = removeComics(comicsRef.current, comicIds);
+    const mutate = (comics) => removeComics(comics, comicIds);
+    mutationLogRef.current.record(mutate);
+
+    const next = mutate(comicsRef.current);
     if (next !== comicsRef.current) {
       storeComics(next);
     }

--- a/frontend/src/hooks/use-comic-library.jsx
+++ b/frontend/src/hooks/use-comic-library.jsx
@@ -39,6 +39,11 @@ export function ComicLibraryProvider({ children }) {
   // They differ while a load is in flight.
   const activeKeyRef = useRef(null);
   const displayedKeyRef = useRef(null);
+  // Two loads can share a key — the dashboard asks for '/api/comics' again after
+  // an upload or a delete — so the key alone cannot tell a stale response from
+  // the current one. Every load also takes a number, and only the latest number
+  // is allowed to write.
+  const requestIdRef = useRef(0);
 
   const storeComics = useCallback((nextComics) => {
     comicsRef.current = nextComics;
@@ -46,6 +51,7 @@ export function ComicLibraryProvider({ children }) {
   }, []);
 
   const resetLibrary = useCallback(() => {
+    requestIdRef.current += 1;
     activeKeyRef.current = null;
     displayedKeyRef.current = null;
     storeComics([]);
@@ -69,6 +75,9 @@ export function ComicLibraryProvider({ children }) {
     // Claim the request before awaiting so a response that has been superseded
     // by a newer one can be recognised and dropped.
     activeKeyRef.current = key;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const isCurrent = () => activeKeyRef.current === key && requestIdRef.current === requestId;
 
     if (showsThisList) {
       setIsRefreshing(true);
@@ -79,7 +88,7 @@ export function ComicLibraryProvider({ children }) {
 
     try {
       const data = await api.get(url);
-      if (activeKeyRef.current !== key) {
+      if (!isCurrent()) {
         return comicsRef.current;
       }
 
@@ -88,7 +97,7 @@ export function ComicLibraryProvider({ children }) {
       storeComics(fetched);
       return fetched;
     } catch (err) {
-      if (activeKeyRef.current !== key) {
+      if (!isCurrent()) {
         return comicsRef.current;
       }
 
@@ -112,7 +121,7 @@ export function ComicLibraryProvider({ children }) {
 
       return comicsRef.current;
     } finally {
-      if (activeKeyRef.current === key) {
+      if (isCurrent()) {
         setIsLoading(false);
         setIsRefreshing(false);
       }

--- a/frontend/src/hooks/use-comic-library.jsx
+++ b/frontend/src/hooks/use-comic-library.jsx
@@ -1,0 +1,177 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from './use-auth';
+import { useToast } from './use-toast';
+import { api } from '@/lib/api';
+import { logger } from '@/lib/logger';
+import { fuzzyFilter } from '@/lib/fuzzy-search';
+import {
+  applyProgressUpdate,
+  isLibraryStale,
+  libraryRequestKey,
+  normaliseComics,
+  removeComics,
+} from '@/lib/comic-library';
+
+const FUZZY_FIELDS = ['title', 'author', 'publisher', 'description', 'tags'];
+
+const ComicLibraryContext = createContext(undefined);
+
+/**
+ * Holds the comic library outside the Dashboard so leaving for the reader and
+ * coming back does not throw the list away and rebuild it from an empty state.
+ *
+ * Metadata only. The covers themselves are cached by the browser against their
+ * versioned URLs.
+ */
+export function ComicLibraryProvider({ children }) {
+  const [comics, setComics] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  // False until a load has finished, so the dashboard shows its skeleton on the
+  // very first paint rather than flashing "no comics in your library yet".
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState(null);
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  // Mirrors of the state that loadLibrary reads, so the callback can stay
+  // stable and not restart the effect that calls it on every render.
+  const comicsRef = useRef([]);
+  const requestKeyRef = useRef(null);
+  const fetchedAtRef = useRef(null);
+
+  const storeComics = useCallback((nextComics) => {
+    comicsRef.current = nextComics;
+    setComics(nextComics);
+  }, []);
+
+  const resetLibrary = useCallback(() => {
+    requestKeyRef.current = null;
+    fetchedAtRef.current = null;
+    storeComics([]);
+    setError(null);
+    setIsLoading(false);
+    setIsRefreshing(false);
+    setHasLoaded(false);
+  }, [storeComics]);
+
+  /**
+   * Fetch a library list, showing whatever is already cached for the same
+   * request in the meantime.
+   *
+   * Returns the comics that ended up displayed.
+   */
+  const loadLibrary = useCallback(async ({ url = '/api/comics', fuzzyQuery = '', force = false } = {}) => {
+    const key = libraryRequestKey(url, fuzzyQuery);
+    const hasCached = requestKeyRef.current === key && fetchedAtRef.current !== null;
+
+    if (hasCached && !force && !isLibraryStale(fetchedAtRef.current)) {
+      return comicsRef.current;
+    }
+
+    // Claim the request before awaiting so a response that has been superseded
+    // by a newer search can be recognised and dropped.
+    requestKeyRef.current = key;
+
+    if (hasCached) {
+      // Cards stay on screen; only the quiet refresh indicator changes.
+      setIsRefreshing(true);
+    } else {
+      storeComics([]);
+      setIsLoading(true);
+    }
+    setError(null);
+
+    try {
+      const data = await api.get(url);
+      if (requestKeyRef.current !== key) {
+        return comicsRef.current;
+      }
+
+      const fetched = fuzzyFilter(normaliseComics(data.comics), fuzzyQuery, FUZZY_FIELDS);
+      fetchedAtRef.current = Date.now();
+      storeComics(fetched);
+      return fetched;
+    } catch (err) {
+      if (requestKeyRef.current !== key) {
+        return comicsRef.current;
+      }
+
+      logger.error('Failed to load comics:', err);
+      const message = err.status === 429
+        ? `Search rate limit exceeded. Please wait ${err.data?.retryAfter || 60} seconds before trying again.`
+        : err.message || 'Could not load comics.';
+      toast({
+        title: err.status === 429 ? 'Rate limit exceeded' : 'Error',
+        description: message,
+        variant: 'destructive',
+      });
+
+      // A failed background refresh must not replace comics that are already on
+      // screen with an error screen; the cached list is still the best answer.
+      if (!hasCached) {
+        fetchedAtRef.current = null;
+        storeComics([]);
+        setError(message);
+      }
+
+      return comicsRef.current;
+    } finally {
+      if (requestKeyRef.current === key) {
+        setIsLoading(false);
+        setIsRefreshing(false);
+        setHasLoaded(true);
+      }
+    }
+  }, [storeComics, toast]);
+
+  /**
+   * Record a reading position the reader has just saved, so returning to the
+   * library shows the new page immediately instead of after a round trip.
+   */
+  const updateComicProgress = useCallback((comicId, progress) => {
+    const next = applyProgressUpdate(comicsRef.current, comicId, progress);
+    if (next !== comicsRef.current) {
+      storeComics(next);
+    }
+  }, [storeComics]);
+
+  const removeComicsFromLibrary = useCallback((comicIds) => {
+    const next = removeComics(comicsRef.current, comicIds);
+    if (next !== comicsRef.current) {
+      storeComics(next);
+    }
+  }, [storeComics]);
+
+  // One user's library must never be shown to the next one.
+  const lastUserIdRef = useRef(null);
+  useEffect(() => {
+    const userId = user?.id ?? null;
+    if (lastUserIdRef.current === userId) return;
+
+    lastUserIdRef.current = userId;
+    resetLibrary();
+  }, [user, resetLibrary]);
+
+  const value = useMemo(() => ({
+    comics,
+    isLoading,
+    isRefreshing,
+    hasLoaded,
+    error,
+    loadLibrary,
+    updateComicProgress,
+    removeComicsFromLibrary,
+    resetLibrary,
+  }), [comics, isLoading, isRefreshing, hasLoaded, error, loadLibrary, updateComicProgress, removeComicsFromLibrary, resetLibrary]);
+
+  return <ComicLibraryContext.Provider value={value}>{children}</ComicLibraryContext.Provider>;
+}
+
+export function useComicLibrary() {
+  const context = useContext(ComicLibraryContext);
+  if (context === undefined) {
+    throw new Error('useComicLibrary must be used within a ComicLibraryProvider');
+  }
+  return context;
+}

--- a/frontend/src/hooks/use-comic-library.jsx
+++ b/frontend/src/hooks/use-comic-library.jsx
@@ -6,7 +6,6 @@ import { logger } from '@/lib/logger';
 import { fuzzyFilter } from '@/lib/fuzzy-search';
 import {
   applyProgressUpdate,
-  isLibraryStale,
   libraryRequestKey,
   normaliseComics,
   removeComics,
@@ -25,20 +24,21 @@ const ComicLibraryContext = createContext(undefined);
  */
 export function ComicLibraryProvider({ children }) {
   const [comics, setComics] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Starts true: nothing has been loaded yet, so the dashboard shows its
+  // skeleton on the very first paint instead of flashing "no comics yet".
+  const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  // False until a load has finished, so the dashboard shows its skeleton on the
-  // very first paint rather than flashing "no comics in your library yet".
-  const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState(null);
   const { user } = useAuth();
   const { toast } = useToast();
 
-  // Mirrors of the state that loadLibrary reads, so the callback can stay
-  // stable and not restart the effect that calls it on every render.
+  // Mirrors of the state loadLibrary reads, so the callback can stay stable and
+  // not restart the effect that calls it on every render.
   const comicsRef = useRef([]);
-  const requestKeyRef = useRef(null);
-  const fetchedAtRef = useRef(null);
+  // The request most recently started, and the one whose comics are on screen.
+  // They differ while a load is in flight.
+  const activeKeyRef = useRef(null);
+  const displayedKeyRef = useRef(null);
 
   const storeComics = useCallback((nextComics) => {
     comicsRef.current = nextComics;
@@ -46,54 +46,49 @@ export function ComicLibraryProvider({ children }) {
   }, []);
 
   const resetLibrary = useCallback(() => {
-    requestKeyRef.current = null;
-    fetchedAtRef.current = null;
+    activeKeyRef.current = null;
+    displayedKeyRef.current = null;
     storeComics([]);
     setError(null);
-    setIsLoading(false);
+    setIsLoading(true);
     setIsRefreshing(false);
-    setHasLoaded(false);
   }, [storeComics]);
 
   /**
-   * Fetch a library list, showing whatever is already cached for the same
-   * request in the meantime.
+   * Fetch a library list.
    *
-   * Returns the comics that ended up displayed.
+   * Every call goes to the server, so an upload or an edit made elsewhere is
+   * never missed. What changes is the wait: when the comics already on screen
+   * answer this same request they stay put and the fetch happens behind them,
+   * which is what stops a return from the reader clearing the cards.
    */
-  const loadLibrary = useCallback(async ({ url = '/api/comics', fuzzyQuery = '', force = false } = {}) => {
+  const loadLibrary = useCallback(async ({ url = '/api/comics', fuzzyQuery = '' } = {}) => {
     const key = libraryRequestKey(url, fuzzyQuery);
-    const hasCached = requestKeyRef.current === key && fetchedAtRef.current !== null;
-
-    if (hasCached && !force && !isLibraryStale(fetchedAtRef.current)) {
-      return comicsRef.current;
-    }
+    const showsThisList = displayedKeyRef.current === key;
 
     // Claim the request before awaiting so a response that has been superseded
-    // by a newer search can be recognised and dropped.
-    requestKeyRef.current = key;
+    // by a newer one can be recognised and dropped.
+    activeKeyRef.current = key;
 
-    if (hasCached) {
-      // Cards stay on screen; only the quiet refresh indicator changes.
+    if (showsThisList) {
       setIsRefreshing(true);
     } else {
-      storeComics([]);
       setIsLoading(true);
     }
     setError(null);
 
     try {
       const data = await api.get(url);
-      if (requestKeyRef.current !== key) {
+      if (activeKeyRef.current !== key) {
         return comicsRef.current;
       }
 
       const fetched = fuzzyFilter(normaliseComics(data.comics), fuzzyQuery, FUZZY_FIELDS);
-      fetchedAtRef.current = Date.now();
+      displayedKeyRef.current = key;
       storeComics(fetched);
       return fetched;
     } catch (err) {
-      if (requestKeyRef.current !== key) {
+      if (activeKeyRef.current !== key) {
         return comicsRef.current;
       }
 
@@ -107,20 +102,19 @@ export function ComicLibraryProvider({ children }) {
         variant: 'destructive',
       });
 
-      // A failed background refresh must not replace comics that are already on
-      // screen with an error screen; the cached list is still the best answer.
-      if (!hasCached) {
-        fetchedAtRef.current = null;
+      // A refresh that fails must not replace comics that are already on screen
+      // with an error page; what is displayed is still the best answer there is.
+      if (!showsThisList) {
+        displayedKeyRef.current = null;
         storeComics([]);
         setError(message);
       }
 
       return comicsRef.current;
     } finally {
-      if (requestKeyRef.current === key) {
+      if (activeKeyRef.current === key) {
         setIsLoading(false);
         setIsRefreshing(false);
-        setHasLoaded(true);
       }
     }
   }, [storeComics, toast]);
@@ -143,13 +137,23 @@ export function ComicLibraryProvider({ children }) {
     }
   }, [storeComics]);
 
-  // One user's library must never be shown to the next one.
-  const lastUserIdRef = useRef(null);
+  // Drop one session's library on the way out, so it is not still in memory for
+  // whoever logs in next.
+  //
+  // Logging out is the only moment worth doing this. Logging in cannot need it,
+  // because reaching the login page means a logged-out state cleared the store
+  // already — and clearing here on the way *in* would be unsafe: effects run
+  // child-first, so it would fire after the dashboard had already asked for its
+  // library and would strand it on an empty screen.
+  const wasLoggedInRef = useRef(false);
   useEffect(() => {
-    const userId = user?.id ?? null;
-    if (lastUserIdRef.current === userId) return;
+    if (user) {
+      wasLoggedInRef.current = true;
+      return;
+    }
+    if (!wasLoggedInRef.current) return;
 
-    lastUserIdRef.current = userId;
+    wasLoggedInRef.current = false;
     resetLibrary();
   }, [user, resetLibrary]);
 
@@ -157,13 +161,11 @@ export function ComicLibraryProvider({ children }) {
     comics,
     isLoading,
     isRefreshing,
-    hasLoaded,
     error,
     loadLibrary,
     updateComicProgress,
     removeComicsFromLibrary,
-    resetLibrary,
-  }), [comics, isLoading, isRefreshing, hasLoaded, error, loadLibrary, updateComicProgress, removeComicsFromLibrary, resetLibrary]);
+  }), [comics, isLoading, isRefreshing, error, loadLibrary, updateComicProgress, removeComicsFromLibrary]);
 
   return <ComicLibraryContext.Provider value={value}>{children}</ComicLibraryContext.Provider>;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -83,12 +83,14 @@
     @apply relative overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm transition-all hover:shadow-md hover:-translate-y-1;
   }
 
+  /* A column, so the progress bar can sit above the buttons rather than beside
+     them. The inner row keeps the original horizontal arrangement. */
   .reader-controls {
-    @apply fixed bottom-0 left-0 right-0 bg-gradient-to-t from-background/90 to-transparent p-4 opacity-100 flex justify-between items-center;
+    @apply fixed bottom-0 left-0 right-0 bg-gradient-to-t from-background/90 to-transparent p-4 opacity-100 flex flex-col gap-3;
   }
-  
+
   .reader-controls-fullscreen {
-    @apply fixed bottom-0 left-0 right-0 bg-gradient-to-t from-background/90 to-transparent p-4 opacity-0 transition-opacity duration-300 hover:opacity-100 flex justify-between items-center;
+    @apply fixed bottom-0 left-0 right-0 bg-gradient-to-t from-background/90 to-transparent p-4 opacity-0 transition-opacity duration-300 hover:opacity-100 flex flex-col gap-3;
   }
 
   .page-navigation {

--- a/frontend/src/lib/comic-library.js
+++ b/frontend/src/lib/comic-library.js
@@ -67,6 +67,49 @@ export function applyProgressUpdate(comics, comicId, progress) {
   return changed ? updated : comics;
 }
 
+/**
+ * Records the changes made to the library while a fetch is in flight.
+ *
+ * A response describes the library as it was when the server answered, so a
+ * deletion or a saved reading position that landed after that is missing from
+ * it. Replaying those changes over the response is what stops it resurrecting a
+ * deleted comic or rewinding a page number that has already moved on.
+ *
+ * Only changes recorded after a load began are replayed onto it: anything older
+ * was the server's to know about.
+ */
+export function createMutationLog() {
+  let entries = [];
+  let loadsInFlight = 0;
+
+  return {
+    // Returns the mark the caller passes back to rebase().
+    beginLoad() {
+      loadsInFlight += 1;
+      return entries.length;
+    },
+
+    // The log is only worth keeping while something might still replay it.
+    endLoad() {
+      loadsInFlight = Math.max(0, loadsInFlight - 1);
+      if (loadsInFlight === 0) entries = [];
+    },
+
+    record(mutate) {
+      if (loadsInFlight > 0) entries.push(mutate);
+    },
+
+    rebase(comics, mark) {
+      return entries.slice(mark).reduce((current, mutate) => mutate(current), comics);
+    },
+
+    reset() {
+      entries = [];
+      loadsInFlight = 0;
+    },
+  };
+}
+
 export function removeComics(comics, comicIds) {
   const removed = new Set((comicIds || []).map(String));
   if (removed.size === 0) return comics;

--- a/frontend/src/lib/comic-library.js
+++ b/frontend/src/lib/comic-library.js
@@ -8,24 +8,16 @@
  */
 
 /**
- * How long a cached library stays usable without a background refresh. Long
- * enough that returning from a comic reuses the cards on screen, short enough
- * that a second tab's upload shows up on the next visit.
- */
-export const LIBRARY_STALE_MS = 30 * 1000;
-
-/**
- * One request produces one cached list. The URL alone is not enough: the fuzzy
- * query is applied client-side after the response, so two visits sharing a URL
- * can still hold different comics.
+ * Identifies which list the store is currently holding. The URL alone is not
+ * enough: the fuzzy query is applied client-side after the response, so two
+ * visits sharing a URL can still produce different comics.
+ *
+ * Every visit still refetches. The key only decides whether the comics on
+ * screen answer the request being made — and so whether to show a skeleton or
+ * refresh quietly behind them.
  */
 export function libraryRequestKey(url, fuzzyQuery = "") {
   return `${url}::${fuzzyQuery}`;
-}
-
-export function isLibraryStale(fetchedAt, now = Date.now(), staleMs = LIBRARY_STALE_MS) {
-  if (!fetchedAt) return true;
-  return now - fetchedAt >= staleMs;
 }
 
 /**

--- a/frontend/src/lib/comic-library.js
+++ b/frontend/src/lib/comic-library.js
@@ -1,0 +1,84 @@
+/**
+ * Pure helpers behind the comic library store.
+ *
+ * The store keeps comic metadata only. Cover image bytes stay with the browser
+ * cache, which already handles memory, disk, revalidation and eviction; a second
+ * hand-rolled image cache would need its own invalidation and size limits for no
+ * gain.
+ */
+
+/**
+ * How long a cached library stays usable without a background refresh. Long
+ * enough that returning from a comic reuses the cards on screen, short enough
+ * that a second tab's upload shows up on the next visit.
+ */
+export const LIBRARY_STALE_MS = 30 * 1000;
+
+/**
+ * One request produces one cached list. The URL alone is not enough: the fuzzy
+ * query is applied client-side after the response, so two visits sharing a URL
+ * can still hold different comics.
+ */
+export function libraryRequestKey(url, fuzzyQuery = "") {
+  return `${url}::${fuzzyQuery}`;
+}
+
+export function isLibraryStale(fetchedAt, now = Date.now(), staleMs = LIBRARY_STALE_MS) {
+  if (!fetchedAt) return true;
+  return now - fetchedAt >= staleMs;
+}
+
+/**
+ * Flatten the API shape into what the cards and table read. `tags` becomes a
+ * list of names for filtering and display; the full objects stay on
+ * `tagDetails` for anything that needs the badge metadata.
+ */
+export function normaliseComic(comic) {
+  const tags = comic.tags || [];
+
+  return {
+    ...comic,
+    tagDetails: tags,
+    hiddenTagNames: tags.filter((tag) => tag.hideFromLibrary).map((tag) => tag.name),
+    tags: tags.map((tag) => tag.name),
+    lastReadPage: comic.readingProgress ? comic.readingProgress.currentPage : undefined,
+  };
+}
+
+export function normaliseComics(comics) {
+  return (comics || []).map(normaliseComic);
+}
+
+/**
+ * Apply a reading position the reader just saved. Returns the same array when
+ * the comic is not in this list, so a store update cannot pointlessly re-render
+ * every card.
+ *
+ * A null progress clears the position, which is what resetting does.
+ */
+export function applyProgressUpdate(comics, comicId, progress) {
+  const targetId = String(comicId);
+  let changed = false;
+
+  const updated = comics.map((comic) => {
+    if (String(comic.id) !== targetId) return comic;
+    changed = true;
+
+    if (!progress) {
+      return { ...comic, readingProgress: null, lastReadPage: undefined };
+    }
+
+    const readingProgress = { ...(comic.readingProgress || {}), ...progress };
+    return { ...comic, readingProgress, lastReadPage: readingProgress.currentPage };
+  });
+
+  return changed ? updated : comics;
+}
+
+export function removeComics(comics, comicIds) {
+  const removed = new Set((comicIds || []).map(String));
+  if (removed.size === 0) return comics;
+
+  const remaining = comics.filter((comic) => !removed.has(String(comic.id)));
+  return remaining.length === comics.length ? comics : remaining;
+}

--- a/frontend/src/lib/comic-library.test.js
+++ b/frontend/src/lib/comic-library.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applyProgressUpdate,
+  createMutationLog,
   libraryRequestKey,
   normaliseComic,
   normaliseComics,
@@ -72,6 +73,91 @@ describe("applyProgressUpdate", () => {
 
   it("returns the same list when the comic is not in it, so nothing re-renders", () => {
     expect(applyProgressUpdate(comics, 99, { currentPage: 1 })).toBe(comics);
+  });
+});
+
+describe("createMutationLog", () => {
+  // What the server would answer for a library it believes still has both.
+  const serverAnswer = () => [
+    { id: 1, title: "Conan", readingProgress: { currentPage: 2 }, lastReadPage: 2 },
+    { id: 2, title: "Vampirella", readingProgress: null },
+  ];
+
+  const remove = (ids) => (comics) => removeComics(comics, ids);
+  const setPage = (id, page) => (comics) => applyProgressUpdate(comics, id, { currentPage: page });
+
+  it("replays a deletion that happened while the fetch was out", () => {
+    const log = createMutationLog();
+
+    const mark = log.beginLoad();
+    log.record(remove([2]));
+    const rebased = log.rebase(serverAnswer(), mark);
+    log.endLoad();
+
+    expect(rebased.map((comic) => comic.id)).toEqual([1]);
+  });
+
+  it("replays a reading position saved while the fetch was out", () => {
+    const log = createMutationLog();
+
+    const mark = log.beginLoad();
+    log.record(setPage(1, 40));
+    const rebased = log.rebase(serverAnswer(), mark);
+    log.endLoad();
+
+    expect(rebased[0].lastReadPage).toBe(40);
+  });
+
+  it("leaves a fetch alone when the change came after it landed", () => {
+    const log = createMutationLog();
+
+    const mark = log.beginLoad();
+    const rebased = log.rebase(serverAnswer(), mark);
+    log.endLoad();
+    // Past endLoad nothing is in flight, so this change has no response left to
+    // correct; the store applies it directly.
+    log.record(remove([2]));
+
+    expect(rebased.map((comic) => comic.id)).toEqual([1, 2]);
+    expect(log.rebase(serverAnswer(), 0).map((comic) => comic.id)).toEqual([1, 2]);
+  });
+
+  it("does not replay a change that predates the load", () => {
+    const log = createMutationLog();
+
+    const first = log.beginLoad();
+    log.record(remove([2]));
+    // A second load starts after the deletion, so the server already knows.
+    const second = log.beginLoad();
+
+    expect(log.rebase(serverAnswer(), second).map((comic) => comic.id)).toEqual([1, 2]);
+    expect(log.rebase(serverAnswer(), first).map((comic) => comic.id)).toEqual([1]);
+  });
+
+  it("keeps the log until the last overlapping load has finished", () => {
+    const log = createMutationLog();
+
+    const first = log.beginLoad();
+    log.beginLoad();
+    log.record(remove([2]));
+    log.endLoad();
+
+    expect(log.rebase(serverAnswer(), first).map((comic) => comic.id)).toEqual([1]);
+
+    // Nothing is in flight now, so the log starts over rather than growing for
+    // the rest of the session.
+    log.endLoad();
+    expect(log.rebase(serverAnswer(), 0).map((comic) => comic.id)).toEqual([1, 2]);
+  });
+
+  it("forgets everything when the library is reset on logout", () => {
+    const log = createMutationLog();
+
+    const mark = log.beginLoad();
+    log.record(remove([2]));
+    log.reset();
+
+    expect(log.rebase(serverAnswer(), mark).map((comic) => comic.id)).toEqual([1, 2]);
   });
 });
 

--- a/frontend/src/lib/comic-library.test.js
+++ b/frontend/src/lib/comic-library.test.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIBRARY_STALE_MS,
+  applyProgressUpdate,
+  isLibraryStale,
+  libraryRequestKey,
+  normaliseComic,
+  normaliseComics,
+  removeComics,
+} from "./comic-library";
+
+describe("normaliseComic", () => {
+  it("flattens tags while keeping the badge metadata", () => {
+    const comic = normaliseComic({
+      id: 1,
+      title: "Conan",
+      tags: [
+        { id: 7, name: "Marvel", hideFromLibrary: false },
+        { id: 8, name: "Secret", hideFromLibrary: true },
+      ],
+      readingProgress: null,
+    });
+
+    expect(comic.tags).toEqual(["Marvel", "Secret"]);
+    expect(comic.hiddenTagNames).toEqual(["Secret"]);
+    expect(comic.tagDetails).toHaveLength(2);
+  });
+
+  it("exposes the stored page as lastReadPage, and leaves it unset without progress", () => {
+    expect(normaliseComic({ id: 1, readingProgress: { currentPage: 12 } }).lastReadPage).toBe(12);
+    expect(normaliseComic({ id: 1, readingProgress: null }).lastReadPage).toBeUndefined();
+  });
+
+  it("survives a comic that has no tags at all", () => {
+    expect(normaliseComics([{ id: 1 }])[0].tags).toEqual([]);
+    expect(normaliseComics(undefined)).toEqual([]);
+  });
+});
+
+describe("libraryRequestKey", () => {
+  it("separates a filtered list from the full library", () => {
+    expect(libraryRequestKey("/api/comics")).not.toBe(libraryRequestKey("/api/comics?tags=Marvel"));
+  });
+
+  it("separates two searches that share a URL", () => {
+    expect(libraryRequestKey("/api/comics", "conan")).not.toBe(libraryRequestKey("/api/comics", "vampirella"));
+  });
+});
+
+describe("isLibraryStale", () => {
+  it("treats a library that was never fetched as stale", () => {
+    expect(isLibraryStale(null)).toBe(true);
+  });
+
+  it("keeps a just-fetched library usable", () => {
+    const now = 1000000;
+    expect(isLibraryStale(now - 1000, now)).toBe(false);
+  });
+
+  it("goes stale once the window has passed", () => {
+    const now = 1000000;
+    expect(isLibraryStale(now - LIBRARY_STALE_MS, now)).toBe(true);
+  });
+});
+
+describe("applyProgressUpdate", () => {
+  const comics = [
+    { id: 1, title: "Conan", readingProgress: { currentPage: 2, revision: 1 }, lastReadPage: 2 },
+    { id: 2, title: "Vampirella", readingProgress: null },
+  ];
+
+  it("records the page the reader just saved", () => {
+    const updated = applyProgressUpdate(comics, 1, { currentPage: 9, revision: 4, completed: false });
+
+    expect(updated[0].lastReadPage).toBe(9);
+    expect(updated[0].readingProgress).toMatchObject({ currentPage: 9, revision: 4 });
+    expect(updated[1]).toBe(comics[1]);
+  });
+
+  it("matches a comic id that arrives as a string from the route", () => {
+    expect(applyProgressUpdate(comics, "2", { currentPage: 5 })[1].lastReadPage).toBe(5);
+  });
+
+  it("clears the position when progress is reset", () => {
+    const updated = applyProgressUpdate(comics, 1, null);
+
+    expect(updated[0].readingProgress).toBeNull();
+    expect(updated[0].lastReadPage).toBeUndefined();
+  });
+
+  it("returns the same list when the comic is not in it, so nothing re-renders", () => {
+    expect(applyProgressUpdate(comics, 99, { currentPage: 1 })).toBe(comics);
+  });
+});
+
+describe("removeComics", () => {
+  const comics = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+  it("drops every deleted comic", () => {
+    expect(removeComics(comics, [1, 3]).map((comic) => comic.id)).toEqual([2]);
+  });
+
+  it("returns the same list when nothing matched", () => {
+    expect(removeComics(comics, [99])).toBe(comics);
+    expect(removeComics(comics, [])).toBe(comics);
+  });
+});

--- a/frontend/src/lib/comic-library.test.js
+++ b/frontend/src/lib/comic-library.test.js
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  LIBRARY_STALE_MS,
   applyProgressUpdate,
-  isLibraryStale,
   libraryRequestKey,
   normaliseComic,
   normaliseComics,
@@ -44,22 +42,6 @@ describe("libraryRequestKey", () => {
 
   it("separates two searches that share a URL", () => {
     expect(libraryRequestKey("/api/comics", "conan")).not.toBe(libraryRequestKey("/api/comics", "vampirella"));
-  });
-});
-
-describe("isLibraryStale", () => {
-  it("treats a library that was never fetched as stale", () => {
-    expect(isLibraryStale(null)).toBe(true);
-  });
-
-  it("keeps a just-fetched library usable", () => {
-    const now = 1000000;
-    expect(isLibraryStale(now - 1000, now)).toBe(false);
-  });
-
-  it("goes stale once the window has passed", () => {
-    const now = 1000000;
-    expect(isLibraryStale(now - LIBRARY_STALE_MS, now)).toBe(true);
   });
 });
 

--- a/frontend/src/lib/comic-progress.js
+++ b/frontend/src/lib/comic-progress.js
@@ -1,3 +1,21 @@
+/**
+ * Turn what someone typed into a jump-to-page box into a page index.
+ *
+ * Returns a zero-based index, or null when the value is not a page at all —
+ * including the half-finished states a controlled input goes through while
+ * being typed into, which must leave the reader where it is.
+ */
+export function parsePageNumber(rawValue, pageCount) {
+  if (!Number.isInteger(pageCount) || pageCount < 1) return null;
+
+  const parsed = Number.parseInt(String(rawValue).trim(), 10);
+  if (Number.isNaN(parsed)) return null;
+
+  // Clamping rather than rejecting: asking for page 500 of 40 plainly means the
+  // end, and refusing to move would just look broken.
+  return Math.min(Math.max(parsed, 1), pageCount) - 1;
+}
+
 export function getComicProgressState(comic) {
   const currentPage = comic.readingProgress?.currentPage ?? comic.lastReadPage ?? 0;
   const pageCount = comic.pageCount ?? 0;

--- a/frontend/src/lib/comic-progress.test.js
+++ b/frontend/src/lib/comic-progress.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { parsePageNumber } from "./comic-progress";
+
+describe("parsePageNumber", () => {
+  it("turns a one-based page into a zero-based index", () => {
+    expect(parsePageNumber("1", 40)).toBe(0);
+    expect(parsePageNumber("40", 40)).toBe(39);
+    expect(parsePageNumber(12, 40)).toBe(11);
+  });
+
+  it("clamps a page outside the comic to its nearest end", () => {
+    expect(parsePageNumber("500", 40)).toBe(39);
+    expect(parsePageNumber("0", 40)).toBe(0);
+    expect(parsePageNumber("-3", 40)).toBe(0);
+  });
+
+  it("rejects the half-typed states an input passes through", () => {
+    expect(parsePageNumber("", 40)).toBeNull();
+    expect(parsePageNumber("   ", 40)).toBeNull();
+    expect(parsePageNumber("abc", 40)).toBeNull();
+    expect(parsePageNumber("-", 40)).toBeNull();
+  });
+
+  it("rejects everything while the comic has no pages", () => {
+    expect(parsePageNumber("1", 0)).toBeNull();
+    expect(parsePageNumber("1", undefined)).toBeNull();
+  });
+
+  it("ignores trailing junk rather than refusing to move", () => {
+    expect(parsePageNumber("7abc", 40)).toBe(6);
+  });
+});

--- a/frontend/src/lib/keyboard.js
+++ b/frontend/src/lib/keyboard.js
@@ -1,0 +1,15 @@
+/**
+ * Whether a keyboard event landed somewhere the user is entering text.
+ *
+ * Global shortcuts have to check this. A reader that turns the page on every
+ * ArrowLeft would move the comic while someone is editing the page number, and
+ * a shortcut that focuses the search box would swallow a typed "/".
+ */
+export function isTypingTarget(target) {
+  if (!target || typeof target !== "object") return false;
+
+  const tagName = typeof target.tagName === "string" ? target.tagName.toUpperCase() : "";
+  if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") return true;
+
+  return target.isContentEditable === true;
+}

--- a/frontend/src/lib/keyboard.test.js
+++ b/frontend/src/lib/keyboard.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isTypingTarget } from "./keyboard";
+
+describe("isTypingTarget", () => {
+  it("recognises the fields a shortcut must not interrupt", () => {
+    expect(isTypingTarget({ tagName: "INPUT" })).toBe(true);
+    expect(isTypingTarget({ tagName: "TEXTAREA" })).toBe(true);
+    expect(isTypingTarget({ tagName: "SELECT" })).toBe(true);
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: true })).toBe(true);
+  });
+
+  it("leaves shortcuts working everywhere else", () => {
+    expect(isTypingTarget({ tagName: "BODY" })).toBe(false);
+    expect(isTypingTarget({ tagName: "BUTTON" })).toBe(false);
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: false })).toBe(false);
+  });
+
+  it("survives an event with no usable target", () => {
+    expect(isTypingTarget(null)).toBe(false);
+    expect(isTypingTarget(undefined)).toBe(false);
+    expect(isTypingTarget({})).toBe(false);
+  });
+});

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -4,8 +4,11 @@ import { Button } from "@/components/ui/button.jsx";
 import { ArrowLeft, ArrowRight, Info, Maximize, ZoomIn, ZoomOut, RefreshCw } from "lucide-react";
 import { useToast } from "@/hooks/use-toast.js";
 import { Skeleton } from "@/components/ui/skeleton.jsx";
+import { Progress } from "@/components/ui/progress.jsx";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { isTypingTarget } from "@/lib/keyboard";
+import { parsePageNumber } from "@/lib/comic-progress";
 import { useComicLibrary } from "@/hooks/use-comic-library.jsx";
 
 export default function ComicReader() {
@@ -23,6 +26,7 @@ export default function ComicReader() {
   const [zoomLevel, setZoomLevel] = useState(1);
   const [mousePosition, setMousePosition] = useState({ x: 0.5, y: 0.5 });
   const imageContainerRef = useRef(null);
+  const pageInputRef = useRef(null);
   
   // Refs for async operations
   const progressAbortController = useRef(null);
@@ -438,6 +442,31 @@ export default function ComicReader() {
     goToPage(currentPage + 1);
   }, [goToPage, currentPage]);
 
+  // The jump-to-page box holds raw text, not a page number: it has to survive
+  // the empty and half-typed states an input passes through. It is reconciled
+  // with the reader whenever the page changes by any other means.
+  const [pageInput, setPageInput] = useState("1");
+
+  useEffect(() => {
+    setPageInput(String(currentPage + 1));
+  }, [currentPage]);
+
+  const commitPageInput = useCallback(() => {
+    const requestedPage = parsePageNumber(pageInput, comicPages.length);
+
+    if (requestedPage === null) {
+      setPageInput(String(currentPageRef.current + 1));
+      return;
+    }
+
+    // Echo the clamped value back, so typing 500 in a 40-page comic settles on
+    // 40 rather than leaving a number that does not match the page shown.
+    setPageInput(String(requestedPage + 1));
+    if (requestedPage !== currentPageRef.current) {
+      goToPage(requestedPage);
+    }
+  }, [pageInput, comicPages.length, goToPage]);
+
   // Force a page to come from the server again, bypassing the browser cache.
   // A unique URL is what does the bypassing: the page endpoint is cacheable, so
   // re-requesting the plain URL would simply be answered locally.
@@ -507,12 +536,24 @@ export default function ComicReader() {
   // reader keeps focus in the document either way.
   useEffect(() => {
     const handleKeyPress = (event) => {
+      // Arrow keys belong to the jump-to-page box while it has focus; turning
+      // the page under someone editing a page number would be maddening.
+      if (isTypingTarget(event.target)) return;
+
       switch (event.key) {
         case "ArrowLeft":
           handlePreviousPage();
           break;
         case "ArrowRight":
           handleNextPage();
+          break;
+        case "Home":
+          event.preventDefault();
+          goToPage(0);
+          break;
+        case "End":
+          event.preventDefault();
+          goToPage(comicPages.length - 1);
           break;
         default:
           break;
@@ -521,7 +562,7 @@ export default function ComicReader() {
 
     window.addEventListener("keydown", handleKeyPress);
     return () => window.removeEventListener("keydown", handleKeyPress);
-  }, [handlePreviousPage, handleNextPage]);
+  }, [handlePreviousPage, handleNextPage, goToPage, comicPages.length]);
 
   // Handle fullscreen change events
   useEffect(() => {
@@ -592,14 +633,14 @@ export default function ComicReader() {
       {/* Navigation areas for clicking left/right sides of screen */}
       <div 
         className={`page-navigation left-0 ${isFullscreen ? 'z-[55]' : ''}`}
-        style={{ bottom: '60px' }} // Leave space for controls to prevent overlap
+        style={{ bottom: '88px' }} // Leave space for controls to prevent overlap
         onClick={() => handleScreenNavClick('left')}
         aria-label="Previous page"
       ></div>
       
       <div 
         className={`page-navigation right-0 ${isFullscreen ? 'z-[55]' : ''}`}
-        style={{ bottom: '60px' }} // Leave space for controls to prevent overlap
+        style={{ bottom: '88px' }} // Leave space for controls to prevent overlap
         onClick={() => handleScreenNavClick('right')}
         aria-label="Next page"
       ></div>
@@ -797,47 +838,80 @@ export default function ComicReader() {
       
       {/* Reader controls - different styling in fullscreen mode */}
       <div className={isFullscreen ? "reader-controls-fullscreen" : "reader-controls"}>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            onClick={handlePreviousPage}
-            disabled={currentPage === 0}
-            className={isFullscreen ? "" : "bg-card"}
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" /> Previous
-          </Button>
-          
-          {/* Force reload button */}
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={handleForceReload}
-            title="Force reload current page"
-            className={isFullscreen ? "" : "bg-card"}
-          >
-            <RefreshCw className="h-4 w-4" />
-          </Button>
-        </div>
-        
-        <div className="flex items-center gap-2">
-          <div className="text-sm">
-            Page {currentPage + 1} of {comicPages.length}
+        {/* How far through the comic this page is, at a glance */}
+        {comicPages.length > 0 && (
+          <Progress
+            value={((currentPage + 1) / comicPages.length) * 100}
+            aria-label={`Page ${currentPage + 1} of ${comicPages.length}`}
+            className="h-1 w-full rounded-none bg-muted/60"
+          />
+        )}
+
+        <div className="flex w-full items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={handlePreviousPage}
+              disabled={currentPage === 0}
+              className={isFullscreen ? "" : "bg-card"}
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" /> Previous
+            </Button>
+
+            {/* Force reload button */}
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleForceReload}
+              title="Force reload current page"
+              className={isFullscreen ? "" : "bg-card"}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
           </div>
-          {isZoomed && (
-            <div className="text-xs bg-primary/20 px-2 py-1 rounded">
-              {Math.round(zoomLevel * 100)}% zoom
-            </div>
-          )}
+
+          <div className="flex items-center gap-2">
+            <form
+              className="flex items-center gap-1.5 text-sm"
+              onSubmit={(event) => {
+                event.preventDefault();
+                commitPageInput();
+                pageInputRef.current?.blur();
+              }}
+            >
+              <label htmlFor="reader-page-input" className="sr-only">Go to page</label>
+              <input
+                id="reader-page-input"
+                ref={pageInputRef}
+                type="number"
+                inputMode="numeric"
+                min={1}
+                max={comicPages.length || 1}
+                value={pageInput}
+                onChange={(event) => setPageInput(event.target.value)}
+                onBlur={commitPageInput}
+                disabled={comicPages.length === 0}
+                title="Go to page"
+                className="h-8 w-16 rounded-md border border-input bg-background px-2 text-center text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
+              />
+              <span className="whitespace-nowrap">of {comicPages.length}</span>
+            </form>
+            {isZoomed && (
+              <div className="text-xs bg-primary/20 px-2 py-1 rounded">
+                {Math.round(zoomLevel * 100)}% zoom
+              </div>
+            )}
+          </div>
+
+          <Button
+            variant="outline"
+            onClick={handleNextPage}
+            disabled={currentPage === comicPages.length - 1}
+            className={isFullscreen ? "" : "bg-card"}
+          >
+            Next <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
         </div>
-        
-        <Button
-          variant="outline"
-          onClick={handleNextPage}
-          disabled={currentPage === comicPages.length - 1}
-          className={isFullscreen ? "" : "bg-card"}
-        >
-          Next <ArrowRight className="ml-2 h-4 w-4" />
-        </Button>
       </div>
     </div>
   );

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+﻿import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button.jsx";
 import { ArrowLeft, ArrowRight, Info, Maximize, ZoomIn, ZoomOut, RefreshCw } from "lucide-react";
@@ -26,7 +26,6 @@ export default function ComicReader() {
   
   // Refs for async operations
   const progressAbortController = useRef(null);
-  const reloadAbortController = useRef(null); // For aborting force reload operations
   const currentPageRef = useRef(0); // Ref to track current page for async operations
   const loadQueueRef = useRef([]); // Queue of pages to load
   const isLoadingRef = useRef(false); // Flag to track if we're currently loading a page
@@ -182,21 +181,6 @@ export default function ComicReader() {
            pageIndex <= Math.min(comicPages.length - 1, currentPageRef.current + CACHE_SIZE_FORWARD);
   }, [comicPages.length]);
 
-  // Snapshot a loaded image into a detached, self-contained Image so that
-  // re-displaying a cached page never hits the network again.
-  const toCachedImage = (img) => {
-    const canvas = document.createElement('canvas');
-    canvas.width = img.width;
-    canvas.height = img.height;
-    canvas.getContext('2d').drawImage(img, 0, 0);
-
-    // JPEG keeps the bounded page cache compact. Lossless PNG snapshots can
-    // expand photographic comic pages enough to exhaust memory on mobile.
-    const cachedImg = new Image();
-    cachedImg.src = canvas.toDataURL('image/jpeg', 0.92);
-    return cachedImg;
-  };
-
   // Object to track in-progress loads to prevent duplicate requests
   const loadingPagesRef = useRef({});
   
@@ -222,24 +206,16 @@ export default function ComicReader() {
     
     // Create a new promise for this load
     const loadPromise = new Promise((resolve, reject) => {
-      // Create a new image object with a unique timestamp to prevent browser caching
+      // The plain page URL, deliberately: the endpoint is cacheable, so asking
+      // for it again is answered by the browser without touching the network.
+      // A cache-busting parameter here would make every page a fresh download.
       const img = new Image();
-      const url = `${comicPages[pageIndex]}?_t=${Date.now()}`;
-      
-      img.crossOrigin = 'Anonymous'; // Enable CORS for the canvas operations
-      
+      const url = comicPages[pageIndex];
+
       img.onload = () => {
         // Only update cache if this page is still in the cache window
         if (isInCacheWindow(pageIndex)) {
-          let cached;
-          try {
-            cached = toCachedImage(img);
-          } catch {
-            // Canvas snapshot failed; fall back to the original image
-            cached = img;
-          }
-
-          setImageCache(prev => ({ ...prev, [pageIndex]: cached }));
+          setImageCache(prev => ({ ...prev, [pageIndex]: img }));
         }
         // Remove from loading tracker
         delete loadingPagesRef.current[pageIndex];
@@ -257,7 +233,6 @@ export default function ComicReader() {
         reject();
       };
       
-      // Set the source with the timestamp to prevent caching
       img.src = url;
     });
     
@@ -463,172 +438,63 @@ export default function ComicReader() {
     goToPage(currentPage + 1);
   }, [goToPage, currentPage]);
 
-  // Function to force reload the current page from the server
+  // Force a page to come from the server again, bypassing the browser cache.
+  // A unique URL is what does the bypassing: the page endpoint is cacheable, so
+  // re-requesting the plain URL would simply be answered locally.
   const handleForceReload = useCallback(() => {
     if (comicPages.length === 0 || currentPage < 0 || currentPage >= comicPages.length) {
       return;
     }
-    
-    // If there's already a reload in progress, abort it
-    if (reloadAbortController.current) {
-      reloadAbortController.current.abort();
-      reloadAbortController.current = null;
-    }
-    
-    // Create a new abort controller for this reload
-    reloadAbortController.current = new AbortController();
-    const signal = reloadAbortController.current.signal;
-    
-    // Store the current page to ensure we stay on it
+
     const pageToReload = currentPage;
-    
-    // Show toast to indicate reload is happening
+
     toast({
       title: "Reloading page",
       description: `Forcing reload of page ${pageToReload + 1}`,
     });
-    
-    // Clear the current page from cache
+
     setImageCache(prevCache => {
       const newCache = { ...prevCache };
-      delete newCache[pageToReload]; // Remove from cache to force reload
+      delete newCache[pageToReload];
       return newCache;
     });
-    
-    // Set loading states
     setIsPageImageLoading(true);
     setImageLoadedSuccessfully(false);
-    
-    // Use fetch with AbortController instead of Image directly
-    const url = `${comicPages[pageToReload]}?_force_reload=${Date.now()}`;
-    
-    api.blob(url, { signal })
-      .then(blob => {
-        // Check if the operation was aborted
-        if (signal.aborted) return;
-        
-        // Create a URL for the blob
-        const blobUrl = URL.createObjectURL(blob);
-        
-        // Create an image from the blob URL
-        const img = new Image();
-        
-        img.onload = () => {
-          try {
-            // Check if the operation was aborted
-            if (signal.aborted) {
-              URL.revokeObjectURL(blobUrl);
-              return;
-            }
-            
-            // Make sure we're still on the same page
-            if (currentPage !== pageToReload) {
-              // If page has changed, just update the cache but don't change UI
-              setImageCache(prev => ({
-                ...prev,
-                [pageToReload]: img
-              }));
-              URL.revokeObjectURL(blobUrl);
-              return;
-            }
-            
-            const cachedImg = toCachedImage(img);
 
-            // Free the blob URL
-            URL.revokeObjectURL(blobUrl);
+    const img = new Image();
 
-            // Update cache with the new image
-            setImageCache(prev => ({
-              ...prev,
-              [pageToReload]: cachedImg
-            }));
-            
-            // Update UI state only if we're still on the same page
-            setIsPageImageLoading(false);
-            setImageLoadedSuccessfully(true);
-            
-            // Success toast
-            toast({
-              title: "Page reloaded",
-              description: `Successfully reloaded page ${pageToReload + 1}`,
-              variant: "success",
-            });
-            
-            // Clear the abort controller reference
-            reloadAbortController.current = null;
-          } catch (error) {
-            // Check if the operation was aborted
-            if (signal.aborted) return;
-            
-            logger.error("Error reloading page:", error);
-            
-            // Only show error if we're still on the same page
-            if (currentPage === pageToReload) {
-              toast({
-                title: "Error reloading",
-                description: "There was a problem reloading the page. Please try again.",
-                variant: "destructive",
-              });
-              setIsPageImageLoading(false);
-              setImageLoadedSuccessfully(false);
-            }
-            
-            // Clear the abort controller reference
-            reloadAbortController.current = null;
-          }
-        };
-        
-        img.onerror = () => {
-          // Check if the operation was aborted
-          if (signal.aborted) {
-            URL.revokeObjectURL(blobUrl);
-            return;
-          }
-          
-          logger.error("Failed to reload image");
-          URL.revokeObjectURL(blobUrl);
-          
-          // Only show error if we're still on the same page
-          if (currentPage === pageToReload) {
-            toast({
-              title: "Reload failed",
-              description: "Could not reload the page. Please try again later.",
-              variant: "destructive",
-            });
-            setIsPageImageLoading(false);
-            setImageLoadedSuccessfully(false);
-          }
-          
-          // Clear the abort controller reference
-          reloadAbortController.current = null;
-        };
-        
-        // Set the source to start loading
-        img.src = blobUrl;
-      })
-      .catch(error => {
-        // Check if the operation was aborted
-        if (signal.aborted) return;
-        
-        // Handle fetch errors
-        logger.error("Fetch error:", error);
-        
-        // Only show error if we're still on the same page
-        if (currentPage === pageToReload) {
-          toast({
-            title: "Reload failed",
-            description: "Could not reload the page from server. Please try again later.",
-            variant: "destructive",
-          });
-          setIsPageImageLoading(false);
-          setImageLoadedSuccessfully(false);
-        }
-        
-        // Clear the abort controller reference
-        reloadAbortController.current = null;
+    img.onload = () => {
+      setImageCache(prev => ({ ...prev, [pageToReload]: img }));
+
+      // The reader may have moved on while this was loading; the cache above is
+      // still worth keeping, but the loading state belongs to another page now.
+      if (currentPageRef.current !== pageToReload) return;
+
+      setIsPageImageLoading(false);
+      setImageLoadedSuccessfully(true);
+      toast({
+        title: "Page reloaded",
+        description: `Successfully reloaded page ${pageToReload + 1}`,
+        variant: "success",
       });
+    };
+
+    img.onerror = () => {
+      logger.error("Failed to reload image");
+      if (currentPageRef.current !== pageToReload) return;
+
+      setIsPageImageLoading(false);
+      setImageLoadedSuccessfully(false);
+      toast({
+        title: "Reload failed",
+        description: "Could not reload the page. Please try again later.",
+        variant: "destructive",
+      });
+    };
+
+    img.src = `${comicPages[pageToReload]}?_force_reload=${Date.now()}`;
   }, [comicPages, currentPage, toast]);
-  
+
   const handleScreenNavClick = (direction) => {
     if (direction === 'left') {
       handlePreviousPage();
@@ -905,8 +771,8 @@ export default function ComicReader() {
                     .map(pageNum => (
                       <li key={pageNum} className={pageNum === currentPage ? 'font-bold' : ''}>
                         Page {pageNum + 1}: {' '}
-                        {imageCache[pageNum] === 'loading' ? '🔄 Loading' : 
-                         imageCache[pageNum] === 'failed' ? '❌ Failed' : '✅ Loaded'}
+                        {imageCache[pageNum] === 'loading' ? 'ðŸ”„ Loading' : 
+                         imageCache[pageNum] === 'failed' ? 'âŒ Failed' : 'âœ… Loaded'}
                         {pageNum === currentPage ? ' (current)' : ''}
                       </li>
                     ))

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast.js";
 import { Skeleton } from "@/components/ui/skeleton.jsx";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { useComicLibrary } from "@/hooks/use-comic-library.jsx";
 
 export default function ComicReader() {
   const { comicId } = useParams();
@@ -34,6 +35,7 @@ export default function ComicReader() {
   
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { updateComicProgress } = useComicLibrary();
 
   const CACHE_SIZE_FORWARD = 5;
   const CACHE_SIZE_BACKWARD = 5;
@@ -70,6 +72,12 @@ export default function ComicReader() {
       if (typeof storedRevision === 'number' && storedRevision > progressRevisionRef.current) {
         progressRevisionRef.current = storedRevision;
       }
+
+      // Keep the library card in step with what was just stored, so going back
+      // shows the new page straight away instead of after another /api/comics.
+      if (response?.progress) {
+        updateComicProgress(comicId, response.progress);
+      }
     } catch (error) {
       // A superseded save is expected, not a failure
       if (error.name === 'AbortError' || controller.signal.aborted) return;
@@ -97,7 +105,7 @@ export default function ComicReader() {
         progressAbortController.current = null;
       }
     }
-  }, [comicId, comic, toast]);
+  }, [comicId, comic, toast, updateComicProgress]);
 
   // Track mount state so an in-flight progress save that resolves after the
   // reader closes does not try to toast onto the next screen.

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -492,9 +492,13 @@ export default function ComicReader() {
     setImageLoadedSuccessfully(false);
 
     const img = new Image();
+    let settleForcedLoad = () => {};
+    let failForcedLoad = () => {};
 
     img.onload = () => {
+      delete loadingPagesRef.current[pageToReload];
       setImageCache(prev => ({ ...prev, [pageToReload]: img }));
+      settleForcedLoad(img);
 
       // The reader may have moved on while this was loading; the cache above is
       // still worth keeping, but the loading state belongs to another page now.
@@ -511,6 +515,8 @@ export default function ComicReader() {
 
     img.onerror = () => {
       logger.error("Failed to reload image");
+      delete loadingPagesRef.current[pageToReload];
+      failForcedLoad();
       if (currentPageRef.current !== pageToReload) return;
 
       setIsPageImageLoading(false);
@@ -521,6 +527,21 @@ export default function ComicReader() {
         variant: "destructive",
       });
     };
+
+    // Dropping the page from the cache above leaves the loading effect wanting
+    // it back, and it would ask for the plain URL - the browser-cached copy
+    // this reload exists to get past. Publishing the forced load through the
+    // tracker every other loader already consults hands that effect this
+    // request instead: no second download, and no stale image that can land
+    // last and take the cache entry back.
+    const forcedLoad = new Promise((resolve, reject) => {
+      settleForcedLoad = resolve;
+      failForcedLoad = reject;
+    });
+    // A caller is not guaranteed; without this a failed reload would surface as
+    // an unhandled rejection on top of the toast that already reports it.
+    forcedLoad.catch(() => {});
+    loadingPagesRef.current[pageToReload] = forcedLoad;
 
     img.src = `${comicPages[pageToReload]}?_force_reload=${Date.now()}`;
   }, [comicPages, currentPage, toast]);
@@ -807,8 +828,10 @@ export default function ComicReader() {
                     .map(pageNum => (
                       <li key={pageNum} className={pageNum === currentPage ? 'font-bold' : ''}>
                         Page {pageNum + 1}: {' '}
-                        {imageCache[pageNum] === 'loading' ? 'ðŸ”„ Loading' : 
-                         imageCache[pageNum] === 'failed' ? 'âŒ Failed' : 'âœ… Loaded'}
+                        {/* Escape sequences, not literals: these icons went through a bad
+                            re-encoding once and came back as mojibake. */}
+                        {imageCache[pageNum] === 'loading' ? '\u{1F504} Loading' :
+                         imageCache[pageNum] === 'failed' ? '\u274C Failed' : '\u2705 Loaded'}
                         {pageNum === currentPage ? ' (current)' : ''}
                       </li>
                     ))

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -27,15 +27,15 @@ export default function Dashboard() {
     comics,
     isLoading,
     isRefreshing,
-    hasLoaded,
     error,
     loadLibrary,
     updateComicProgress,
     removeComicsFromLibrary,
   } = useComicLibrary();
-  // Before the first load settles there is nothing to show but the skeleton.
-  const showSkeleton = isLoading || !hasLoaded;
   const [isSearching, setIsSearching] = useState(false); // Specific state for search operations
+  // A search keeps the current results visible under its own overlay; every
+  // other first-time load has nothing to show yet but the skeleton.
+  const showSkeleton = isLoading && !isSearching;
   const [isSearchActive, setIsSearchActive] = useState(false);
   const [editingComic, setEditingComic] = useState(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -49,17 +49,17 @@ export default function Dashboard() {
   const [shareModalComicId, setShareModalComicId] = useState(null);
   const [shareModalComicTitle, setShareModalComicTitle] = useState(null);
 
-  const fetchComicsFromApi = useCallback(async (url, fuzzyQuery = '', { force = false } = {}) => {
+  const fetchComicsFromApi = useCallback(async (url, fuzzyQuery = '') => {
     lastComicsUrl.current = url;
     lastSearchQuery.current = fuzzyQuery;
-    // Searches show their own overlay; the store decides between the skeleton
-    // and a quiet background refresh for everything else.
+    // A search keeps its own overlay over the results it is replacing; the store
+    // decides between the skeleton and a quiet refresh for everything else.
     const isSearchRequest = Boolean(fuzzyQuery) || url.includes('tags=');
     if (isSearchRequest) {
       setIsSearching(true);
     }
     try {
-      await loadLibrary({ url, fuzzyQuery, force });
+      await loadLibrary({ url, fuzzyQuery });
     } finally {
       if (isSearchRequest) {
         setIsSearching(false);
@@ -67,9 +67,9 @@ export default function Dashboard() {
     }
   }, [loadLibrary]);
 
-  const loadComics = useCallback(async ({ force = false } = {}) => {
+  const loadComics = useCallback(async () => {
     setIsSearchActive(false); // Reset search active state
-    await fetchComicsFromApi('/api/comics', '', { force });
+    await fetchComicsFromApi('/api/comics');
   }, [fetchComicsFromApi]);
 
   const fetchFilteredComics = async (searchQuery, tagNamesArray) => {
@@ -85,9 +85,7 @@ export default function Dashboard() {
     }
 
     setIsSearchActive(!!searchQuery || (tagNamesArray && tagNamesArray.length > 0));
-    // A search always asks the server, so results never lag behind a filter the
-    // user just changed.
-    await fetchComicsFromApi(url, searchQuery, { force: true });
+    await fetchComicsFromApi(url, searchQuery);
   };
 
   useEffect(() => {
@@ -162,7 +160,7 @@ export default function Dashboard() {
         }],
       });
       
-      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current, { force: true });
+      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current);
 
       return true;
     } catch (error) {
@@ -191,7 +189,7 @@ export default function Dashboard() {
       await api.patch("/api/comics", {
         updates: comicIds.map((id) => ({ id, changes: { addTags: [tag] } })),
       });
-      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current, { force: true });
+      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current);
       toast({ title: "Tag added", description: `Added “${tag}” to ${comicIds.length} comic(s).` });
     } catch (error) {
       logger.error("Error adding a tag to selected comics:", error);
@@ -313,7 +311,7 @@ export default function Dashboard() {
       ) : error ? (
         <div className="text-center py-12">
           <p className="text-xl text-destructive mb-4">{error}</p>
-          <Button onClick={() => loadComics({ force: true })}>Try Again</Button>
+          <Button onClick={loadComics}>Try Again</Button>
         </div>
       ) : comics.length === 0 ? (
         <div className="text-center py-12">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -43,6 +43,9 @@ export default function Dashboard() {
   const { toast } = useToast();
   const lastComicsUrl = useRef('/api/comics');
   const lastSearchQuery = useRef('');
+  // Searches can overlap. Only the last one started is allowed to take the
+  // overlay down, so a quick first result cannot uncover a search still running.
+  const searchRequestId = useRef(0);
 
   // State for ShareComicModal
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
@@ -55,13 +58,18 @@ export default function Dashboard() {
     // A search keeps its own overlay over the results it is replacing; the store
     // decides between the skeleton and a quiet refresh for everything else.
     const isSearchRequest = Boolean(fuzzyQuery) || url.includes('tags=');
+    const requestId = searchRequestId.current + 1;
+    searchRequestId.current = requestId;
     if (isSearchRequest) {
       setIsSearching(true);
     }
     try {
       await loadLibrary({ url, fuzzyQuery });
     } finally {
-      if (isSearchRequest) {
+      // Any latest request may take the overlay down, not just a search: a plain
+      // reload started after a search is the one whose result is on screen, and
+      // leaving the flag to the search alone would strand the overlay.
+      if (searchRequestId.current === requestId) {
         setIsSearching(false);
       }
     }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -13,16 +13,29 @@ import { ShareComicModal } from "@/components/ShareComicModal.jsx";
 import { PendingSharesAlert } from "@/components/PendingSharesAlert.jsx";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
-import { fuzzyFilter } from "@/lib/fuzzy-search";
 import { getComicProgressState } from "@/lib/comic-progress";
+import { useComicLibrary } from "@/hooks/use-comic-library.jsx";
+
+// Covers above the fold are worth fetching eagerly; the rest can wait until
+// they are scrolled towards.
+const EAGER_COVER_COUNT = 8;
 
 export default function Dashboard() {
-  const [comics, setComics] = useState([]);
-  // searchResults will now always mirror comics state, simplifying logic.
-  // const [searchResults, setSearchResults] = useState([]); 
-  const [isLoading, setIsLoading] = useState(true);
+  // The library lives in a store, so returning from a comic re-renders the
+  // cards that are already loaded instead of clearing them and starting over.
+  const {
+    comics,
+    isLoading,
+    isRefreshing,
+    hasLoaded,
+    error,
+    loadLibrary,
+    updateComicProgress,
+    removeComicsFromLibrary,
+  } = useComicLibrary();
+  // Before the first load settles there is nothing to show but the skeleton.
+  const showSkeleton = isLoading || !hasLoaded;
   const [isSearching, setIsSearching] = useState(false); // Specific state for search operations
-  const [error, setError] = useState(null); // Added error state
   const [isSearchActive, setIsSearchActive] = useState(false);
   const [editingComic, setEditingComic] = useState(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -36,49 +49,27 @@ export default function Dashboard() {
   const [shareModalComicId, setShareModalComicId] = useState(null);
   const [shareModalComicTitle, setShareModalComicTitle] = useState(null);
 
-  const processComicsResponse = useCallback((data, fuzzyQuery = '') => {
-    const processedComics = data.comics.map(comic => ({
-      ...comic,
-      tagDetails: comic.tags || [],
-      hiddenTagNames: (comic.tags || []).filter(tag => tag.hideFromLibrary).map(tag => tag.name),
-      tags: comic.tags ? comic.tags.map(tag => tag.name) : [],
-      lastReadPage: comic.readingProgress ? comic.readingProgress.currentPage : undefined,
-    }));
-    setComics(fuzzyFilter(processedComics, fuzzyQuery, ["title", "author", "publisher", "description", "tags"]));
-    // setSearchResults(processedComics); // comics state is now the single source of truth for display
-    setError(null);
-  }, []);
-
-  const fetchComicsFromApi = useCallback(async (url, fuzzyQuery = '') => {
+  const fetchComicsFromApi = useCallback(async (url, fuzzyQuery = '', { force = false } = {}) => {
     lastComicsUrl.current = url;
     lastSearchQuery.current = fuzzyQuery;
-    // If this is a search operation, use the isSearching state instead of full isLoading
-    if (fuzzyQuery || url.includes('tags=')) {
+    // Searches show their own overlay; the store decides between the skeleton
+    // and a quiet background refresh for everything else.
+    const isSearchRequest = Boolean(fuzzyQuery) || url.includes('tags=');
+    if (isSearchRequest) {
       setIsSearching(true);
-    } else {
-      setIsLoading(true);
     }
-    setError(null);
     try {
-      const data = await api.get(url);
-      processComicsResponse(data, fuzzyQuery);
-    } catch (err) {
-      logger.error("Failed to load comics:", err);
-      const message = err.status === 429
-        ? `Search rate limit exceeded. Please wait ${err.data?.retryAfter || 60} seconds before trying again.`
-        : err.message || "Could not load comics.";
-      toast({ title: err.status === 429 ? "Rate limit exceeded" : "Error", description: message, variant: "destructive" });
-      setError(message);
-      setComics([]);
+      await loadLibrary({ url, fuzzyQuery, force });
     } finally {
-      setIsLoading(false);
-      setIsSearching(false);
+      if (isSearchRequest) {
+        setIsSearching(false);
+      }
     }
-  }, [processComicsResponse, toast]);
+  }, [loadLibrary]);
 
-  const loadComics = useCallback(async () => {
+  const loadComics = useCallback(async ({ force = false } = {}) => {
     setIsSearchActive(false); // Reset search active state
-    await fetchComicsFromApi('/api/comics');
+    await fetchComicsFromApi('/api/comics', '', { force });
   }, [fetchComicsFromApi]);
 
   const fetchFilteredComics = async (searchQuery, tagNamesArray) => {
@@ -87,16 +78,18 @@ export default function Dashboard() {
     if (tagNamesArray && tagNamesArray.length > 0) {
       queryParams.append('tags', tagNamesArray.join(','));
     }
-    
+
     const queryString = queryParams.toString();
     if (queryString) {
       url += `?${queryString}`;
     }
-    
+
     setIsSearchActive(!!searchQuery || (tagNamesArray && tagNamesArray.length > 0));
-    await fetchComicsFromApi(url, searchQuery);
+    // A search always asks the server, so results never lag behind a filter the
+    // user just changed.
+    await fetchComicsFromApi(url, searchQuery, { force: true });
   };
-  
+
   useEffect(() => {
     loadComics();
   }, [loadComics]);
@@ -139,13 +132,9 @@ export default function Dashboard() {
   const resetReadingProgress = async (comicId) => {
     try {
       await api.post(`/api/comics/${comicId}/reading-progress/reset`, {});
-      
-      // Update local state
-      const updatedComics = comics.map(c => 
-        c.id === comicId ? { ...c, lastReadPage: undefined, readingProgress: null } : c
-      );
-      setComics(updatedComics);
-      
+
+      updateComicProgress(comicId, null);
+
       return true;
     } catch (error) {
       logger.error("Error resetting reading progress:", error);
@@ -173,23 +162,21 @@ export default function Dashboard() {
         }],
       });
       
-      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current);
-      
+      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current, { force: true });
+
       return true;
     } catch (error) {
       logger.error("Error updating comic:", error);
       throw error;
     }
   };
-  
+
   const deleteComic = async (comicId, { confirmOrphaned = false } = {}) => {
     try {
       await api.delete("/api/comics", { body: { comicIds: [comicId], confirmOrphaned } });
-      
-      // Update local state
-      const updatedComics = comics.filter(c => c.id !== comicId);
-      setComics(updatedComics);
-      
+
+      removeComicsFromLibrary([comicId]);
+
       return true;
     } catch (error) {
       if (error.data?.code !== "orphaned_comics_confirmation_required") {
@@ -204,7 +191,7 @@ export default function Dashboard() {
       await api.patch("/api/comics", {
         updates: comicIds.map((id) => ({ id, changes: { addTags: [tag] } })),
       });
-      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current);
+      await fetchComicsFromApi(lastComicsUrl.current, lastSearchQuery.current, { force: true });
       toast({ title: "Tag added", description: `Added “${tag}” to ${comicIds.length} comic(s).` });
     } catch (error) {
       logger.error("Error adding a tag to selected comics:", error);
@@ -216,7 +203,7 @@ export default function Dashboard() {
   const deleteSelectedComics = async (comicIds, { confirmOrphaned = false } = {}) => {
     try {
       const result = await api.delete("/api/comics", { body: { comicIds, confirmOrphaned } });
-      setComics((currentComics) => currentComics.filter((comic) => !comicIds.includes(comic.id)));
+      removeComicsFromLibrary(comicIds);
       const orphanCount = result.orphanedComicIds?.length || 0;
       toast({
         title: "Comics deleted",
@@ -265,7 +252,14 @@ export default function Dashboard() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="flex flex-col md:flex-row justify-between items-center mb-8 gap-4">
-        <h1 className="text-3xl font-comic">My Comic Library</h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-comic">My Comic Library</h1>
+          {/* A background refresh keeps the cards it already has; this is the
+              only sign that fresher data is on its way. */}
+          {isRefreshing && (
+            <span className="text-sm text-muted-foreground" role="status">Refreshing…</span>
+          )}
+        </div>
         <div className="flex flex-wrap items-center justify-center gap-2">
           <div className="flex rounded-md border p-1" aria-label="Library view">
             <Button variant={viewMode === "grid" ? "secondary" : "ghost"} size="sm" onClick={() => setViewMode("grid")} aria-pressed={viewMode === "grid"}>
@@ -292,7 +286,7 @@ export default function Dashboard() {
       <PendingSharesAlert />
 
       {/* Loading overlay for search operations */}
-      {isSearching && !isLoading && (
+      {isSearching && !showSkeleton && (
         <div className="fixed inset-0 bg-background/50 backdrop-blur-sm z-50 flex items-center justify-center pointer-events-none">
           <div className="bg-card p-6 rounded-lg shadow-lg flex items-center space-x-4 border">
             <svg className="animate-spin h-8 w-8 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -304,7 +298,7 @@ export default function Dashboard() {
         </div>
       )}
       
-      {isLoading ? (
+      {showSkeleton ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
           {[...Array(6)].map((_, i) => (
             <div key={i} className="comic-card animate-pulse">
@@ -319,7 +313,7 @@ export default function Dashboard() {
       ) : error ? (
         <div className="text-center py-12">
           <p className="text-xl text-destructive mb-4">{error}</p>
-          <Button onClick={loadComics}>Try Again</Button>
+          <Button onClick={() => loadComics({ force: true })}>Try Again</Button>
         </div>
       ) : comics.length === 0 ? (
         <div className="text-center py-12">
@@ -369,10 +363,11 @@ export default function Dashboard() {
                 </div>
               )}
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-                {items.map((comic) => (
+                {items.map((comic, index) => (
                   <ComicCard
                     key={comic.id}
                     comic={comic}
+                    coverPriority={index < EAGER_COVER_COUNT}
                     onResetProgress={resetReadingProgress}
                     onEditComic={handleEditComic}
                     onDeleteComic={deleteComic}


### PR DESCRIPTION
Closes #57.

Returning from the reader unmounted `Dashboard`, refetched `/api/comics` from an empty state and rebuilt every `ComicCard`, so each cover was requested again and the cards sat grey until the images came back.

## Backend

- **Cover responses are now cacheable.** `private, max-age=31536000, immutable`, plus `ETag` and `Last-Modified`, and conditional requests answered with `304`. The stored cover filename carries a `uniqid`, so a cover URL can never change content — regenerating a cover produces a new URL and the old immutable entry is simply never asked for again.
- The response also opts out of Symfony's session auto-cache-control (`Symfony-Session-NoAutoCacheControl`). Without it, `AbstractSessionListener` rewrites `Cache-Control` on every response whose request touched the session — which is every authenticated request — and the whole policy would have been silently discarded.
- **The placeholder gets a deliberately weaker policy**: 300s and no `immutable`. It answers a comic's *un-versioned* cover URL when the file is missing, so pinning that answer for a year would leave a comic that regains its cover file showing the placeholder. It still gets an ETag, so repeat views are a cheap `304`. This is the one place the implementation departs from the plan in the issue, which asked for equivalent headers.
- **Tags and owners are batch-loaded** when serializing a library instead of lazy-loading per comic. Reading progress was already batched.

Cover access remains authenticated, and the ownership checks are untouched.

## Frontend

- **`ComicLibraryProvider`** holds the comic list outside `Dashboard`, so navigating into a comic and back re-renders the cards that are already there instead of clearing them. Every visit still refetches — nothing is skipped, so an upload or an edit made elsewhere is never missed — but the fetch happens behind the cards rather than in place of them. A refresh that fails keeps what is on screen rather than replacing it with an error page.
- **`ComicReader` writes the saved reading position back into the store**, so the page number on the card is correct the moment you return, without waiting for another `/api/comics`.
- **`ComicCard`**: `decoding="async"`, the first row of covers loads eagerly and the rest lazily, and a genuine first load fades in instead of snapping.

The store holds comic metadata and reading progress only. Cover bytes stay with the browser's own HTTP cache, which already handles memory, disk, revalidation and eviction — a second hand-rolled image cache would need its own invalidation and size limits for no gain.

## Measurements

Through the real nginx stack with a real session, a cover comes back with the full policy intact and both revalidation forms return **304 with 0 bytes**. The cover measured is 1,067,693 bytes, previously re-fetched on every return to the library.

Library endpoint with 100 comics, measured in the isolated test database:

| | queries | time |
|---|---|---|
| before | 103 | 140.4 ms |
| after | **4** | **72.8 ms** |

The time roughly halves locally where the database is one container away; on a deployment with real latency to the database, 4 round-trips instead of 103 matters considerably more.

## Tests

- `ComicCoverSecurityTest` — cache headers, both conditional-request forms, placeholder policy, filename mismatch, and the existing ownership cases.
- `ComicLibraryQueryTest` — a guard asserting the library endpoint costs the same number of queries for 2 comics as for 6. Verified to actually bite: removing the batching makes it fail 9 vs 5.
- `comic-library.test.js` — the store's pure helpers.

Backend 121 tests / 320 assertions, frontend 27 tests, lint clean, production build succeeds.

## Not verified

The in-browser feel of returning from the reader was not observed directly — there's no browser automation in the environment I built this in. That the cards stay on screen rests on the store logic and its unit tests. Worth a manual click-through before merging.

## Review notes

The second commit is a self-review pass that fixed three things worth calling out:

1. A 30-second stale window meant a comic uploaded and returned to within that window was missing from the library. The staleness concept is gone entirely, along with the `force` flag it needed.
2. Resetting the store on any user change was unsafe: effects run child-first, so a reset driven by the login transition could fire *after* `Dashboard` had started loading, invalidate that in-flight request and strand the page on a permanent skeleton. It now resets only on logout, when no protected page is mounted.
3. Searching had lost its old behaviour of keeping results visible under the overlay. Restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared comic-library state across navigation.
  - Added page-number navigation, Home/End controls, progress display, and search keyboard shortcuts.
  - Added background refresh indicators and immediate reading-progress updates.
  - Improved cover loading with prioritization, lazy loading, fade-ins, and fallbacks.

- **Performance**
  - Improved comic-list loading and browser caching for pages and covers.
  - Added conditional caching to reduce unnecessary downloads.

- **Bug Fixes**
  - Invalid cover filenames are rejected.
  - Reader progress and page navigation handle invalid input safely.
  - Failed refreshes preserve currently displayed comics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->