### PR TITLE
feat: explicit-content classification and 18+ gate for comic sharing (#62)

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -291,6 +291,14 @@ the rest because it is the key to every endpoint that serves a cover, a page or
 an archive. The invitation email names no explicit comic either — an inbox is
 previewed on lock screens and read by scanners.
 
+`GET /api/shares/invitations/{token}` needs **both** halves before it reveals
+anything: the caller must be identified as the recipient *and* that share must
+carry a confirmation. An age declaration is made by one person about themselves,
+so it is not a property of the link and cannot unlock the link — this endpoint is
+public, and a forwarded email, a scanner or a proxy log holds the same token the
+recipient does. It also withholds `adultConfirmed` from everyone else, because
+whether the invited person has declared their age is a fact about them.
+
 The client shows a neutral placeholder, never the real cover blurred: blurring
 still sends the bytes, and the point of the gate is that they do not leave the
 server.

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -38,7 +38,7 @@ This document provides detailed information for developers working on the projec
 
 #### ✅ Comic Sharing System
 - **ComicShare Entity**: Defined in `ComicShare.php`. A durable, revocable grant of read access to the owner's single copy — sharing never creates a second `Comic` row or a second file
-- **ShareInvitationToken Entity**: Defined in `ShareInvitationToken.php`. Only a SHA-256 hash of each invitation link is stored; resending mints a new token and retires the old link
+- **ShareInvitationToken Entity**: Defined in `ShareInvitationToken.php`. Only a SHA-256 hash of each invitation link is stored. One link per invitation, good for a single claim within two months; accepting spends it and revokes every other token for that share, and resending mints a new one and retires the old link
 - **ComicVoter**: `Security/Voter/ComicVoter.php` answers `COMIC_VIEW`, `COMIC_EDIT`, `COMIC_DELETE` and `COMIC_SHARE` for every endpoint that touches a comic
 - **Share Controller**: `ShareController.php` under `/api/shares` — invite, resend, revoke, stop sharing, preview, accept, decline, remove, restore and tombstone cleanup
 - **Tombstones**: Deleting a comic nulls the relationship and records `unavailableAt` plus a `tombstoneReason`, so recipients are told why a comic disappeared. They are recipient-only — the owner caused the deletion, has no comic left to manage, and the comic leaves their sharing list entirely
@@ -181,6 +181,29 @@ already been accepted survives both.
 A raw 256-bit token needs no work factor: there is no dictionary to slow an
 attacker down through.
 
+##### One link, one claim
+
+`isUsable()` is the whole rule: unused, unrevoked, and not past `expiresAt`.
+Every way a share can move on retires the links it had — accepting spends the one
+that was used and revokes the rest, and declining, revoking, stopping sharing,
+resending and tombstoning all revoke outstanding tokens. So a claimed link is
+dead for *every* purpose afterwards, not only for the one that claimed it:
+previewing, accepting, declining and confirming an age all resolve the same
+token and all refuse.
+
+**Previewing deliberately does not spend it.** Mail scanners, corporate link
+checkers and preview bots follow links without a person behind them, so a token
+that burned on a `GET` would be dead before the recipient ever saw it. That is
+why the link is not what keeps anyone out: it only ever previews. Accepting
+requires signing in as the intended recipient, and for an explicit comic the
+preview reveals nothing to a link holder at all.
+
+`INVITATION_TTL` is **two months**, and one constant sets both the token's expiry
+and the pending share's, so a link and the invitation behind it can never
+disagree about whether they are still live. Two months because answering is not
+always quick — the recipient may have no account here yet — against the cost that
+an escaped link stays live longer.
+
 ### Permissions
 
 `ComicVoter` is the single place that decides access. Every endpoint serving any
@@ -222,15 +245,19 @@ invitation is issued, so a request rejected as a duplicate, by permissions, or
 by validation does not spend it.
 
 #### Answering
-1. The email carries a single **Review invitation** link
-2. `GET /api/shares/invitations/{token}` returns cover, title, author, page
-   count, sender and expiry, and changes nothing — mail scanners and
+1. The email carries a single **Review invitation** link, good for one claim
+   within two months
+2. `GET /api/shares/invitations/{token}` returns sender and expiry — plus cover,
+   title, author and page count for a comic that is not classified 18+ — and
+   changes nothing. It does not spend the token, because mail scanners and
    link-preview services follow links without a person behind them
 3. `POST .../accept` or `.../decline` requires a button press. A signed-in
    recipient can also answer from `/sharing` without the token, since they have
    already identified themselves more strongly than the token could
-4. Accepting sets the status, spends every outstanding token, and the comic
-   appears in the recipient's normal collection
+4. Accepting sets the status, **spends the link and revokes every other
+   outstanding token for that share**, and the comic appears in the recipient's
+   normal collection. From then on the link refuses every use — preview, accept,
+   decline and age confirmation alike
 
 #### Losing access
 - **Revoke one recipient** (`POST /api/shares/{id}/revoke`) or **stop sharing

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -143,8 +143,14 @@ the row, enforced by a unique index on `(comic_id, recipient_email_normalized)`.
   access is untouched and restoring it is one click
 - **expiresAt**: bounds an unanswered invitation. Cleared on acceptance — access
   does not expire, only the invitation did
-- **comicTitleSnapshot / comicAuthorSnapshot / ownerNameSnapshot**: refreshed
-  whenever an invitation is issued, so a tombstone can still name what it was
+- **comicTitleSnapshot / comicAuthorSnapshot / ownerNameSnapshot /
+  explicitContentSnapshot**: refreshed whenever an invitation is issued, so a
+  tombstone can still name what it was — and still know that what it names was
+  18+, which is why deleting a comic cannot leak the title an unconfirmed age
+  gate was holding back
+- **senderResponsibilityAcceptedAt / adultConfirmedAt**: the two acknowledgements
+  this relationship records, both server-generated. See
+  [Explicit content and the 18+ gate](#explicit-content-and-the-18-gate)
 - **unavailableAt / tombstoneReason**: `owner_deleted`, `owner_account_deleted`,
   `file_missing` or `administratively_removed`
 
@@ -183,7 +189,7 @@ same question.
 
 | Action | Owner | Admin | Accepted recipient |
 |---|---|---|---|
-| `COMIC_VIEW` (read, cover, pages, own progress) | Yes | Yes | Yes |
+| `COMIC_VIEW` (read, cover, pages, own progress) | Yes | Yes | Yes, once any 18+ gate is passed |
 | `COMIC_EDIT` | Yes | Yes | No |
 | `COMIC_DELETE` | Yes | Yes | No |
 | `COMIC_SHARE` | Yes | No | No |
@@ -196,7 +202,9 @@ permanent second copy the model exists to avoid.
 ### Sharing Workflow
 
 #### Inviting
-1. The owner enters a recipient email in `ShareComicModal`
+1. The owner enters a recipient email in `ShareComicModal` and ticks
+   **I understand** against the responsibility notice — unticked every time the
+   modal opens, and required before **Send invitation** is live
 2. `POST /api/shares/comics/{comicId}/invitations` creates or reopens the
    `ComicShare`, mints a token and emails the link — all one unit of work, so a
    send that fails rolls the invitation back rather than showing the owner a
@@ -242,6 +250,79 @@ by validation does not spend it.
 - **Remove all dead shares** (`DELETE /api/shares/tombstones`) clears tombstones
   and other dead ends, individually or in bulk, and never touches a live share.
   The confirmation states the count
+
+### Explicit content and the 18+ gate
+
+> A comic is 18+ because its owner said so. Nothing else says so on their behalf.
+
+`Comic.explicitContent` is a deliberate, comic-level classification, independent
+of every tag — including the library-hiding ones. Hiding a comic from your own
+library is a shelving preference and says nothing about what is inside it, so
+inferring an age rating from it would put an 18+ warning on a comic somebody
+merely wanted out of the way. Imports and uploads start non-explicit, existing
+comics migrated as non-explicit, and tag edits never touch the flag.
+
+#### The two acknowledgements
+
+Both live on the same `ComicShare` row, so one record is the whole audit trail
+for one sharing relationship. Neither timestamp is ever read from the request —
+an audit trail the audited party can write is not one.
+
+| Field | Written when | Required |
+|---|---|---|
+| `senderResponsibilityAcceptedAt` | the invitation is created | every new share |
+| `adultConfirmedAt` | the recipient declares they are 18+ | explicit comics only |
+
+`POST /api/shares/comics/{comicId}/invitations` rejects a body whose
+`senderResponsibilityAccepted` is not literally `true`, with
+`400 share_responsibility_acknowledgement_required`. Resending preserves both
+timestamps — it is the same relationship reaching the same person. Re-inviting
+somebody after a decline, revoke or lapse reuses the row but takes a fresh
+sender acknowledgement and clears any age declaration: that is a new offer of
+the comic as it is now.
+
+#### What an unconfirmed recipient may see
+
+Nothing that identifies the comic. Pending-share, invitation-preview and
+recipient serializers all return `null` for `comicId`, `comicTitle`,
+`comicAuthor`, `pageCount` and `coverImagePath`, alongside `explicitContent`,
+`requiresAdultConfirmation` and `adultConfirmed`. The comic id is redacted with
+the rest because it is the key to every endpoint that serves a cover, a page or
+an archive. The invitation email names no explicit comic either — an inbox is
+previewed on lock screens and read by scanners.
+
+The client shows a neutral placeholder, never the real cover blurred: blurring
+still sends the bytes, and the point of the gate is that they do not leave the
+server.
+
+#### Where the gate is enforced
+
+`ComicShareRepository::readableQueryBuilder()` is the single definition of "a
+share that lets this user read this comic", and it requires
+`explicitContent = false OR adultConfirmedAt IS NOT NULL`. `findAccessFor()`,
+`findAccessIndexedByComic()` and `findVisibleCollectionShares()` all build on
+it, so `COMIC_VIEW` answers no for an unconfirmed explicit share — and with it
+the metadata, cover, page and progress endpoints, not merely the screen that
+asks the question. `ComicShareService::accept()` and `acceptShare()` refuse
+separately, with `403 adult_confirmation_required`, so a direct API call cannot
+put an unconfirmed explicit comic into somebody's collection.
+
+`POST /api/shares/{id}/confirm-adult` and
+`POST /api/shares/invitations/{token}/confirm-adult` record the declaration for
+the intended, authenticated recipient. They are idempotent: a repeat keeps the
+original timestamp, because confirming twice is a retry and not a new
+declaration. Declining never requires confirming.
+
+#### Re-gating
+
+Marking an already-shared comic explicit **fails closed**: every live share loses
+its `adultConfirmedAt` in the same unit of work as the reclassification. Those
+recipients agreed to read something that was not classified 18+, and an old
+silence is not a declaration about the comic as it is now. The relationship, its
+status and the recipient's place in their own collection all survive — reading
+stops, the share does not — and one confirmation restores it. Unmarking the
+comic restores access immediately, because there is no longer anything to
+confirm about.
 
 #### Cleanup Process
 `app:cleanup-expired-shares` deletes pending invitations whose expiry has passed.
@@ -794,6 +875,41 @@ Test users are created for development and testing purposes. Their credentials a
 - Admin user: `testadmin@example.com` with password `AdminPass123!`
 - Regular user: `testuser1@example.com` with password `UserPass123!`
 - Regular user: `testuser2@example.com` with password `UserPass123!`
+
+### Automated Test Suites
+
+```sh
+# Backend — PHPUnit, needs the database container up
+docker compose exec php php vendor/bin/phpunit
+
+# Frontend — Vitest
+cd frontend && npm test
+```
+
+The frontend suite is split into two Vitest projects, by file extension, because
+the two kinds of test genuinely differ:
+
+| Pattern | Project | Environment | For |
+|---|---|---|---|
+| `src/**/*.test.js` | `unit` | `node` | pure logic — helpers, classification and wording rules |
+| `src/**/*.test.jsx` | `dom` | `jsdom` | a rendered component, driven through Testing Library |
+
+Standing a DOM up for the helper tests would cost seconds per file to give them
+something none of them touch, so the extension decides. `src/test/setup.js` runs
+for the `dom` project only. It registers `@testing-library/jest-dom`, unmounts
+between tests — auto-cleanup does not register itself while Vitest's globals are
+off, and they deliberately are — and stubs the browser APIs Radix calls during a
+normal mount that jsdom does not implement: `matchMedia`, `ResizeObserver`,
+`IntersectionObserver`, `scrollIntoView` and the pointer-capture methods. Without
+them a dialog or checkbox throws before a single assertion runs, and the failure
+reads like a bug in the component rather than a gap in the environment.
+
+Component tests mock the modules at the edges — `@/lib/api`, the toast, auth,
+sharing and library hooks — and render the real component with the real UI
+primitives, so what is asserted is what a user would see. Copy is asserted
+against the constants exported from `lib/sharing.js` rather than against
+paraphrases, which is what stops the responsibility notice or the 18+ warning
+being watered down in a component without a test noticing.
 
 ### Testing Commands
 You can test the current implementation using the following commands:

--- a/backend/migrations/Version20260807160000.php
+++ b/backend/migrations/Version20260807160000.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Explicit-content classification, and the two acknowledgements a share records.
+ *
+ * The comic-level flag is what an 18+ warning is derived from — never a tag, and
+ * never the library-hiding preference, which says nothing about content. Both
+ * acknowledgements live on the share itself so one row is the whole audit trail
+ * for one sharing relationship: the sender accepting responsibility, and the
+ * recipient declaring their age where the comic requires it.
+ */
+final class Version20260807160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the explicit-content flag and the sender/recipient share acknowledgements.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Existing comics are non-explicit: nobody has been asked yet, and
+        // guessing an age rating for somebody else's library is exactly what
+        // this feature exists to stop.
+        $this->addSql('ALTER TABLE comic ADD explicit_content TINYINT(1) DEFAULT 0 NOT NULL');
+
+        // Nullable for history. Shares created before this existed have no
+        // acknowledgement to record and must not pretend otherwise; every share
+        // created from now on gets a server-generated timestamp.
+        // The snapshot joins the title and author ones already kept here, so a
+        // tombstone can still tell that what it describes was 18+ after the
+        // comic that would have answered is gone.
+        $this->addSql(
+            'ALTER TABLE comic_share
+                ADD sender_responsibility_accepted_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+                ADD adult_confirmed_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+                ADD explicit_content_snapshot TINYINT(1) DEFAULT 0 NOT NULL'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comic DROP explicit_content');
+        $this->addSql(
+            'ALTER TABLE comic_share
+                DROP sender_responsibility_accepted_at,
+                DROP adult_confirmed_at,
+                DROP explicit_content_snapshot'
+        );
+    }
+}

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -264,8 +264,11 @@ class ComicController extends AbstractController
     }
 
     #[Route('', name: 'batch_update', methods: ['PATCH'])]
-    public function batchUpdate(Request $request, EntityManagerInterface $entityManager): JsonResponse
-    {
+    public function batchUpdate(
+        Request $request,
+        EntityManagerInterface $entityManager,
+        ComicShareService $shareService
+    ): JsonResponse {
         $user = $this->getUser();
         if (!$user instanceof User) {
             return $this->json(['message' => 'User not authenticated'], Response::HTTP_UNAUTHORIZED);
@@ -323,6 +326,18 @@ class ComicController extends AbstractController
                 if (array_key_exists($field, $changes)) {
                     $setter = 'set' . ucfirst($field);
                     $comic->{$setter}($changes[$field]);
+                }
+            }
+
+            if (array_key_exists('explicitContent', $changes)) {
+                $wasExplicit = $comic->isExplicitContent();
+                $comic->setExplicitContent($changes['explicitContent']);
+
+                // Same rule as the single-comic update: newly explicit means
+                // every live share loses its confirmation and the recipient has
+                // to make the declaration again.
+                if (!$wasExplicit && $changes['explicitContent']) {
+                    $shareService->regateSharesForComic($comic);
                 }
             }
 
@@ -516,7 +531,8 @@ class ComicController extends AbstractController
         int $id,
         Request $request,
         EntityManagerInterface $entityManager,
-        AdminAuditService $auditService
+        AdminAuditService $auditService,
+        ComicShareService $shareService
     ): JsonResponse {
         // Get the current user
         $user = $this->getUser();
@@ -546,6 +562,7 @@ class ComicController extends AbstractController
             'author' => $comic->getAuthor(),
             'publisher' => $comic->getPublisher(),
             'description' => $comic->getDescription(),
+            'explicitContent' => $comic->isExplicitContent(),
         ];
         $tagOwner = $comic->getOwner() ?? $user;
 
@@ -564,6 +581,12 @@ class ComicController extends AbstractController
 
         if (isset($data['description'])) {
             $comic->setDescription($data['description']);
+        }
+
+        // array_key_exists rather than isset, so unticking the box — an explicit
+        // false — is a change the same way ticking it is.
+        if (array_key_exists('explicitContent', $data ?? []) && is_bool($data['explicitContent'])) {
+            $comic->setExplicitContent($data['explicitContent']);
         }
 
         // Update tags if provided
@@ -596,6 +619,15 @@ class ComicController extends AbstractController
             }
         }
 
+        // Newly explicit: everyone who is already reading it agreed to something
+        // that was not classified 18+, so the gate closes on them until they say
+        // otherwise. Done before the flush so the re-gate and the reclassification
+        // land together — a crash between the two would leave recipients reading
+        // a comic nobody had confirmed for.
+        if (!$metadataBefore['explicitContent'] && $comic->isExplicitContent()) {
+            $shareService->regateSharesForComic($comic);
+        }
+
         if (in_array('ROLE_ADMIN', $user->getRoles(), true) && $comic->getOwner()?->getId() !== $user->getId()) {
             $auditService->log($user, 'comic_update', 'comic', $comic->getId(), [
                 'ownerId' => $comic->getOwner()?->getId(),
@@ -605,6 +637,7 @@ class ComicController extends AbstractController
                     'author' => $comic->getAuthor(),
                     'publisher' => $comic->getPublisher(),
                     'description' => $comic->getDescription(),
+                    'explicitContent' => $comic->isExplicitContent(),
                 ],
             ]);
         }
@@ -1404,8 +1437,15 @@ class ComicController extends AbstractController
                 return [];
             }
 
-            $allowedFields = ['title', 'author', 'publisher', 'description', 'tags', 'addTags'];
+            $allowedFields = ['title', 'author', 'publisher', 'description', 'tags', 'addTags', 'explicitContent'];
             if (array_diff(array_keys($changes), $allowedFields) !== []) {
+                return [];
+            }
+
+            // A classification is a yes or a no. Anything else — "true", 1, null
+            // — is a client that has not decided, and guessing which way it
+            // meant is not this endpoint's job.
+            if (array_key_exists('explicitContent', $changes) && !is_bool($changes['explicitContent'])) {
                 return [];
             }
 

--- a/backend/src/Controller/ComicController.php
+++ b/backend/src/Controller/ComicController.php
@@ -200,10 +200,7 @@ class ComicController extends AbstractController
 
             $sharedComicIds = $ownership === 'mine'
                 ? []
-                : array_values(array_filter(array_map(
-                    static fn (ComicShare $share): ?int => $share->getComic()?->getId(),
-                    $this->shareRepository->findVisibleCollectionShares($user)
-                )));
+                : $this->shareRepository->findVisibleCollectionComicIds($user);
 
             if ($ownership === 'shared') {
                 // An empty IN () is not valid DQL, and a user with no shares
@@ -584,8 +581,10 @@ class ComicController extends AbstractController
         }
 
         // array_key_exists rather than isset, so unticking the box — an explicit
-        // false — is a change the same way ticking it is.
-        if (array_key_exists('explicitContent', $data ?? []) && is_bool($data['explicitContent'])) {
+        // false — is a change the same way ticking it is. Guarded on is_array
+        // because a valid JSON scalar body ("5") decodes without error and
+        // array_key_exists would fatal on it.
+        if (is_array($data) && array_key_exists('explicitContent', $data) && is_bool($data['explicitContent'])) {
             $comic->setExplicitContent($data['explicitContent']);
         }
 

--- a/backend/src/Controller/ShareController.php
+++ b/backend/src/Controller/ShareController.php
@@ -65,6 +65,7 @@ class ShareController extends AbstractController
                 'title' => $comic->getTitle(),
                 'author' => $comic->getAuthor(),
                 'coverImagePath' => $this->comicSerializer->coverUrl($comic),
+                'explicitContent' => $comic->isExplicitContent(),
                 'recipients' => [],
             ];
 
@@ -126,9 +127,17 @@ class ShareController extends AbstractController
         }
 
         try {
-            $invitation = $this->shareService->invite($comic, $user, $email);
+            $invitation = $this->shareService->invite(
+                $comic,
+                $user,
+                $email,
+                // Strictly true: a missing key, a string "true" or anything else
+                // truthy is not somebody having read the notice and ticked the
+                // box, and this timestamp is meant to record that they did.
+                (is_array($data) ? ($data['senderResponsibilityAccepted'] ?? null) : null) === true
+            );
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json([
@@ -152,7 +161,7 @@ class ShareController extends AbstractController
         try {
             $invitation = $this->shareService->resend($share);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json([
@@ -215,7 +224,7 @@ class ShareController extends AbstractController
         try {
             $invitation = $this->shareService->resolveInvitation($token);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         $share = $invitation->getComicShare();
@@ -225,24 +234,111 @@ class ShareController extends AbstractController
         // Only what the invitation is *about* goes out unconditionally; the
         // cover and the recipient's own address are gated on identity.
         $isForCurrentUser = $this->isRecipient($share, $user);
+        // Holding the token is not an age declaration, and it cannot be: nobody
+        // has identified themselves yet. So an explicit invitation describes
+        // itself and nothing else until the person it was sent to signs in and
+        // says they are 18 or older.
+        $redact = $share->requiresAdultConfirmation();
 
         return $this->json([
             'invitation' => [
-                'comicTitle' => $comic?->getTitle() ?? $share->getComicTitleSnapshot(),
-                'comicAuthor' => $comic?->getAuthor() ?? $share->getComicAuthorSnapshot(),
-                'pageCount' => $comic?->getPageCount(),
+                'comicTitle' => $redact ? null : ($comic?->getTitle() ?? $share->getComicTitleSnapshot()),
+                'comicAuthor' => $redact ? null : ($comic?->getAuthor() ?? $share->getComicAuthorSnapshot()),
+                'pageCount' => $redact ? null : $comic?->getPageCount(),
                 'ownerName' => $share->getOwnerNameSnapshot(),
                 // The intended recipient learns nothing from this — it is their
                 // own address — so withholding it costs them nothing and stops
                 // the link from disclosing who was invited.
                 'recipientEmail' => $isForCurrentUser ? $share->getRecipientEmailNormalized() : null,
                 'expiresAt' => $invitation->getExpiresAt()->format('c'),
-                'coverImagePath' => $comic && $isForCurrentUser
+                'coverImagePath' => $comic && $isForCurrentUser && !$redact
                     ? $this->comicSerializer->coverUrl($comic)
                     : null,
                 'isForCurrentUser' => $isForCurrentUser,
+                'explicitContent' => $share->isExplicitContent(),
+                'requiresAdultConfirmation' => $redact,
+                'adultConfirmed' => $share->getAdultConfirmedAt() !== null,
             ],
         ]);
+    }
+
+    /**
+     * Record the recipient's declaration that they are 18 or older, from an
+     * emailed invitation link.
+     *
+     * A POST because it writes, and because a GET would be followed by the same
+     * mail scanners the preview is careful about — making an age declaration
+     * something a link preview could make on somebody's behalf.
+     */
+    #[Route('/invitations/{token}/confirm-adult', name: 'app_shares_invitation_confirm_adult', methods: ['POST'])]
+    public function confirmAdultForInvitation(string $token, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!$this->isAdultConfirmed($request)) {
+            return $this->json([
+                'message' => 'You must confirm that you are 18 or older to access this shared comic.',
+                'code' => ShareException::CODE_ADULT_CONFIRMATION_REQUIRED,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $invitation = $this->shareService->resolveInvitation($token);
+            $share = $this->shareService->confirmAdult($invitation->getComicShare(), $user);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json([
+            'message' => 'Age confirmed.',
+            // Freshly serialized, so the caller gets the now-unlocked view back
+            // from the same request that unlocked it.
+            'share' => $this->shareSerializer->forRecipient($share),
+        ]);
+    }
+
+    /** The same declaration, made from the Sharing page rather than a link. */
+    #[Route('/{id}/confirm-adult', name: 'app_shares_confirm_adult', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function confirmAdultForShare(int $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $share = $this->findReceivedShare($id, $user);
+        if ($share instanceof JsonResponse) {
+            return $share;
+        }
+
+        if (!$this->isAdultConfirmed($request)) {
+            return $this->json([
+                'message' => 'You must confirm that you are 18 or older to access this shared comic.',
+                'code' => ShareException::CODE_ADULT_CONFIRMATION_REQUIRED,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $this->shareService->confirmAdult($share, $user);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json([
+            'message' => 'Age confirmed.',
+            'share' => $this->shareSerializer->forRecipient($share),
+        ]);
+    }
+
+    /**
+     * Whether the request carries the declaration itself.
+     *
+     * Only the boolean is read. The moment it was made is the server's to
+     * record, because a timestamp the declaring party can choose is not
+     * evidence of anything.
+     */
+    private function isAdultConfirmed(Request $request): bool
+    {
+        $data = json_decode($request->getContent(), true);
+
+        return is_array($data) && ($data['adultConfirmed'] ?? null) === true;
     }
 
     #[Route('/invitations/{token}/accept', name: 'app_shares_invitation_accept', methods: ['POST'])]
@@ -256,7 +352,7 @@ class ShareController extends AbstractController
             $invitation = $this->shareService->resolveInvitation($token);
             $share = $this->shareService->accept($invitation, $user);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json([
@@ -276,7 +372,7 @@ class ShareController extends AbstractController
             $invitation = $this->shareService->resolveInvitation($token);
             $this->shareService->decline($invitation, $user);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json(['message' => 'Invitation declined.']);
@@ -300,7 +396,7 @@ class ShareController extends AbstractController
         try {
             $this->shareService->acceptShare($share, $user);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json([
@@ -320,7 +416,7 @@ class ShareController extends AbstractController
         try {
             $this->shareService->declineShare($share, $user);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json(['message' => 'Invitation declined.']);
@@ -338,7 +434,7 @@ class ShareController extends AbstractController
         try {
             $this->shareService->removeFromCollection($share);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json([
@@ -358,7 +454,7 @@ class ShareController extends AbstractController
         try {
             $this->shareService->restoreToCollection($share);
         } catch (ShareException $exception) {
-            return $this->json(['message' => $exception->getMessage()], $exception->getStatusCode());
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
         }
 
         return $this->json([

--- a/backend/src/Controller/ShareController.php
+++ b/backend/src/Controller/ShareController.php
@@ -234,11 +234,18 @@ class ShareController extends AbstractController
         // Only what the invitation is *about* goes out unconditionally; the
         // cover and the recipient's own address are gated on identity.
         $isForCurrentUser = $this->isRecipient($share, $user);
-        // Holding the token is not an age declaration, and it cannot be: nobody
-        // has identified themselves yet. So an explicit invitation describes
-        // itself and nothing else until the person it was sent to signs in and
-        // says they are 18 or older.
-        $redact = $share->requiresAdultConfirmation();
+
+        // An age declaration is made by one person about themselves. It is not
+        // a property of the link, so it cannot unlock the link.
+        //
+        // Both halves are needed. Confirming is what opens the gate, but only
+        // for whoever confirmed: this endpoint is public, and a forwarded email,
+        // a scanner or a proxy log holds the same token the recipient does. So
+        // an explicit invitation stays shut for everybody the server cannot
+        // identify as the recipient, however many times the recipient has
+        // confirmed.
+        $redact = $share->isExplicitContent()
+            && !($isForCurrentUser && $share->getAdultConfirmedAt() !== null);
 
         return $this->json([
             'invitation' => [
@@ -256,8 +263,12 @@ class ShareController extends AbstractController
                     : null,
                 'isForCurrentUser' => $isForCurrentUser,
                 'explicitContent' => $share->isExplicitContent(),
+                // Phrased for whoever is asking: "you must confirm to see this".
                 'requiresAdultConfirmation' => $redact,
-                'adultConfirmed' => $share->getAdultConfirmedAt() !== null,
+                // Withheld from everyone else, because whether the invited
+                // person has declared their age is a fact about them, and a
+                // link holder is not entitled to it.
+                'adultConfirmed' => $isForCurrentUser && $share->getAdultConfirmedAt() !== null,
             ],
         ]);
     }

--- a/backend/src/Entity/Comic.php
+++ b/backend/src/Entity/Comic.php
@@ -71,6 +71,18 @@ class Comic
     #[ORM\Column(length: 500, nullable: true)]
     private ?string $dropboxPath = null;
 
+    /**
+     * The owner's declaration that this comic contains adult material.
+     *
+     * Deliberately independent of every tag, including the ones that hide a
+     * comic from the library: hiding is a shelving preference and says nothing
+     * about content, so inferring an age rating from it would put an 18+ warning
+     * on a comic somebody merely wanted out of the way. Only the owner ticking
+     * the box sets this.
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $explicitContent = false;
+
     public function __construct()
     {
         $this->uploadedAt = new \DateTimeImmutable();
@@ -244,6 +256,18 @@ class Comic
     public function setDropboxPath(?string $dropboxPath): static
     {
         $this->dropboxPath = $dropboxPath;
+
+        return $this;
+    }
+
+    public function isExplicitContent(): bool
+    {
+        return $this->explicitContent;
+    }
+
+    public function setExplicitContent(bool $explicitContent): static
+    {
+        $this->explicitContent = $explicitContent;
 
         return $this;
     }

--- a/backend/src/Entity/ComicShare.php
+++ b/backend/src/Entity/ComicShare.php
@@ -111,6 +111,37 @@ class ComicShare
     #[ORM\Column(length: 255)]
     private string $ownerNameSnapshot = '';
 
+    /**
+     * Whether the comic was marked explicit when the snapshots were last taken.
+     *
+     * Kept alongside the title snapshot because a tombstone outlives the comic
+     * that would otherwise answer the question — and the title it preserves is
+     * exactly the identifying detail an unconfirmed age gate is holding back.
+     * Deleting the comic must not be the way that title gets out.
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $explicitContentSnapshot = false;
+
+    /**
+     * When the sender accepted responsibility for what they were sharing.
+     *
+     * Per share rather than per account: the acknowledgement is about this
+     * comic going to this person, so a blanket "I understand" ticked once a year
+     * ago would not be a record of anything. Null only on shares created before
+     * the acknowledgement existed.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $senderResponsibilityAcceptedAt = null;
+
+    /**
+     * When the recipient declared they are 18 or older, for a comic the owner
+     * marked explicit. Null means the gate is still closed, which is the state
+     * an explicit share starts in and returns to whenever the comic is newly
+     * marked explicit.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $adultConfirmedAt = null;
+
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?\DateTimeImmutable $unavailableAt = null;
 
@@ -152,6 +183,7 @@ class ComicShare
         if ($this->comic !== null) {
             $this->comicTitleSnapshot = (string) $this->comic->getTitle();
             $this->comicAuthorSnapshot = $this->comic->getAuthor();
+            $this->explicitContentSnapshot = $this->comic->isExplicitContent();
         }
 
         if ($this->owner !== null) {
@@ -269,6 +301,78 @@ class ComicShare
     public function getOwnerNameSnapshot(): string
     {
         return $this->ownerNameSnapshot;
+    }
+
+    public function getSenderResponsibilityAcceptedAt(): ?\DateTimeImmutable
+    {
+        return $this->senderResponsibilityAcceptedAt;
+    }
+
+    /**
+     * Record the sender's acknowledgement, now.
+     *
+     * The timestamp is taken here and never read off the request: an audit trail
+     * the audited party can write is not one.
+     */
+    public function acceptSenderResponsibility(): self
+    {
+        $this->senderResponsibilityAcceptedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    public function getAdultConfirmedAt(): ?\DateTimeImmutable
+    {
+        return $this->adultConfirmedAt;
+    }
+
+    /**
+     * Record the recipient's age declaration, once.
+     *
+     * Idempotent on purpose: confirming twice is a double click or a retried
+     * request, and neither is a reason to move the moment the declaration was
+     * actually made.
+     */
+    public function confirmAdult(): self
+    {
+        $this->adultConfirmedAt ??= new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    /**
+     * Close the age gate again.
+     *
+     * Used when a comic that was already shared becomes explicit: the recipient
+     * agreed to read something that was not marked 18+, so their earlier silence
+     * cannot stand in for a declaration about the comic it is now.
+     */
+    public function resetAdultConfirmation(): self
+    {
+        $this->adultConfirmedAt = null;
+
+        return $this;
+    }
+
+    /**
+     * Whether the comic behind this share is classified 18+.
+     *
+     * Answered by the comic while there is one, and by the snapshot once there
+     * is not — so a tombstone still knows what it is a tombstone of.
+     */
+    public function isExplicitContent(): bool
+    {
+        return $this->comic?->isExplicitContent() ?? $this->explicitContentSnapshot;
+    }
+
+    /**
+     * Whether this share is currently waiting on the recipient's age
+     * declaration. False for anything that is not explicit, so the ordinary
+     * flow never notices this exists.
+     */
+    public function requiresAdultConfirmation(): bool
+    {
+        return $this->isExplicitContent() && $this->adultConfirmedAt === null;
     }
 
     public function getUnavailableAt(): ?\DateTimeImmutable
@@ -414,10 +518,23 @@ class ComicShare
             && $this->unavailableAt === null;
     }
 
+    /**
+     * Whether the recipient may actually read the comic right now.
+     *
+     * Access and readability are separated because an explicit comic can suspend
+     * the second without touching the first: the relationship survives an age
+     * gate closing, so the recipient still has a share to confirm against and
+     * still keeps their place in their collection once they do.
+     */
+    public function grantsReadAccess(): bool
+    {
+        return $this->grantsAccess() && !$this->requiresAdultConfirmation();
+    }
+
     /** Whether the recipient should see this in their normal collection. */
     public function isVisibleInCollection(): bool
     {
-        return $this->grantsAccess() && $this->recipientRemovedAt === null;
+        return $this->grantsReadAccess() && $this->recipientRemovedAt === null;
     }
 
     public function isPending(?\DateTimeImmutable $now = null): bool

--- a/backend/src/Repository/ComicShareRepository.php
+++ b/backend/src/Repository/ComicShareRepository.php
@@ -47,12 +47,9 @@ class ComicShareRepository extends ServiceEntityRepository
      */
     public function findAccessFor(User $user, Comic $comic): ?ComicShare
     {
-        return $this->recipientQueryBuilder($user)
+        return $this->readableQueryBuilder($user)
             ->andWhere('s.comic = :comic')
-            ->andWhere('s.status = :accepted')
-            ->andWhere('s.unavailableAt IS NULL')
             ->setParameter('comic', $comic)
-            ->setParameter('accepted', ComicShare::STATUS_ACCEPTED)
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
@@ -66,14 +63,9 @@ class ComicShareRepository extends ServiceEntityRepository
      */
     public function findVisibleCollectionShares(User $user): array
     {
-        return $this->recipientQueryBuilder($user)
-            ->andWhere('s.status = :accepted')
-            ->andWhere('s.unavailableAt IS NULL')
-            ->andWhere('s.comic IS NOT NULL')
+        return $this->readableQueryBuilder($user)
             ->andWhere('s.recipientRemovedAt IS NULL')
-            ->setParameter('accepted', ComicShare::STATUS_ACCEPTED)
             ->addSelect('c', 'o')
-            ->leftJoin('s.comic', 'c')
             ->leftJoin('s.owner', 'o')
             ->getQuery()
             ->getResult();
@@ -201,14 +193,11 @@ class ComicShareRepository extends ServiceEntityRepository
             return [];
         }
 
-        $shares = $this->recipientQueryBuilder($user)
+        $shares = $this->readableQueryBuilder($user)
             ->addSelect('o')
             ->leftJoin('s.owner', 'o')
             ->andWhere('s.comic IN (:comics)')
-            ->andWhere('s.status = :accepted')
-            ->andWhere('s.unavailableAt IS NULL')
             ->setParameter('comics', $comics)
-            ->setParameter('accepted', ComicShare::STATUS_ACCEPTED)
             ->getQuery()
             ->getResult();
 
@@ -327,6 +316,28 @@ class ComicShareRepository extends ServiceEntityRepository
             ->setParameter('email', ComicShare::normaliseEmail((string) $user->getEmail()))
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * Shares that actually let this user read the comic behind them, aliased
+     * `s` with the comic joined as `c`.
+     *
+     * Every read path resolves access through this, so an age gate cannot hold
+     * on one endpoint and be missing on another: an accepted share on a comic
+     * the owner has marked explicit grants nothing until that recipient has
+     * declared their age on this very share.
+     *
+     * Note what it does *not* filter on: a comic the recipient removed from
+     * their own collection is still readable, because hiding is not giving up.
+     */
+    private function readableQueryBuilder(User $user): \Doctrine\ORM\QueryBuilder
+    {
+        return $this->recipientQueryBuilder($user)
+            ->innerJoin('s.comic', 'c')
+            ->andWhere('s.status = :accepted')
+            ->andWhere('s.unavailableAt IS NULL')
+            ->andWhere('c.explicitContent = false OR s.adultConfirmedAt IS NOT NULL')
+            ->setParameter('accepted', ComicShare::STATUS_ACCEPTED);
     }
 
     /**

--- a/backend/src/Repository/ComicShareRepository.php
+++ b/backend/src/Repository/ComicShareRepository.php
@@ -138,12 +138,26 @@ class ComicShareRepository extends ServiceEntityRepository
      */
     public function findLiveSharesForComic(Comic $comic): array
     {
-        return $this->createQueryBuilder('s')
-            ->andWhere('s.comic = :comic')
-            ->andWhere('s.unavailableAt IS NULL')
-            ->andWhere('s.status IN (:live)')
-            ->setParameter('comic', $comic)
-            ->setParameter('live', [ComicShare::STATUS_PENDING, ComicShare::STATUS_ACCEPTED])
+        return $this->liveSharesForComicQueryBuilder($comic)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * The live shares on this comic whose recipient has confirmed their age —
+     * the only ones re-gating has anything to do.
+     *
+     * Narrowed in the query rather than after loading, so a comic shared with
+     * fifty people and confirmed by three hydrates three rows. That is where
+     * the cost of re-gating actually is; going round the ORM to save the rest
+     * would cost the identity-map consistency the callers rely on.
+     *
+     * @return list<ComicShare>
+     */
+    public function findConfirmedSharesForComic(Comic $comic): array
+    {
+        return $this->liveSharesForComicQueryBuilder($comic)
+            ->andWhere('s.adultConfirmedAt IS NOT NULL')
             ->getQuery()
             ->getResult();
     }
@@ -259,15 +273,28 @@ class ComicShareRepository extends ServiceEntityRepository
     /** Counterpart to {@see findLiveSharesForComic()} for the deletion warning. */
     public function countLiveSharesForComic(Comic $comic): int
     {
-        return (int) $this->createQueryBuilder('s')
+        return (int) $this->liveSharesForComicQueryBuilder($comic)
             ->select('COUNT(s.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * "A share on this comic that still means something to its recipient",
+     * aliased `s` — pending or accepted, and not tombstoned.
+     *
+     * One definition, because deleting a comic, stopping sharing, warning the
+     * owner how many people that affects and re-gating all have to agree on
+     * which shares they are talking about.
+     */
+    private function liveSharesForComicQueryBuilder(Comic $comic): \Doctrine\ORM\QueryBuilder
+    {
+        return $this->createQueryBuilder('s')
             ->andWhere('s.comic = :comic')
             ->andWhere('s.unavailableAt IS NULL')
             ->andWhere('s.status IN (:live)')
             ->setParameter('comic', $comic)
-            ->setParameter('live', [ComicShare::STATUS_PENDING, ComicShare::STATUS_ACCEPTED])
-            ->getQuery()
-            ->getSingleScalarResult();
+            ->setParameter('live', [ComicShare::STATUS_PENDING, ComicShare::STATUS_ACCEPTED]);
     }
 
     private function deadSharesQueryBuilder(User $user): \Doctrine\ORM\QueryBuilder

--- a/backend/src/Repository/ComicShareRepository.php
+++ b/backend/src/Repository/ComicShareRepository.php
@@ -56,19 +56,25 @@ class ComicShareRepository extends ServiceEntityRepository
     }
 
     /**
-     * Every share this user has accepted and not hidden — the shared half of
-     * their collection.
+     * The comics in the shared half of this user's collection, as ids.
      *
-     * @return list<ComicShare>
+     * Ids rather than entities because that is all the library query wants: it
+     * folds them into one `WHERE owner = ? OR id IN (…)` and re-reads the comics
+     * itself. Hydrating a share, its comic and its owner per row — three objects
+     * apiece, thrown away immediately — was the most expensive thing the
+     * dashboard did before it had loaded anything a reader can see.
+     *
+     * @return list<int>
      */
-    public function findVisibleCollectionShares(User $user): array
+    public function findVisibleCollectionComicIds(User $user): array
     {
-        return $this->readableQueryBuilder($user)
+        $rows = $this->readableQueryBuilder($user)
+            ->select('IDENTITY(s.comic) AS comicId')
             ->andWhere('s.recipientRemovedAt IS NULL')
-            ->addSelect('c', 'o')
-            ->leftJoin('s.owner', 'o')
             ->getQuery()
-            ->getResult();
+            ->getScalarResult();
+
+        return array_map(static fn ($id): int => (int) $id, array_column($rows, 'comicId'));
     }
 
     /**
@@ -123,6 +129,11 @@ class ComicShareRepository extends ServiceEntityRepository
     public function findAllForOwnerIncludingTombstones(User $user): array
     {
         return $this->createQueryBuilder('s')
+            // Joined because the export reads the comic off every row. Left, not
+            // inner: a tombstone has no comic left, and it is precisely the rows
+            // that lost theirs that an export still has to describe.
+            ->addSelect('c')
+            ->leftJoin('s.comic', 'c')
             ->andWhere('s.owner = :owner')
             ->setParameter('owner', $user)
             ->orderBy('s.createdAt', 'DESC')

--- a/backend/src/Security/Voter/ComicVoter.php
+++ b/backend/src/Security/Voter/ComicVoter.php
@@ -70,6 +70,11 @@ final class ComicVoter extends Voter
         // Hiding a comic from your own collection does not give up access —
         // findAccessFor deliberately ignores recipientRemovedAt — so a link
         // straight to the reader keeps working until the owner revokes it.
+        //
+        // It does apply the 18+ gate, which is why that gate holds for covers,
+        // pages and archives and not only for the screen that asks the question:
+        // an accepted share on a comic marked explicit answers no here until
+        // that recipient has declared their age on it.
         return $this->shareRepository->findAccessFor($user, $comic) !== null;
     }
 }

--- a/backend/src/Service/ComicSerializer.php
+++ b/backend/src/Service/ComicSerializer.php
@@ -112,6 +112,10 @@ class ComicSerializer
             'description' => $comic->getDescription(),
             'coverImagePath' => $this->coverUrl($comic),
             'pageCount' => $comic->getPageCount(),
+            // The owner's own classification, independent of every tag. It is
+            // what an 18+ gate is derived from when the comic is shared, and it
+            // has to survive a round trip through the edit dialog unchanged.
+            'explicitContent' => $comic->isExplicitContent(),
             'fileSize' => $comic->getFileSize(),
             'uploadedAt' => $comic->getUploadedAt()?->format('c'),
             'updatedAt' => $comic->getUpdatedAt()?->format('c'),

--- a/backend/src/Service/ComicShareSerializer.php
+++ b/backend/src/Service/ComicShareSerializer.php
@@ -43,7 +43,10 @@ class ComicShareSerializer
      */
     public function forOwner(ComicShare $share): array
     {
-        return $this->common($share) + [
+        // Never redacted. The owner classified the comic, and owns the file; an
+        // age gate protects a recipient from content they have not agreed to
+        // see, not a person from their own library.
+        return $this->common($share, false) + [
             'recipientEmail' => $share->getRecipientEmailNormalized(),
             'recipientName' => $share->getRecipientUser()?->getName(),
             // Resending only makes sense while the recipient still has a choice
@@ -61,15 +64,18 @@ class ComicShareSerializer
     public function forRecipient(ComicShare $share): array
     {
         $owner = $share->getOwner();
+        $needsConfirmation = $share->requiresAdultConfirmation();
 
-        return $this->common($share) + [
+        return $this->common($share, $needsConfirmation) + [
             'ownerName' => $share->getOwnerNameSnapshot(),
             'ownerId' => $owner?->getId(),
             'removedFromCollection' => $share->getRecipientRemovedAt()?->format('c'),
             // An invitation can still be answered from the Sharing page while it
-            // is pending, has a comic behind it and has not run out.
+            // is pending, has a comic behind it and has not run out. Answering
+            // an explicit one starts with the age gate, so the page has to be
+            // able to tell "you may answer this" from "you may accept it now".
             'canAnswer' => $share->isPending(),
-            'canRead' => $share->grantsAccess(),
+            'canRead' => $share->grantsReadAccess(),
             'canRestore' => $share->grantsAccess() && $share->getRecipientRemovedAt() !== null,
             'canRemove' => $share->grantsAccess() && $share->getRecipientRemovedAt() === null,
             // A dead entry is one nothing can be done with any more; these are
@@ -80,24 +86,35 @@ class ComicShareSerializer
     }
 
     /**
+     * @param bool $redact withhold everything that identifies the comic, for a
+     *                     recipient who has not passed the age gate. The comic
+     *                     id goes too: it is the key to every endpoint that
+     *                     serves a cover, a page or an archive, so leaving it in
+     *                     would make the gate a suggestion.
      * @return array<string, mixed>
      */
-    private function common(ComicShare $share): array
+    private function common(ComicShare $share, bool $redact): array
     {
         $comic = $share->getComic();
 
         return [
             'id' => $share->getId(),
             'status' => $share->getStatus(),
-            'comicId' => $comic?->getId(),
+            'comicId' => $redact ? null : $comic?->getId(),
             // Falls back to the snapshot so a tombstone can still name the
             // comic it used to be.
-            'comicTitle' => $comic?->getTitle() ?? $share->getComicTitleSnapshot(),
-            'comicAuthor' => $comic?->getAuthor() ?? $share->getComicAuthorSnapshot(),
-            'pageCount' => $comic?->getPageCount(),
+            'comicTitle' => $redact ? null : ($comic?->getTitle() ?? $share->getComicTitleSnapshot()),
+            'comicAuthor' => $redact ? null : ($comic?->getAuthor() ?? $share->getComicAuthorSnapshot()),
+            'pageCount' => $redact ? null : $comic?->getPageCount(),
             // Null for a tombstone: there is no file left, and the URL of one
             // that has been deleted must not be handed out.
-            'coverImagePath' => $comic ? $this->comicSerializer->coverUrl($comic) : null,
+            'coverImagePath' => $comic && !$redact ? $this->comicSerializer->coverUrl($comic) : null,
+            // Booleans rather than the stored timestamps: the client only ever
+            // needs to know which screen to show. The timestamps stay on the
+            // record as the audit trail they were added for.
+            'explicitContent' => $share->isExplicitContent(),
+            'requiresAdultConfirmation' => $share->requiresAdultConfirmation(),
+            'adultConfirmed' => $share->getAdultConfirmedAt() !== null,
             'createdAt' => $share->getCreatedAt()->format('c'),
             'acceptedAt' => $share->getAcceptedAt()?->format('c'),
             'declinedAt' => $share->getDeclinedAt()?->format('c'),

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -26,8 +26,20 @@ use Twig\Environment;
  */
 class ComicShareService
 {
-    /** How long an unanswered invitation stays open. */
-    public const INVITATION_TTL = '+7 days';
+    /**
+     * How long an unanswered invitation stays open — the link and the pending
+     * relationship together, so the two can never disagree about whether an
+     * invitation is still live.
+     *
+     * Two months, because answering one is not always quick: the recipient may
+     * have no account here yet, and a week is easy to lose to a holiday or a
+     * full inbox. The cost is that a link which escapes — forwarded, scanned,
+     * sitting in a proxy log — stays live for longer, which is why the window is
+     * not the thing keeping anybody out. A link only ever previews; accepting
+     * requires signing in as the intended recipient, and an explicit comic
+     * reveals nothing to a link holder at all.
+     */
+    public const INVITATION_TTL = '+2 months';
 
     public function __construct(
         private readonly EntityManagerInterface $entityManager,

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -54,10 +54,30 @@ class ComicShareService
      * rolls the invitation back, so the owner is never shown a recipient who
      * was never actually contacted.
      *
+     * @param bool $senderResponsibilityAccepted the sender's acknowledgement
+     *                                           that they are responsible for
+     *                                           what they hand out, and for
+     *                                           having classified it correctly
+     *
      * @throws ShareException
      */
-    public function invite(Comic $comic, User $owner, string $recipientEmail): IssuedInvitation
-    {
+    public function invite(
+        Comic $comic,
+        User $owner,
+        string $recipientEmail,
+        bool $senderResponsibilityAccepted
+    ): IssuedInvitation {
+        // Checked before anything else is decided, so a share cannot come into
+        // existence without the acknowledgement that goes on the record with it.
+        // The tick box in the UI is a prompt, not the rule.
+        if (!$senderResponsibilityAccepted) {
+            throw new ShareException(
+                'You must acknowledge responsibility for the content you share.',
+                400,
+                ShareException::CODE_RESPONSIBILITY_REQUIRED
+            );
+        }
+
         $email = ComicShare::normaliseEmail($recipientEmail);
 
         if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -95,10 +115,17 @@ class ComicShareService
             // Declined, revoked, or a pending invitation that lapsed. The row is
             // reused rather than duplicated, which is what the unique index on
             // (comic, recipient) is there to guarantee.
-            $share->setOwner($owner)->refreshSnapshots();
+            //
+            // Reusing the row does not carry the old age declaration forward:
+            // this is a fresh offer of the comic as it is now, and the previous
+            // relationship ended without the recipient reading anything.
+            $share->setOwner($owner)->refreshSnapshots()->resetAdultConfirmation();
         }
 
         $share->markPending($this->invitationExpiry());
+        // A new share, so a new acknowledgement. Resending does not come through
+        // here and keeps the timestamp it already has.
+        $share->acceptSenderResponsibility();
 
         return $this->issueInvitation($share, $comic, $owner);
     }
@@ -175,9 +202,12 @@ class ComicShareService
         // must not be able to mark a link used on their way to a 403 — the
         // controller happens not to flush after that, but a link that only
         // survives because nothing later in the request writes is not a link
-        // the legitimate recipient can rely on.
+        // the legitimate recipient can rely on. The age gate is checked here for
+        // the same reason: being sent to the warning must not cost the recipient
+        // the link they need once they have answered it.
         $share = $token->getComicShare();
         $this->assertRecipient($share, $recipient);
+        $this->assertAdultConfirmed($share);
         $token->markUsed();
 
         return $this->acceptShare($share, $recipient);
@@ -209,6 +239,11 @@ class ComicShareService
     {
         $this->assertRecipient($share, $recipient);
         $this->assertAnswerable($share);
+        // The warning on the invitation page is a prompt; this is the boundary.
+        // Accepting is what puts a comic in somebody's collection, so an
+        // unconfirmed explicit share must not get that far however the request
+        // was made.
+        $this->assertAdultConfirmed($share);
 
         $share->markAccepted($recipient)->refreshSnapshots();
         // Every link that was issued for this invitation is spent now.
@@ -231,6 +266,80 @@ class ComicShareService
         $this->entityManager->flush();
 
         return $share;
+    }
+
+    /**
+     * Record that this recipient has declared they are 18 or older, for this
+     * share.
+     *
+     * The declaration belongs to the share and not to the account: somebody may
+     * be willing to make it about one comic and not about the next, and a
+     * per-account flag would answer for them.
+     *
+     * Idempotent — a second confirmation keeps the first timestamp — so a
+     * retried request cannot rewrite when the declaration was actually made.
+     *
+     * @throws ShareException
+     */
+    public function confirmAdult(ComicShare $share, User $recipient): ComicShare
+    {
+        $this->assertRecipient($share, $recipient);
+
+        if ($share->isTombstoned() || $share->getComic() === null) {
+            throw new ShareException('The shared comic is no longer available.', 410);
+        }
+
+        if ($share->getStatus() === ComicShare::STATUS_REVOKED) {
+            throw new ShareException('The owner has withdrawn this invitation.', 410);
+        }
+
+        if ($share->getStatus() === ComicShare::STATUS_DECLINED) {
+            throw new ShareException('You have already declined this invitation.', 409);
+        }
+
+        // Only a pending invitation runs out. An accepted share has no expiry —
+        // markAccepted clears it — so this cannot lock out somebody re-gated
+        // long after they accepted.
+        if ($share->isExpired()) {
+            throw new ShareException('This invitation has expired.', 410);
+        }
+
+        if (!$share->getComic()->isExplicitContent()) {
+            throw new ShareException('This comic is not marked as explicit content.', 409);
+        }
+
+        $share->confirmAdult();
+        $this->entityManager->flush();
+
+        return $share;
+    }
+
+    /**
+     * Re-close the age gate on every live share of a comic that has just been
+     * marked explicit.
+     *
+     * Fails closed by design. Those recipients agreed to read something that was
+     * not classified 18+, and an old silence is not a declaration about the
+     * comic as it is now — so access stops until each of them says so. The
+     * relationship, its status and the recipient's place in their own collection
+     * are untouched: this suspends reading, it does not undo the share.
+     *
+     * @return int the number of shares re-gated
+     */
+    public function regateSharesForComic(Comic $comic): int
+    {
+        $regated = 0;
+
+        foreach ($this->shareRepository->findLiveSharesForComic($comic) as $share) {
+            if ($share->getAdultConfirmedAt() === null) {
+                continue;
+            }
+
+            $share->resetAdultConfirmation();
+            ++$regated;
+        }
+
+        return $regated;
     }
 
     /** Withdraw one recipient's access. Takes effect on the next request. */
@@ -413,8 +522,14 @@ class ComicShareService
     {
         $ownerName = $owner->getName() ?: $owner->getEmail();
 
+        // An email is the least controlled surface there is: it sits in an inbox,
+        // gets previewed on a lock screen and is scanned on the way. For an
+        // explicit comic the template is given no title and no cover to show, so
+        // the identifying details stay behind the age gate rather than being
+        // announced by the notification of it.
         $body = $this->twig->render('emails/share_comic.html.twig', [
             'comic' => $comic,
+            'explicitContent' => $comic->isExplicitContent(),
             'userName' => $ownerName,
             'shareLink' => $this->invitationUrl($plaintextToken),
             'privacyUrl' => rtrim($this->frontendUrl, '/') . '/privacy',
@@ -486,6 +601,20 @@ class ComicShareService
 
         if ($share->isExpired()) {
             throw new ShareException('This invitation has expired.', 410);
+        }
+    }
+
+    /**
+     * @throws ShareException
+     */
+    private function assertAdultConfirmed(ComicShare $share): void
+    {
+        if ($share->requiresAdultConfirmation()) {
+            throw new ShareException(
+                'You must confirm that you are 18 or older to access this shared comic.',
+                403,
+                ShareException::CODE_ADULT_CONFIRMATION_REQUIRED
+            );
         }
     }
 

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -324,17 +324,20 @@ class ComicShareService
      * relationship, its status and the recipient's place in their own collection
      * are untouched: this suspends reading, it does not undo the share.
      *
+     * Mutates rather than issuing a bulk UPDATE, and asks the repository for
+     * only the shares that have something to reset. A DQL UPDATE would be one
+     * query, but it writes round the identity map — a share already loaded in
+     * this request would go on reporting a confirmation the database no longer
+     * holds — and it would commit on its own, splitting the single flush that
+     * makes the re-gate and the reclassification land together.
+     *
      * @return int the number of shares re-gated
      */
     public function regateSharesForComic(Comic $comic): int
     {
         $regated = 0;
 
-        foreach ($this->shareRepository->findLiveSharesForComic($comic) as $share) {
-            if ($share->getAdultConfirmedAt() === null) {
-                continue;
-            }
-
+        foreach ($this->shareRepository->findConfirmedSharesForComic($comic) as $share) {
             $share->resetAdultConfirmation();
             ++$regated;
         }

--- a/backend/src/Service/PersonalDataExporter.php
+++ b/backend/src/Service/PersonalDataExporter.php
@@ -125,6 +125,12 @@ final class PersonalDataExporter
                 'expiresAt' => $share->getExpiresAt()?->format(\DateTimeInterface::ATOM),
                 'unavailableAt' => $share->getUnavailableAt()?->format(\DateTimeInterface::ATOM),
                 'tombstoneReason' => $share->getTombstoneReason(),
+                // The two declarations this share records. They are statements
+                // the user made about themselves, so an export of what is held
+                // about them has to include them.
+                'senderResponsibilityAcceptedAt' => $share->getSenderResponsibilityAcceptedAt()?->format(\DateTimeInterface::ATOM),
+                'adultConfirmedAt' => $share->getAdultConfirmedAt()?->format(\DateTimeInterface::ATOM),
+                'explicitContent' => $share->isExplicitContent(),
             ],
             $shares,
         );

--- a/backend/src/Service/PersonalDataExporter.php
+++ b/backend/src/Service/PersonalDataExporter.php
@@ -89,6 +89,10 @@ final class PersonalDataExporter
             'author' => $comic->getAuthor(),
             'publisher' => $comic->getPublisher(),
             'description' => $comic->getDescription(),
+            // The owner's own classification, and stored as such. An export
+            // that named it only on the shares handed out would omit it
+            // entirely for a comic nobody has been invited to.
+            'explicitContent' => $comic->isExplicitContent(),
             'coverImagePath' => $this->comicSerializer->coverUrl($comic),
             'pageCount' => $comic->getPageCount(),
             'fileSize' => $comic->getFileSize(),

--- a/backend/src/Service/ShareException.php
+++ b/backend/src/Service/ShareException.php
@@ -12,13 +12,50 @@ namespace App\Service;
  */
 class ShareException extends \RuntimeException
 {
-    public function __construct(string $message, private readonly int $statusCode = 400)
-    {
+    /** The sender did not acknowledge responsibility for what they are sharing. */
+    public const CODE_RESPONSIBILITY_REQUIRED = 'share_responsibility_acknowledgement_required';
+
+    /** The recipient has not declared they are 18 or older. */
+    public const CODE_ADULT_CONFIRMATION_REQUIRED = 'adult_confirmation_required';
+
+    /**
+     * @param string|null $errorCode a stable identifier for failures the client
+     *                               has to react to rather than merely display,
+     *                               such as opening the age gate. Most failures
+     *                               need none: their message is the whole
+     *                               response.
+     */
+    public function __construct(
+        string $message,
+        private readonly int $statusCode = 400,
+        private readonly ?string $errorCode = null,
+    ) {
         parent::__construct($message);
     }
 
     public function getStatusCode(): int
     {
         return $this->statusCode;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * The JSON body describing this failure, with the code only where there is
+     * one to give.
+     *
+     * @return array<string, string>
+     */
+    public function toPayload(): array
+    {
+        $payload = ['message' => $this->getMessage()];
+        if ($this->errorCode !== null) {
+            $payload['code'] = $this->errorCode;
+        }
+
+        return $payload;
     }
 }

--- a/backend/templates/emails/share_comic.html.twig
+++ b/backend/templates/emails/share_comic.html.twig
@@ -64,10 +64,25 @@
         </div>
         <div class="content">
             <p>Hi there,</p>
-            <p>
-                <span class="highlight">{{ userName|e }}</span> would like to share the comic
-                "<span class="highlight">{{ comic.title|e }}</span>" with you.
-            </p>
+            {# An explicit comic is not named here. The email is the one place
+               the recipient cannot choose to open: it is previewed on lock
+               screens and read by scanners, so the title stays behind the age
+               gate along with everything else that identifies the comic. #}
+            {% if explicitContent %}
+                <p>
+                    <span class="highlight">{{ userName|e }}</span> would like to share a comic with you.
+                </p>
+                <p class="highlight">
+                    They have marked it as containing explicit adult content (18+).
+                    You will be asked to confirm that you are 18 or older before any
+                    details of the comic are shown to you.
+                </p>
+            {% else %}
+                <p>
+                    <span class="highlight">{{ userName|e }}</span> would like to share the comic
+                    "<span class="highlight">{{ comic.title|e }}</span>" with you.
+                </p>
+            {% endif %}
             {# One link, and it only opens a preview. Mail scanners and
                link-preview services follow links without a person behind them,
                so nothing here may accept or decline on the recipient's

--- a/backend/tests/Factory/ComicFactory.php
+++ b/backend/tests/Factory/ComicFactory.php
@@ -39,6 +39,10 @@ final class ComicFactory extends ModelFactory
             'author' => self::faker()->name(),
             'publisher' => self::faker()->company(),
             'description' => self::faker()->sentence(),
+            // Never randomised. An age classification is the owner's deliberate
+            // statement, and a test comic that is sometimes 18+ would make the
+            // gate's tests pass for the wrong reason.
+            'explicitContent' => false,
             'owner' => UserFactory::new(),
         ];
     }
@@ -46,5 +50,10 @@ final class ComicFactory extends ModelFactory
     public function ownedBy(User $user): self
     {
         return $this->addState(['owner' => $user]);
+    }
+
+    public function explicit(): self
+    {
+        return $this->addState(['explicitContent' => true]);
     }
 }

--- a/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
@@ -75,6 +75,30 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
         self::assertNotNull($received['comicTitle']);
     }
 
+    public function testAScalarJsonBodyIsRejectedRatherThanFatal(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'malformed@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        // `5` is valid JSON, so it decodes without error and reaches the field
+        // handling as an int. Reading a key off it must not take the request
+        // down with a TypeError.
+        $this->browser()->request(
+            'PATCH',
+            '/api/comics/' . $comic->getId(),
+            [],
+            [],
+            array_merge(
+                ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+                $this->csrfHeader()
+            ),
+            '5'
+        );
+
+        self::assertResponseIsSuccessful();
+        self::assertFalse($this->getJson('/api/comics/' . $comic->getId())['comic']['explicitContent']);
+    }
+
     public function testChangingTagsNeverTouchesTheExplicitFlag(): void
     {
         $owner = $this->createAndLoginUser(['email' => 'tagger@test.local']);
@@ -232,6 +256,52 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
         self::assertSame('Alex Owner', $invitation['ownerName']);
     }
 
+    public function testConfirmingDoesNotUnlockTheInvitationForEveryoneElseHoldingTheLink(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create([
+            'title' => 'Still Secret',
+            'author' => 'Still Secret Author',
+            'pageCount' => 42,
+        ])->object();
+        $recipient = $this->createAndLoginUser(['email' => 'the-one@test.local']);
+        [$share, $plaintext] = $this->createPendingInvitation($comic, $owner, (string) $recipient->getEmail());
+
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
+
+        // The recipient made a declaration about themselves. It says nothing
+        // about whoever else the link reached — a forwarded email, a scanner, a
+        // proxy log — so the preview must stay shut for all of them.
+        //
+        // The cookie jar is emptied rather than simply not used: this test signed
+        // in above, and a session left behind would answer as the recipient and
+        // make the assertions below pass without proving anything.
+        $this->client->getCookieJar()->clear();
+        $this->client->request('GET', '/api/shares/invitations/' . $plaintext, [], [], ['HTTP_ACCEPT' => 'application/json']);
+        self::assertResponseIsSuccessful();
+        $signedOut = $this->json()['invitation'];
+        self::assertNull($signedOut['comicTitle'], 'A signed-out link holder must not see the title.');
+        self::assertNull($signedOut['comicAuthor']);
+        self::assertNull($signedOut['pageCount']);
+        self::assertTrue($signedOut['requiresAdultConfirmation']);
+        // Nor may the link report what the person it was sent to has declared.
+        self::assertFalse($signedOut['adultConfirmed']);
+
+        $this->createAndLoginUser(['email' => 'wrong-account@test.local']);
+        $wrongAccount = $this->getJson('/api/shares/invitations/' . $plaintext)['invitation'];
+        self::assertNull($wrongAccount['comicTitle'], 'A signed-in stranger must not see the title.');
+        self::assertFalse($wrongAccount['adultConfirmed']);
+
+        // The recipient who actually made the declaration does see it.
+        $this->loginAs($recipient);
+        $forRecipient = $this->getJson('/api/shares/invitations/' . $plaintext)['invitation'];
+        self::assertSame('Still Secret', $forRecipient['comicTitle']);
+        self::assertSame(42, $forRecipient['pageCount']);
+        self::assertFalse($forRecipient['requiresAdultConfirmation']);
+        self::assertTrue($forRecipient['adultConfirmed']);
+    }
+
     public function testAnUnconfirmedExplicitInvitationCannotBeAccepted(): void
     {
         $owner = UserFactory::createOne()->object();
@@ -313,6 +383,32 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
             self::assertSame(ShareException::CODE_ADULT_CONFIRMATION_REQUIRED, $payload['code']);
         }
 
+        $this->refresh();
+        self::assertNull($this->onlyShare()->getAdultConfirmedAt());
+    }
+
+    public function testAnAgeDeclarationCannotBeMadeByACrossSiteRequest(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $recipient = $this->createAndLoginUser(['email' => 'csrf@test.local']);
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        // The generic /api rule covers this, but it is worth pinning here: of
+        // every endpoint on the site, this is the one whose entire purpose is to
+        // record a declaration a person makes about themselves. Another site
+        // being able to make it for them, in their session, is the whole reason
+        // the rule exists.
+        $this->browser()->request(
+            'POST',
+            '/api/shares/' . $share->getId() . '/confirm-adult',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            json_encode(['adultConfirmed' => true], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(403);
         $this->refresh();
         self::assertNull($this->onlyShare()->getAdultConfirmedAt());
     }

--- a/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
@@ -1,0 +1,684 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Comic;
+use App\Entity\ComicShare;
+use App\Entity\ShareInvitationToken;
+use App\Entity\Tag;
+use App\Entity\User;
+use App\Service\ComicShareService;
+use App\Service\ShareException;
+use App\Tests\Factory\ComicFactory;
+use App\Tests\Factory\TagFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\Functional\AbstractApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Explicit-content classification, and the two acknowledgements a share records.
+ *
+ * The rules pinned here are the ones the React warning cannot be trusted with:
+ * a share cannot exist without the sender's acknowledgement, an explicit comic
+ * gives up nothing that identifies it until its recipient has declared their
+ * age, and both timestamps belong to the server. The classification is the
+ * owner's alone — a tag, hidden or not, never stands in for it.
+ */
+final class ExplicitShareControllerTest extends AbstractApiTestCase
+{
+    /* ---------------------------------------------------------------------- */
+    /* Classification                                                          */
+    /* ---------------------------------------------------------------------- */
+
+    public function testAComicIsNotExplicitUntilItsOwnerSaysSo(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'classifier@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        self::assertFalse($this->getJson('/api/comics/' . $comic->getId())['comic']['explicitContent']);
+
+        $this->patchJson('/api/comics/' . $comic->getId(), ['explicitContent' => true]);
+        self::assertResponseIsSuccessful();
+        self::assertTrue($this->getJson('/api/comics/' . $comic->getId())['comic']['explicitContent']);
+
+        // And back again, because unticking the box has to be a change too.
+        $this->patchJson('/api/comics/' . $comic->getId(), ['explicitContent' => false]);
+        self::assertResponseIsSuccessful();
+        self::assertFalse($this->getJson('/api/comics/' . $comic->getId())['comic']['explicitContent']);
+    }
+
+    public function testHidingAComicFromTheLibraryIsNotAnAgeClassification(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'shelver@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $hidden = TagFactory::new()->createdBy($owner)->create(['name' => 'private-shelf'])->object();
+        $this->managed(Tag::class, (int) $hidden->getId())->setHideFromLibrary(true);
+        $this->flush();
+
+        $this->patchJson('/api/comics/' . $comic->getId(), ['tags' => ['private-shelf']]);
+        self::assertResponseIsSuccessful();
+
+        // A hidden tag is a shelving preference. Somebody may hide a comic for
+        // a dozen unrelated reasons, and none of them says anything about what
+        // is inside it.
+        self::assertFalse($this->getJson('/api/comics/' . $comic->getId())['comic']['explicitContent']);
+
+        // So sharing it behaves exactly like sharing anything else: no gate.
+        $recipient = UserFactory::createOne(['email' => 'unbothered@test.local'])->object();
+        $this->postInvitation((int) $comic->getId(), (string) $recipient->getEmail());
+        self::assertResponseStatusCodeSame(201);
+
+        $this->loginAs($recipient);
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'][0];
+        self::assertFalse($received['requiresAdultConfirmation']);
+        self::assertNotNull($received['comicTitle']);
+    }
+
+    public function testChangingTagsNeverTouchesTheExplicitFlag(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'tagger@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+
+        $this->patchJson('/api/comics/' . $comic->getId(), ['tags' => ['horror', 'noir']]);
+        self::assertResponseIsSuccessful();
+
+        self::assertTrue($this->getJson('/api/comics/' . $comic->getId())['comic']['explicitContent']);
+    }
+
+    /* ---------------------------------------------------------------------- */
+    /* Sender acknowledgement                                                  */
+    /* ---------------------------------------------------------------------- */
+
+    public function testAnInvitationWithoutTheSenderAcknowledgementIsRejected(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'unacknowledged@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        foreach ([[], ['senderResponsibilityAccepted' => false], ['senderResponsibilityAccepted' => 'true']] as $body) {
+            $payload = $this->postJson(
+                '/api/shares/comics/' . $comic->getId() . '/invitations',
+                array_merge(['email' => 'guest@example.com'], $body)
+            );
+
+            self::assertResponseStatusCodeSame(400);
+            self::assertSame(ShareException::CODE_RESPONSIBILITY_REQUIRED, $payload['code']);
+        }
+
+        // And nothing was created on the way to any of those rejections.
+        self::assertSame([], $this->getJson('/api/shares/shared-by-me')['sharedByMe']);
+    }
+
+    public function testAnAcknowledgedInvitationStoresAServerGeneratedTimestamp(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'acknowledger@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $before = new \DateTimeImmutable('-1 minute');
+        $this->postInvitation((int) $comic->getId(), 'guest@example.com');
+        self::assertResponseStatusCodeSame(201);
+
+        $share = $this->onlyShare();
+        self::assertNotNull($share->getSenderResponsibilityAcceptedAt());
+        self::assertGreaterThan($before, $share->getSenderResponsibilityAcceptedAt());
+        self::assertLessThan(new \DateTimeImmutable('+1 minute'), $share->getSenderResponsibilityAcceptedAt());
+    }
+
+    public function testAClientCannotSupplyItsOwnSenderAcknowledgementTimestamp(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'forger@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $this->postInvitation((int) $comic->getId(), 'guest@example.com', [
+            'senderResponsibilityAcceptedAt' => '1999-01-01T00:00:00+00:00',
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        // An audit trail the audited party can write is not one.
+        $accepted = $this->onlyShare()->getSenderResponsibilityAcceptedAt();
+        self::assertNotNull($accepted);
+        self::assertGreaterThan(new \DateTimeImmutable('-1 minute'), $accepted);
+    }
+
+    public function testTheAcknowledgementIsNotExposedAsATimestampToClients(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'discreet@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $payload = $this->postInvitation((int) $comic->getId(), 'guest@example.com');
+
+        // The record is kept server-side; the client is told state, not history.
+        self::assertArrayNotHasKey('senderResponsibilityAcceptedAt', $payload['share']);
+        self::assertArrayNotHasKey('adultConfirmedAt', $payload['share']);
+    }
+
+    public function testResendingKeepsTheOriginalSenderAcknowledgement(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'resender@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $payload = $this->postInvitation((int) $comic->getId(), 'guest@example.com');
+        $shareId = $payload['share']['id'];
+        // Read back from storage on both sides. The in-memory object still
+        // carries microseconds the DATETIME column does not, and comparing one
+        // against the other would fail on precision rather than on the value.
+        $this->refresh();
+        $original = $this->onlyShare()->getSenderResponsibilityAcceptedAt();
+
+        $this->postJson('/api/shares/' . $shareId . '/resend');
+        self::assertResponseIsSuccessful();
+
+        // Resending is the same relationship reaching the same person again, so
+        // there is no second decision to record.
+        $this->refresh();
+        self::assertEquals($original, $this->onlyShare()->getSenderResponsibilityAcceptedAt());
+    }
+
+    /* ---------------------------------------------------------------------- */
+    /* What an unconfirmed recipient may see                                   */
+    /* ---------------------------------------------------------------------- */
+
+    public function testAnExplicitPendingShareRevealsNothingThatIdentifiesTheComic(): void
+    {
+        $owner = UserFactory::createOne(['name' => 'Alex Owner'])->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create([
+            'title' => 'Secret Title',
+            'author' => 'Secret Author',
+            'pageCount' => 42,
+            'coverImagePath' => 'covers/missing/cover.png',
+        ])->object();
+        $recipient = $this->createAndLoginUser(['email' => 'unconfirmed@test.local']);
+        $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        $share = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'][0];
+
+        self::assertTrue($share['explicitContent']);
+        self::assertTrue($share['requiresAdultConfirmation']);
+        self::assertFalse($share['adultConfirmed']);
+        // The comic id goes too: it is the key to every endpoint that serves a
+        // cover, a page or an archive.
+        self::assertNull($share['comicId']);
+        self::assertNull($share['comicTitle']);
+        self::assertNull($share['comicAuthor']);
+        self::assertNull($share['pageCount']);
+        self::assertNull($share['coverImagePath']);
+        // What is left is enough to decide with: who is offering, and until when.
+        self::assertSame('Alex Owner', $share['ownerName']);
+        self::assertNotNull($share['expiresAt']);
+    }
+
+    public function testASignedOutTokenHolderLearnsNothingAboutAnExplicitComic(): void
+    {
+        $owner = UserFactory::createOne(['name' => 'Alex Owner'])->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create([
+            'title' => 'Secret Title',
+            'author' => 'Secret Author',
+            'coverImagePath' => 'covers/missing/cover.png',
+        ])->object();
+        [, $plaintext] = $this->createPendingInvitation($comic, $owner, 'invited@test.local');
+
+        // Possession of the link is not an age declaration — nobody has said who
+        // they are yet — so it buys only a description of the invitation.
+        $this->client->request('GET', '/api/shares/invitations/' . $plaintext, [], [], ['HTTP_ACCEPT' => 'application/json']);
+        self::assertResponseIsSuccessful();
+
+        $invitation = $this->json()['invitation'];
+        self::assertTrue($invitation['explicitContent']);
+        self::assertTrue($invitation['requiresAdultConfirmation']);
+        self::assertNull($invitation['comicTitle']);
+        self::assertNull($invitation['comicAuthor']);
+        self::assertNull($invitation['pageCount']);
+        self::assertNull($invitation['coverImagePath']);
+        self::assertSame('Alex Owner', $invitation['ownerName']);
+    }
+
+    public function testAnUnconfirmedExplicitInvitationCannotBeAccepted(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $recipient = $this->createAndLoginUser(['email' => 'eager@test.local']);
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        $payload = $this->postJson('/api/shares/' . $share->getId() . '/accept');
+        self::assertResponseStatusCodeSame(403);
+        self::assertSame(ShareException::CODE_ADULT_CONFIRMATION_REQUIRED, $payload['code']);
+
+        $this->refresh();
+        self::assertSame(ComicShare::STATUS_PENDING, $this->onlyShare()->getStatus());
+    }
+
+    public function testAnUnconfirmedExplicitLinkCannotBeAcceptedAndKeepsItsToken(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $recipient = $this->createAndLoginUser(['email' => 'linked@test.local']);
+        [, $plaintext] = $this->createPendingInvitation($comic, $owner, (string) $recipient->getEmail());
+
+        $payload = $this->postJson('/api/shares/invitations/' . $plaintext . '/accept');
+        self::assertResponseStatusCodeSame(403);
+        self::assertSame(ShareException::CODE_ADULT_CONFIRMATION_REQUIRED, $payload['code']);
+
+        // Being sent to the warning must not cost the recipient the link they
+        // need once they have answered it.
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/accept');
+        self::assertResponseIsSuccessful();
+    }
+
+    /* ---------------------------------------------------------------------- */
+    /* Making the declaration                                                  */
+    /* ---------------------------------------------------------------------- */
+
+    public function testOnlyTheIntendedRecipientCanConfirmTheirAge(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $share = $this->persistShare($comic, $owner, 'intended@test.local');
+
+        // Reported as missing rather than forbidden, so share ids cannot be
+        // probed by anyone who is not a party to them.
+        $this->createAndLoginUser(['email' => 'stranger@test.local']);
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseStatusCodeSame(404);
+
+        $this->refresh();
+        self::assertNull($this->onlyShare()->getAdultConfirmedAt());
+    }
+
+    public function testATokenHolderWhoIsNotTheRecipientCannotConfirm(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        [, $plaintext] = $this->createPendingInvitation($comic, $owner, 'intended@test.local');
+
+        $this->createAndLoginUser(['email' => 'forwarded-to@test.local']);
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseStatusCodeSame(403);
+
+        $this->refresh();
+        self::assertNull($this->onlyShare()->getAdultConfirmedAt());
+    }
+
+    public function testConfirmationRequiresTheDeclarationItself(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $recipient = $this->createAndLoginUser(['email' => 'silent@test.local']);
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        foreach ([[], ['adultConfirmed' => false], ['adultConfirmed' => 'yes']] as $body) {
+            $payload = $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', $body);
+            self::assertResponseStatusCodeSame(400);
+            self::assertSame(ShareException::CODE_ADULT_CONFIRMATION_REQUIRED, $payload['code']);
+        }
+
+        $this->refresh();
+        self::assertNull($this->onlyShare()->getAdultConfirmedAt());
+    }
+
+    public function testConfirmingUnlocksTheMetadataAndStoresTheTimestampOnTheSameShare(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create([
+            'title' => 'Now Visible',
+            'author' => 'Some Author',
+            'pageCount' => 42,
+            'coverImagePath' => 'covers/missing/cover.png',
+        ])->object();
+        $recipient = $this->createAndLoginUser(['email' => 'grown-up@test.local']);
+        $this->postInvitationAsOwner($comic, $owner, (string) $recipient->getEmail());
+        $this->loginAs($recipient);
+        $share = $this->onlyShare();
+
+        $payload = $this->postJson(
+            '/api/shares/' . $share->getId() . '/confirm-adult',
+            ['adultConfirmed' => true]
+        );
+        self::assertResponseIsSuccessful();
+
+        // The response is the now-unlocked view, from the request that unlocked it.
+        self::assertFalse($payload['share']['requiresAdultConfirmation']);
+        self::assertTrue($payload['share']['adultConfirmed']);
+        self::assertSame('Now Visible', $payload['share']['comicTitle']);
+        self::assertSame('Some Author', $payload['share']['comicAuthor']);
+        self::assertSame(42, $payload['share']['pageCount']);
+        self::assertSame($comic->getId(), $payload['share']['comicId']);
+        self::assertNotNull($payload['share']['coverImagePath']);
+
+        // Both acknowledgements are one row: this share is the whole audit trail.
+        $this->refresh();
+        $stored = $this->onlyShare();
+        self::assertNotNull($stored->getAdultConfirmedAt());
+        self::assertNotNull($stored->getSenderResponsibilityAcceptedAt());
+    }
+
+    public function testTheConfirmationTimestampIsTheServersAndSurvivesRepetition(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $recipient = $this->createAndLoginUser(['email' => 'insistent@test.local']);
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', [
+            'adultConfirmed' => true,
+            'adultConfirmedAt' => '1999-01-01T00:00:00+00:00',
+        ]);
+        self::assertResponseIsSuccessful();
+
+        $this->refresh();
+        $first = $this->onlyShare()->getAdultConfirmedAt();
+        self::assertNotNull($first);
+        self::assertGreaterThan(new \DateTimeImmutable('-1 minute'), $first);
+
+        // Confirming again is a double click or a retry, not a new declaration.
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
+
+        $this->refresh();
+        self::assertEquals($first, $this->onlyShare()->getAdultConfirmedAt());
+    }
+
+    public function testConfirmationIsRefusedForSharesThatCannotBeActedOn(): void
+    {
+        $cases = [
+            'revoked' => static fn (ComicShare $share) => $share->markRevoked(),
+            'declined' => static fn (ComicShare $share) => $share->markDeclined(),
+            'expired' => static fn (ComicShare $share) => $share->markPending(new \DateTimeImmutable('-1 day')),
+            'tombstoned' => static fn (ComicShare $share) => $share->markUnavailable(ComicShare::REASON_OWNER_DELETED),
+        ];
+
+        foreach ($cases as $label => $spoil) {
+            $owner = UserFactory::createOne()->object();
+            $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+            $recipient = $this->createAndLoginUser(['email' => $label . '@test.local']);
+            $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+            $spoil($this->managed(ComicShare::class, (int) $share->getId()));
+            $this->flush();
+
+            $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+            self::assertResponseStatusCodeSame(
+                $label === 'declined' ? 409 : 410,
+                sprintf('A %s share must not be confirmable.', $label)
+            );
+        }
+    }
+
+    public function testANonExplicitShareHasNothingToConfirm(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $recipient = $this->createAndLoginUser(['email' => 'ordinary@test.local']);
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseStatusCodeSame(409);
+
+        // The ordinary flow is untouched: accepting still works, with no extra step.
+        $this->postJson('/api/shares/' . $share->getId() . '/accept');
+        self::assertResponseIsSuccessful();
+    }
+
+    /* ---------------------------------------------------------------------- */
+    /* Reading, and the gate closing again                                     */
+    /* ---------------------------------------------------------------------- */
+
+    public function testAConfirmedRecipientReadsAnExplicitComicNormally(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create([
+            'coverImagePath' => 'covers/missing/cover.png',
+        ])->object();
+        $recipient = $this->createAndLoginUser(['email' => 'reader@test.local']);
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
+        $this->postJson('/api/shares/' . $share->getId() . '/accept');
+        self::assertResponseIsSuccessful();
+
+        $this->getJson('/api/comics/' . $comic->getId());
+        self::assertResponseIsSuccessful();
+        $this->requestCover($owner, $comic);
+        self::assertResponseIsSuccessful();
+        self::assertSame([$comic->getId()], array_column($this->getJson('/api/comics')['comics'], 'id'));
+    }
+
+    public function testMarkingAnAlreadySharedComicExplicitClosesTheGateAgain(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->create([
+            'coverImagePath' => 'covers/missing/cover.png',
+        ])->object();
+        $recipient = UserFactory::createOne(['email' => 'regated@test.local'])->object();
+
+        $this->loginAs($recipient);
+        $share = $this->createAcceptedShare($comic, $owner, $recipient);
+        $this->getJson('/api/comics/' . $comic->getId());
+        self::assertResponseIsSuccessful();
+
+        $this->loginAs($owner);
+        $this->patchJson('/api/comics/' . $comic->getId(), ['explicitContent' => true]);
+        self::assertResponseIsSuccessful();
+
+        // Fails closed. They agreed to read something that was not classified
+        // 18+, so nothing they said then answers for the comic as it is now.
+        $this->loginAs($recipient);
+        $this->getJson('/api/comics/' . $comic->getId());
+        self::assertResponseStatusCodeSame(403);
+        // Not only the metadata: the endpoints that serve the actual bytes are
+        // behind the same voter, so an accepted share cannot route around it.
+        $this->requestCover($owner, $comic);
+        self::assertResponseStatusCodeSame(403);
+        $this->browser()->request('GET', '/api/comics/' . $comic->getId() . '/pages/1');
+        self::assertResponseStatusCodeSame(404);
+        self::assertSame([], $this->getJson('/api/comics')['comics']);
+
+        // The relationship survived: it is reading that stopped, not the share.
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'][0];
+        self::assertSame(ComicShare::STATUS_ACCEPTED, $received['status']);
+        self::assertTrue($received['requiresAdultConfirmation']);
+        self::assertFalse($received['canRead']);
+        self::assertNull($received['comicTitle']);
+
+        // And one declaration is all it takes to get back in.
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
+        $this->getJson('/api/comics/' . $comic->getId());
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testUnmarkingAComicRestoresAccessImmediately(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $recipient = UserFactory::createOne(['email' => 'reprieved@test.local'])->object();
+
+        $this->loginAs($recipient);
+        $this->createAcceptedShare($comic, $owner, $recipient);
+
+        $this->loginAs($owner);
+        $this->patchJson('/api/comics/' . $comic->getId(), ['explicitContent' => true]);
+
+        $this->loginAs($recipient);
+        $this->getJson('/api/comics/' . $comic->getId());
+        self::assertResponseStatusCodeSame(403);
+
+        $this->loginAs($owner);
+        $this->patchJson('/api/comics/' . $comic->getId(), ['explicitContent' => false]);
+        self::assertResponseIsSuccessful();
+
+        // Nothing to re-confirm: there is no longer anything to confirm about.
+        $this->loginAs($recipient);
+        $this->getJson('/api/comics/' . $comic->getId());
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testTheGateAlsoClosesThroughTheDashboardBatchUpdate(): void
+    {
+        // The edit dialog on the dashboard saves through PATCH /api/comics, not
+        // the single-comic route, so the re-gate has to hold on both.
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $recipient = UserFactory::createOne(['email' => 'batched@test.local'])->object();
+
+        $this->loginAs($recipient);
+        $this->createAcceptedShare($comic, $owner, $recipient);
+
+        $this->loginAs($owner);
+        $this->patchJson('/api/comics', [
+            'updates' => [['id' => $comic->getId(), 'changes' => ['explicitContent' => true]]],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        $this->loginAs($recipient);
+        $this->getJson('/api/comics/' . $comic->getId());
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testATombstoneOfAnUnconfirmedExplicitComicStillWithholdsItsTitle(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create(['title' => 'Never Revealed'])->object();
+        $recipient = UserFactory::createOne(['email' => 'bereaved@test.local'])->object();
+
+        $this->loginAs($recipient);
+        $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        $this->loginAs($owner);
+        $this->browser()->request('DELETE', '/api/comics/' . $comic->getId(), [], [], $this->csrfHeader());
+        self::assertResponseIsSuccessful();
+
+        // Deleting the comic must not be the way its title gets past the gate:
+        // the snapshot a tombstone keeps is exactly what was being withheld.
+        $this->loginAs($recipient);
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'][0];
+        self::assertTrue($received['isTombstoned']);
+        self::assertTrue($received['requiresAdultConfirmation']);
+        self::assertNull($received['comicTitle']);
+    }
+
+    public function testAnOwnerSeesTheirOwnExplicitComicUnredacted(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'proprietor@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create(['title' => 'Mine To See'])->object();
+
+        $this->postInvitation((int) $comic->getId(), 'guest@example.com');
+
+        // An age gate protects a recipient from content they have not agreed to
+        // see. It is not a lock on somebody's own library.
+        $group = $this->getJson('/api/shares/shared-by-me')['sharedByMe'][0];
+        self::assertSame('Mine To See', $group['title']);
+        self::assertTrue($group['explicitContent']);
+        self::assertSame('Mine To See', $group['recipients'][0]['comicTitle']);
+    }
+
+    /* ---------------------------------------------------------------------- */
+    /* Helpers                                                                 */
+    /* ---------------------------------------------------------------------- */
+
+    /** @param array<string, mixed> $extra */
+    private function postInvitation(int $comicId, string $email, array $extra = []): array
+    {
+        return $this->postJson(
+            '/api/shares/comics/' . $comicId . '/invitations',
+            array_merge(['email' => $email, 'senderResponsibilityAccepted' => true], $extra)
+        );
+    }
+
+    /** Invite as the owner, leaving the caller to log back in as they please. */
+    private function postInvitationAsOwner(Comic $comic, User $owner, string $email): void
+    {
+        $this->loginAs($owner);
+        $this->postInvitation((int) $comic->getId(), $email);
+        self::assertResponseStatusCodeSame(201);
+    }
+
+    private function requestCover(User $owner, Comic $comic): void
+    {
+        $this->browser()->request(
+            'GET',
+            sprintf('/api/comics/cover/%d/%d/cover.png', $owner->getId(), $comic->getId())
+        );
+    }
+
+    private function createAcceptedShare(Comic $comic, User $owner, User $recipient): ComicShare
+    {
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
+
+        static::getContainer()->get(ComicShareService::class)
+            ->acceptShare($share, $this->managed(User::class, (int) $recipient->getId()));
+
+        return $share;
+    }
+
+    /** @return array{0: ComicShare, 1: string} */
+    private function createPendingInvitation(Comic $comic, User $owner, string $recipientEmail): array
+    {
+        $share = $this->persistShare($comic, $owner, $recipientEmail);
+
+        [$plaintext, $hash] = ShareInvitationToken::generate();
+        $token = new ShareInvitationToken($share, $hash, new \DateTimeImmutable('+7 days'));
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->persist($token);
+        $entityManager->flush();
+
+        return [$share, $plaintext];
+    }
+
+    private function persistShare(Comic $comic, User $owner, string $recipientEmail): ComicShare
+    {
+        $share = new ComicShare(
+            $this->managed(Comic::class, (int) $comic->getId()),
+            $this->managed(User::class, (int) $owner->getId()),
+            $recipientEmail
+        );
+        $share->markPending(new \DateTimeImmutable('+7 days'))->acceptSenderResponsibility();
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->persist($share);
+        $entityManager->flush();
+
+        return $share;
+    }
+
+    /** The single share these tests create, read back from storage. */
+    private function onlyShare(): ComicShare
+    {
+        $shares = static::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(ComicShare::class)
+            ->findAll();
+        self::assertCount(1, $shares);
+
+        return $shares[0];
+    }
+
+    private function flush(): void
+    {
+        static::getContainer()->get(EntityManagerInterface::class)->flush();
+    }
+
+    /** Forget everything in memory, so the next read comes from the database. */
+    private function refresh(): void
+    {
+        static::getContainer()->get(EntityManagerInterface::class)->clear();
+    }
+
+    /**
+     * Look an entity up again in the entity manager the container is handing
+     * out now — every request leaves the previous one detached.
+     *
+     * @template T of object
+     * @param class-string<T> $class
+     * @return T
+     */
+    private function managed(string $class, int $id): object
+    {
+        $entity = static::getContainer()->get(EntityManagerInterface::class)->find($class, $id);
+        self::assertNotNull($entity, sprintf('Expected a stored %s with id %d.', $class, $id));
+
+        return $entity;
+    }
+}

--- a/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
@@ -340,6 +340,29 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
     /* Making the declaration                                                  */
     /* ---------------------------------------------------------------------- */
 
+    public function testASpentLinkCannotBeUsedToConfirmAnAgeEither(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $recipient = $this->createAndLoginUser(['email' => 'spent@test.local']);
+        [$share, $plaintext] = $this->createPendingInvitation($comic, $owner, (string) $recipient->getEmail());
+
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/accept');
+        self::assertResponseIsSuccessful();
+
+        // Accepting spends the link, and the age endpoint resolves the same
+        // token as everything else — so it cannot become a way back in for a
+        // link that has already been claimed.
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseStatusCodeSame(409);
+
+        // The share the recipient legitimately holds is untouched by that.
+        $this->refresh();
+        self::assertNotNull($this->managed(ComicShare::class, (int) $share->getId())->getAdultConfirmedAt());
+    }
+
     public function testOnlyTheIntendedRecipientCanConfirmTheirAge(): void
     {
         $owner = UserFactory::createOne()->object();
@@ -785,7 +808,7 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
         $share = $this->persistShare($comic, $owner, $recipientEmail);
 
         [$plaintext, $hash] = ShareInvitationToken::generate();
-        $token = new ShareInvitationToken($share, $hash, new \DateTimeImmutable('+7 days'));
+        $token = new ShareInvitationToken($share, $hash, new \DateTimeImmutable(ComicShareService::INVITATION_TTL));
 
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $entityManager->persist($token);
@@ -801,7 +824,7 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
             $this->managed(User::class, (int) $owner->getId()),
             $recipientEmail
         );
-        $share->markPending(new \DateTimeImmutable('+7 days'))->acceptSenderResponsibility();
+        $share->markPending(new \DateTimeImmutable(ComicShareService::INVITATION_TTL))->acceptSenderResponsibility();
 
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $entityManager->persist($share);

--- a/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
@@ -489,36 +489,73 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
         self::assertResponseIsSuccessful();
     }
 
+    public function testRegatingTouchesOnlyTheSharesThatHaveSomethingToReset(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        // Explicit from the start: a confirmation can only exist on a comic that
+        // was asking for one, so this is the only way to arrive at a share that
+        // has something to withdraw.
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
+        $confirmed = UserFactory::createOne(['email' => 'confirmed@test.local'])->object();
+        $neverAsked = UserFactory::createOne(['email' => 'never-asked@test.local'])->object();
+
+        $this->loginAs($confirmed);
+        $confirmedShare = $this->persistShare($comic, $owner, (string) $confirmed->getEmail());
+        $this->postJson('/api/shares/' . $confirmedShare->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
+        $this->postJson('/api/shares/' . $confirmedShare->getId() . '/accept');
+        self::assertResponseIsSuccessful();
+
+        // Live, and still behind the gate: nothing to reset.
+        $this->loginAs($neverAsked);
+        $this->persistShare($comic, $owner, (string) $neverAsked->getEmail());
+
+        $regated = static::getContainer()->get(ComicShareService::class)
+            ->regateSharesForComic($this->managed(Comic::class, (int) $comic->getId()));
+
+        // One, not two. The query is narrowed to the shares with a declaration
+        // to withdraw, so a comic shared with many people and confirmed by few
+        // loads the few — which is where the cost of re-gating actually is.
+        self::assertSame(1, $regated);
+
+        $this->flush();
+        $this->refresh();
+        self::assertNull($this->managed(ComicShare::class, (int) $confirmedShare->getId())->getAdultConfirmedAt());
+    }
+
     public function testRegatingReachesSharesThatAreAlreadyLoaded(): void
     {
         $owner = UserFactory::createOne()->object();
-        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->explicit()->create()->object();
         $recipient = UserFactory::createOne(['email' => 'in-memory@test.local'])->object();
 
         $this->loginAs($recipient);
-        $share = $this->createAcceptedShare($comic, $owner, $recipient);
+        $share = $this->persistShare($comic, $owner, (string) $recipient->getEmail());
         $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+        self::assertResponseIsSuccessful();
 
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
-        $managedComic = $this->managed(Comic::class, (int) $comic->getId());
         $managedShare = $this->managed(ComicShare::class, (int) $share->getId());
-        $managedComic->setExplicitContent(true);
+        // The precondition the rest of this test is about. Asserted, because a
+        // guard that starts from an already-null field proves nothing.
+        self::assertNotNull($managedShare->getAdultConfirmedAt());
 
-        static::getContainer()->get(ComicShareService::class)->regateSharesForComic($managedComic);
+        static::getContainer()->get(ComicShareService::class)
+            ->regateSharesForComic($this->managed(Comic::class, (int) $comic->getId()));
 
         // Re-gating goes through the ORM on purpose, and this is what says so.
         //
-        // A bulk DQL UPDATE would be fewer queries, but it writes round the
-        // identity map: a share already loaded in this request would keep
-        // reporting a confirmation the database no longer holds, and anything
-        // serializing it afterwards would tell the recipient the gate was open.
-        // It would also split one flush into two commits, which is the opposite
-        // of what ComicController::update() documents.
+        // A bulk DQL UPDATE would be one query, but it writes round the identity
+        // map: this share is already loaded, and it would go on reporting a
+        // confirmation the database no longer holds — so anything serializing it
+        // later in the request would tell the recipient the gate was open. It
+        // would also commit on its own, splitting the single flush that
+        // ComicController::update() documents.
         self::assertNull($managedShare->getAdultConfirmedAt());
 
-        // And it still reaches storage once the caller's single flush lands.
+        // And it still reaches storage on the caller's flush, not before it.
         $entityManager->flush();
-        $entityManager->clear();
+        $this->refresh();
         self::assertNull($this->managed(ComicShare::class, (int) $share->getId())->getAdultConfirmedAt());
     }
 

--- a/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ExplicitShareControllerTest.php
@@ -489,6 +489,39 @@ final class ExplicitShareControllerTest extends AbstractApiTestCase
         self::assertResponseIsSuccessful();
     }
 
+    public function testRegatingReachesSharesThatAreAlreadyLoaded(): void
+    {
+        $owner = UserFactory::createOne()->object();
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $recipient = UserFactory::createOne(['email' => 'in-memory@test.local'])->object();
+
+        $this->loginAs($recipient);
+        $share = $this->createAcceptedShare($comic, $owner, $recipient);
+        $this->postJson('/api/shares/' . $share->getId() . '/confirm-adult', ['adultConfirmed' => true]);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $managedComic = $this->managed(Comic::class, (int) $comic->getId());
+        $managedShare = $this->managed(ComicShare::class, (int) $share->getId());
+        $managedComic->setExplicitContent(true);
+
+        static::getContainer()->get(ComicShareService::class)->regateSharesForComic($managedComic);
+
+        // Re-gating goes through the ORM on purpose, and this is what says so.
+        //
+        // A bulk DQL UPDATE would be fewer queries, but it writes round the
+        // identity map: a share already loaded in this request would keep
+        // reporting a confirmation the database no longer holds, and anything
+        // serializing it afterwards would tell the recipient the gate was open.
+        // It would also split one flush into two commits, which is the opposite
+        // of what ComicController::update() documents.
+        self::assertNull($managedShare->getAdultConfirmedAt());
+
+        // And it still reaches storage once the caller's single flush lands.
+        $entityManager->flush();
+        $entityManager->clear();
+        self::assertNull($this->managed(ComicShare::class, (int) $share->getId())->getAdultConfirmedAt());
+    }
+
     public function testUnmarkingAComicRestoresAccessImmediately(): void
     {
         $owner = UserFactory::createOne()->object();

--- a/backend/tests/Functional/Controller/PrivacyControllerTest.php
+++ b/backend/tests/Functional/Controller/PrivacyControllerTest.php
@@ -18,7 +18,7 @@ final class PrivacyControllerTest extends AbstractApiTestCase
             'dropboxAccessToken' => 'encrypted-access-secret',
             'dropboxRefreshToken' => 'encrypted-refresh-secret',
         ]);
-        ComicFactory::new()->ownedBy($user)->create(['title' => 'Exported Comic']);
+        ComicFactory::new()->ownedBy($user)->explicit()->create(['title' => 'Exported Comic']);
 
         $payload = $this->getJson('/api/privacy/export');
         $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
@@ -26,6 +26,10 @@ final class PrivacyControllerTest extends AbstractApiTestCase
         self::assertResponseIsSuccessful();
         self::assertSame('export@test.local', $payload['account']['email']);
         self::assertSame('Exported Comic', $payload['comics'][0]['title']);
+        // The owner's own classification is stored, so an export of what is
+        // held about them has to name it — and on the comic, not only on the
+        // shares handed out, or a comic nobody was invited to would omit it.
+        self::assertTrue($payload['comics'][0]['explicitContent']);
         self::assertTrue($payload['account']['dropboxConnected']);
         self::assertStringNotContainsString('password', strtolower($encoded));
         self::assertStringNotContainsString('encrypted-access-secret', $encoded);

--- a/backend/tests/Functional/Controller/ShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ShareControllerTest.php
@@ -122,7 +122,7 @@ final class ShareControllerTest extends AbstractApiTestCase
         $this->browser()->request('DELETE', '/api/comics/' . $comic->getId(), [], [], $this->csrfHeader());
         self::assertResponseStatusCodeSame(403);
 
-        $this->postJson('/api/shares/comics/' . $comic->getId() . '/invitations', ['email' => 'third@test.local']);
+        $this->postInvitation((int) $comic->getId(), 'third@test.local');
         self::assertResponseStatusCodeSame(403);
 
         // Downloading the archive is owner-only: a recipient reads through the
@@ -526,10 +526,7 @@ final class ShareControllerTest extends AbstractApiTestCase
         $owner = $this->createAndLoginUser(['email' => 'owner@test.local']);
         $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
 
-        $this->postJson(
-            '/api/shares/comics/' . $comic->getId() . '/invitations',
-            ['email' => '  Mixed.Case@Example.COM  ']
-        );
+        $this->postInvitation((int) $comic->getId(), '  Mixed.Case@Example.COM  ');
         self::assertResponseStatusCodeSame(201);
 
         $shares = static::getContainer()->get(ComicShareRepository::class)->findAllForOwner($owner);
@@ -538,10 +535,7 @@ final class ShareControllerTest extends AbstractApiTestCase
 
         // The same address in a different spelling is the same recipient, so it
         // cannot open a second invitation.
-        $this->postJson(
-            '/api/shares/comics/' . $comic->getId() . '/invitations',
-            ['email' => 'MIXED.CASE@example.com']
-        );
+        $this->postInvitation((int) $comic->getId(), 'MIXED.CASE@example.com');
         self::assertResponseStatusCodeSame(409);
     }
 
@@ -550,10 +544,7 @@ final class ShareControllerTest extends AbstractApiTestCase
         $owner = $this->createAndLoginUser(['email' => 'self@test.local']);
         $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
 
-        $payload = $this->postJson(
-            '/api/shares/comics/' . $comic->getId() . '/invitations',
-            ['email' => 'SELF@test.local']
-        );
+        $payload = $this->postInvitation((int) $comic->getId(), 'SELF@test.local');
 
         self::assertResponseStatusCodeSame(400);
         self::assertStringContainsString('already own', $payload['message']);
@@ -586,7 +577,7 @@ final class ShareControllerTest extends AbstractApiTestCase
         $comic = ComicFactory::new()->ownedBy($owner)->create(['title' => 'Batman: Year One'])->object();
 
         foreach (['jane@example.com', 'bob@example.com'] as $email) {
-            $this->postJson('/api/shares/comics/' . $comic->getId() . '/invitations', ['email' => $email]);
+            $this->postInvitation((int) $comic->getId(), $email);
             self::assertResponseStatusCodeSame(201);
         }
 
@@ -609,10 +600,7 @@ final class ShareControllerTest extends AbstractApiTestCase
         $owner = $this->createAndLoginUser(['email' => 'linker@test.local']);
         $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
 
-        $payload = $this->postJson(
-            '/api/shares/comics/' . $comic->getId() . '/invitations',
-            ['email' => 'guest@example.com']
-        );
+        $payload = $this->postInvitation((int) $comic->getId(), 'guest@example.com');
         self::assertResponseStatusCodeSame(201);
         self::assertArrayHasKey('invitationUrl', $payload);
 
@@ -631,10 +619,7 @@ final class ShareControllerTest extends AbstractApiTestCase
         $owner = $this->createAndLoginUser(['email' => 'resender@test.local']);
         $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
 
-        $first = $this->postJson(
-            '/api/shares/comics/' . $comic->getId() . '/invitations',
-            ['email' => 'guest@example.com']
-        );
+        $first = $this->postInvitation((int) $comic->getId(), 'guest@example.com');
         $shareId = $first['share']['id'];
         $firstToken = substr((string) strrchr($first['invitationUrl'], '/'), 1);
 
@@ -656,17 +641,11 @@ final class ShareControllerTest extends AbstractApiTestCase
         $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
 
         for ($i = 0; $i < 10; ++$i) {
-            $this->postJson(
-                '/api/shares/comics/' . $comic->getId() . '/invitations',
-                ['email' => sprintf('guest%d@example.com', $i)]
-            );
+            $this->postInvitation((int) $comic->getId(), sprintf('guest%d@example.com', $i));
             self::assertResponseStatusCodeSame(201, sprintf('Invitation %d should be within the allowance.', $i + 1));
         }
 
-        $payload = $this->postJson(
-            '/api/shares/comics/' . $comic->getId() . '/invitations',
-            ['email' => 'one-too-many@example.com']
-        );
+        $payload = $this->postInvitation((int) $comic->getId(), 'one-too-many@example.com');
 
         self::assertResponseStatusCodeSame(429);
         self::assertStringContainsString('too many invitations', $payload['message']);
@@ -679,18 +658,18 @@ final class ShareControllerTest extends AbstractApiTestCase
 
         // Requests turned away before anything is sent — a duplicate, and an
         // attempt to share with yourself — must not count against the limit.
-        $this->postJson('/api/shares/comics/' . $comic->getId() . '/invitations', ['email' => 'guest@example.com']);
+        $this->postInvitation((int) $comic->getId(), 'guest@example.com');
         self::assertResponseStatusCodeSame(201);
 
         for ($i = 0; $i < 5; ++$i) {
-            $this->postJson('/api/shares/comics/' . $comic->getId() . '/invitations', ['email' => 'guest@example.com']);
+            $this->postInvitation((int) $comic->getId(), 'guest@example.com');
             self::assertResponseStatusCodeSame(409);
-            $this->postJson('/api/shares/comics/' . $comic->getId() . '/invitations', ['email' => 'careful-sharer@test.local']);
+            $this->postInvitation((int) $comic->getId(), 'careful-sharer@test.local');
             self::assertResponseStatusCodeSame(400);
         }
 
         // Nine of the ten remain, so this is still accepted.
-        $this->postJson('/api/shares/comics/' . $comic->getId() . '/invitations', ['email' => 'another@example.com']);
+        $this->postInvitation((int) $comic->getId(), 'another@example.com');
         self::assertResponseStatusCodeSame(201);
     }
 
@@ -722,6 +701,24 @@ final class ShareControllerTest extends AbstractApiTestCase
             ->acceptShare($share, $this->managed(User::class, (int) $recipient->getId()));
 
         return $share;
+    }
+
+    /**
+     * Send an invitation the way the share modal does, acknowledgement and all.
+     *
+     * Every share now carries the sender's acknowledgement, so the tests that
+     * are about something else say so once here rather than repeating the tick
+     * box in each of them.
+     *
+     * @param array<string, mixed> $extra additional or overriding body fields
+     * @return array<string, mixed>
+     */
+    private function postInvitation(int $comicId, string $email, array $extra = []): array
+    {
+        return $this->postJson(
+            '/api/shares/comics/' . $comicId . '/invitations',
+            array_merge(['email' => $email, 'senderResponsibilityAccepted' => true], $extra)
+        );
     }
 
     /**

--- a/backend/tests/Functional/Controller/ShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ShareControllerTest.php
@@ -614,6 +614,60 @@ final class ShareControllerTest extends AbstractApiTestCase
         self::assertSame(ShareInvitationToken::hash($plaintext), $tokens[0]->getTokenHash());
     }
 
+    public function testAnInvitationLinkIsGoodForOneClaimWithinTwoMonths(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'lifecycle@test.local']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $payload = $this->postInvitation((int) $comic->getId(), 'claimant@test.local');
+        self::assertResponseStatusCodeSame(201);
+        $plaintext = substr((string) strrchr($payload['invitationUrl'], '/'), 1);
+
+        // The window is two months, and the link and the relationship share it,
+        // so neither can outlive the other.
+        $expiresAt = new \DateTimeImmutable($payload['share']['expiresAt']);
+        self::assertGreaterThan(new \DateTimeImmutable('+59 days'), $expiresAt);
+        self::assertLessThan(new \DateTimeImmutable('+62 days'), $expiresAt);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $tokens = $entityManager->getRepository(ShareInvitationToken::class)->findAll();
+        self::assertCount(1, $tokens);
+        self::assertEqualsWithDelta(
+            $expiresAt->getTimestamp(),
+            $tokens[0]->getExpiresAt()->getTimestamp(),
+            5,
+            'The link and the invitation must run out together.'
+        );
+
+        // Previewing does not spend it, however many times it is followed.
+        // Mail scanners and link-preview services open links on the recipient's
+        // behalf, so a link that burned on a GET would be dead before the person
+        // it was sent to ever saw it.
+        $this->createAndLoginUser(['email' => 'claimant@test.local']);
+        foreach ([1, 2, 3] as $_) {
+            $this->getJson('/api/shares/invitations/' . $plaintext);
+            self::assertResponseIsSuccessful();
+        }
+
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/accept');
+        self::assertResponseIsSuccessful();
+
+        // Claimed, and therefore spent — for every one of the things a link can
+        // be used for, not merely the one that spent it.
+        $entityManager->clear();
+        $spent = $entityManager->getRepository(ShareInvitationToken::class)->findAll();
+        self::assertCount(1, $spent);
+        self::assertNotNull($spent[0]->getUsedAt());
+        self::assertFalse($spent[0]->isUsable());
+
+        $this->getJson('/api/shares/invitations/' . $plaintext);
+        self::assertResponseStatusCodeSame(409);
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/accept');
+        self::assertResponseStatusCodeSame(409);
+        $this->postJson('/api/shares/invitations/' . $plaintext . '/decline');
+        self::assertResponseStatusCodeSame(409);
+    }
+
     public function testResendingInvalidatesThePreviousLink(): void
     {
         $owner = $this->createAndLoginUser(['email' => 'resender@test.local']);
@@ -731,7 +785,7 @@ final class ShareControllerTest extends AbstractApiTestCase
         $share = $this->persistShare($comic, $owner, $recipientEmail);
 
         [$plaintext, $hash] = ShareInvitationToken::generate();
-        $token = new ShareInvitationToken($share, $hash, new \DateTimeImmutable('+7 days'));
+        $token = new ShareInvitationToken($share, $hash, new \DateTimeImmutable(ComicShareService::INVITATION_TTL));
 
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $entityManager->persist($token);
@@ -747,7 +801,7 @@ final class ShareControllerTest extends AbstractApiTestCase
             $this->managed(User::class, (int) $owner->getId()),
             $recipientEmail
         );
-        $share->markPending(new \DateTimeImmutable('+7 days'));
+        $share->markPending(new \DateTimeImmutable(ComicShareService::INVITATION_TTL));
 
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $entityManager->persist($share);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,9 @@
       "devDependencies": {
         "@eslint/js": "^9.9.0",
         "@tailwindcss/typography": "^0.5.15",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.3",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.9.0",
@@ -47,6 +50,7 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
+        "jsdom": "^29.1.1",
         "lovable-tagger": "^1.1.7",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.11",
@@ -54,6 +58,13 @@
         "vite": "^5.4.1",
         "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -68,6 +79,72 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -79,9 +156,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -104,6 +181,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
@@ -118,29 +205,159 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -150,7 +367,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -525,7 +741,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -763,6 +978,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2944,6 +3177,99 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2954,6 +3280,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3092,6 +3425,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3200,6 +3534,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -3421,6 +3765,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3478,6 +3832,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -3740,6 +4095,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3751,6 +4127,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3825,6 +4215,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3866,6 +4263,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3911,6 +4318,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3946,6 +4360,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -4201,6 +4628,7 @@
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4965,6 +5393,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5000,6 +5441,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -5287,6 +5738,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5486,6 +5944,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5517,6 +5976,58 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/json-buffer": {
@@ -5586,6 +6097,7 @@
       "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -5944,6 +6456,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5963,6 +6485,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5986,6 +6515,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -6329,6 +6868,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6450,6 +7002,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -6604,6 +7157,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6659,6 +7250,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6671,6 +7263,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6694,6 +7287,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
@@ -6825,6 +7425,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6867,6 +7481,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -7067,6 +7691,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7512,6 +8149,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7574,6 +8224,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -7590,6 +8247,7 @@
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7727,6 +8385,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7744,6 +8403,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7755,6 +8434,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -7880,6 +8585,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -7977,6 +8692,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -8564,7 +9280,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8582,7 +9297,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8600,7 +9314,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8618,7 +9331,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8636,7 +9348,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8654,7 +9365,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8672,7 +9382,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8690,7 +9399,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8708,7 +9416,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8726,7 +9433,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8744,7 +9450,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8762,7 +9467,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8780,7 +9484,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8798,7 +9501,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8816,7 +9518,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8834,7 +9535,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8852,7 +9552,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8870,7 +9569,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8888,7 +9586,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8906,7 +9603,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8924,7 +9620,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8942,7 +9637,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8960,7 +9654,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8978,7 +9671,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8996,7 +9688,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9028,50 +9719,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
-      }
-    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -9091,6 +9738,7 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -9161,6 +9809,54 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -9389,6 +10085,23 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -136,6 +136,7 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -306,7 +307,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -355,9 +355,33 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -367,6 +391,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -741,6 +766,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3286,7 +3312,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3425,7 +3452,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3832,7 +3858,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -4323,7 +4348,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4628,7 +4654,6 @@
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5944,7 +5969,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5984,7 +6008,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -6097,7 +6120,6 @@
       "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6462,6 +6484,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7002,7 +7025,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -7163,6 +7185,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7178,6 +7201,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7188,6 +7212,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7250,7 +7275,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7263,7 +7287,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7293,7 +7316,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
@@ -8247,7 +8271,6 @@
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8385,7 +8408,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8692,7 +8714,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -9280,6 +9301,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9297,6 +9319,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9314,6 +9337,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9331,6 +9355,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9348,6 +9373,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9365,6 +9391,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9382,6 +9409,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9399,6 +9427,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9416,6 +9445,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9433,6 +9463,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9450,6 +9481,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9467,6 +9499,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9484,6 +9517,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9501,6 +9535,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9518,6 +9553,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9535,6 +9571,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9552,6 +9589,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9569,6 +9607,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9586,6 +9625,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9603,6 +9643,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9620,6 +9661,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9637,6 +9679,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9654,6 +9697,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9671,6 +9715,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9688,6 +9733,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9719,6 +9765,50 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -9738,7 +9828,6 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,9 @@
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@tailwindcss/typography": "^0.5.15",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.3",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.0",
@@ -54,6 +57,7 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
+    "jsdom": "^29.1.1",
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",

--- a/frontend/src/components/ComicEditDialog.jsx
+++ b/frontend/src/components/ComicEditDialog.jsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -109,6 +116,13 @@ export function ComicEditDialog({ comic, isOpen, onClose, onSave }) {
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>Edit Comic Details</DialogTitle>
+          {/* Radix wires this to the dialog as its accessible description, so a
+              screen reader announces what the form is for rather than reading
+              the title and dropping the user into an unexplained set of fields.
+              Without one it also warns on every mount. */}
+          <DialogDescription>
+            Change the details stored for this comic, including whether it is classified 18+.
+          </DialogDescription>
         </DialogHeader>
         
         <div className="grid gap-4 py-4">

--- a/frontend/src/components/ComicEditDialog.jsx
+++ b/frontend/src/components/ComicEditDialog.jsx
@@ -4,12 +4,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
 import { X, Tag as TagIcon, Plus } from "lucide-react";
 import { useToast } from "@/hooks/use-toast.js";
 import { useTags } from "@/hooks/use-tags.jsx";
 import { TagBadge } from "@/components/TagBadge";
 import { TagCombobox } from "@/components/TagCombobox";
 import { describeTagSubmission } from "@/lib/tag-suggestions.js";
+import { EXPLICIT_FLAG_DESCRIPTION, EXPLICIT_FLAG_LABEL } from "@/lib/sharing.js";
 
 export function ComicEditDialog({ comic, isOpen, onClose, onSave }) {
   const [title, setTitle] = useState("");
@@ -17,6 +19,7 @@ export function ComicEditDialog({ comic, isOpen, onClose, onSave }) {
   const [publisher, setPublisher] = useState("");
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState([]);
+  const [explicitContent, setExplicitContent] = useState(false);
   const [newTag, setNewTag] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
@@ -29,6 +32,10 @@ export function ComicEditDialog({ comic, isOpen, onClose, onSave }) {
       setPublisher(comic.publisher || "");
       setDescription(comic.description || "");
       setTags(comic.tags || []);
+      // Restored from the comic like every other field, and never inferred from
+      // one: adding or removing a tag — including one that hides the comic from
+      // the library — must leave this exactly as the owner set it.
+      setExplicitContent(comic.explicitContent === true);
     }
   }, [comic]);
 
@@ -67,7 +74,8 @@ export function ComicEditDialog({ comic, isOpen, onClose, onSave }) {
         author,
         publisher,
         description,
-        tags
+        tags,
+        explicitContent
       });
       
       // If we have new tags, add them to the cache
@@ -182,6 +190,24 @@ export function ComicEditDialog({ comic, isOpen, onClose, onSave }) {
                 <Plus size={16} className="mr-1" />
                 Add
               </Button>
+            </div>
+          </div>
+
+          {/* Below the tags, and deliberately not among them. Hiding a comic
+              from the library is a shelving choice; this is a statement about
+              what is inside it, and the two must not be read as one setting. */}
+          <div className="flex items-start gap-3 rounded-md border p-3">
+            <Checkbox
+              id="explicit-content"
+              checked={explicitContent}
+              onCheckedChange={(checked) => setExplicitContent(checked === true)}
+              className="mt-0.5"
+            />
+            <div className="grid gap-1">
+              <Label htmlFor="explicit-content" className="cursor-pointer">
+                {EXPLICIT_FLAG_LABEL}
+              </Label>
+              <p className="text-xs text-muted-foreground">{EXPLICIT_FLAG_DESCRIPTION}</p>
             </div>
           </div>
         </div>

--- a/frontend/src/components/ComicEditDialog.test.jsx
+++ b/frontend/src/components/ComicEditDialog.test.jsx
@@ -53,6 +53,15 @@ describe("ComicEditDialog explicit-content flag", () => {
       .toHaveTextContent("confirm they are 18 or older");
   });
 
+  it("gives the dialog an accessible description", () => {
+    renderDialog();
+
+    // A screen reader otherwise announces the title and drops the user into an
+    // unexplained set of fields — and Radix warns about it on every mount,
+    // which is how this was found.
+    expect(screen.getByRole("dialog")).toHaveAccessibleDescription(/classified 18\+/i);
+  });
+
   it("is unticked for a comic nobody has classified", () => {
     renderDialog();
 

--- a/frontend/src/components/ComicEditDialog.test.jsx
+++ b/frontend/src/components/ComicEditDialog.test.jsx
@@ -1,0 +1,119 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ComicEditDialog } from "./ComicEditDialog";
+import { EXPLICIT_FLAG_DESCRIPTION } from "@/lib/sharing";
+
+vi.mock("@/hooks/use-toast.js", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("@/hooks/use-tags.jsx", () => ({
+  useTags: () => ({
+    tags: [{ id: 1, name: "noir", isGlobal: false, hideFromLibrary: false }],
+    addTagToCache: vi.fn(),
+    searchTags: vi.fn().mockResolvedValue([]),
+    isAdminContext: () => false,
+  }),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+
+const comic = (overrides = {}) => ({
+  id: 3,
+  title: "Sandman",
+  author: "Neil Gaiman",
+  publisher: "Vertigo",
+  description: "Dreams.",
+  tags: [],
+  explicitContent: false,
+  ...overrides,
+});
+
+const renderDialog = (props = {}) => {
+  const onSave = props.onSave ?? vi.fn().mockResolvedValue({});
+
+  const result = render(
+    <ComicEditDialog comic={comic()} isOpen onClose={() => {}} onSave={onSave} {...props} />
+  );
+
+  return { ...result, onSave };
+};
+
+const explicitBox = () => screen.getByRole("checkbox", { name: /explicit content \(18\+\)/i });
+const save = () => screen.getByRole("button", { name: /save changes/i });
+
+describe("ComicEditDialog explicit-content flag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains what marking a comic explicit does to its recipients", () => {
+    renderDialog();
+
+    expect(screen.getByText(EXPLICIT_FLAG_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.getByText(EXPLICIT_FLAG_DESCRIPTION))
+      .toHaveTextContent("confirm they are 18 or older");
+  });
+
+  it("is unticked for a comic nobody has classified", () => {
+    renderDialog();
+
+    expect(explicitBox()).not.toBeChecked();
+  });
+
+  it("restores the flag from the comic it was opened on", () => {
+    renderDialog({ comic: comic({ explicitContent: true }) });
+
+    expect(explicitBox()).toBeChecked();
+  });
+
+  it("treats a comic with no flag at all as not explicit", () => {
+    // An older payload, or one from an endpoint that does not send the field.
+    // Absence is not a classification, and must not read as one either way.
+    renderDialog({ comic: comic({ explicitContent: undefined }) });
+
+    expect(explicitBox()).not.toBeChecked();
+  });
+
+  it("saves the flag through the ordinary update", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderDialog();
+
+    await user.click(explicitBox());
+    await user.click(save());
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      id: 3,
+      title: "Sandman",
+      explicitContent: true,
+    }));
+  });
+
+  it("saves an unticked box as an explicit false, not as an omission", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderDialog({ comic: comic({ explicitContent: true }) });
+
+    // Unticking has to be a change. Sending nothing would leave the comic
+    // classified 18+ with the owner believing they had cleared it.
+    await user.click(explicitBox());
+    await user.click(save());
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ explicitContent: false }));
+  });
+
+  it("is untouched by adding or removing tags", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderDialog({ comic: comic({ explicitContent: true, tags: ["noir"] }) });
+
+    await user.type(screen.getByLabelText(/add a tag/i), "horror");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    // The badge's remove control is an icon-only button inside it, so it is
+    // reached through the badge rather than by an accessible name it has none of.
+    await user.click(within(screen.getByText("noir")).getByRole("button"));
+
+    // Hiding or shelving a comic says nothing about what is inside it, so no
+    // tag edit may move the classification in either direction.
+    expect(explicitBox()).toBeChecked();
+
+    await user.click(save());
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ explicitContent: true }));
+  });
+});

--- a/frontend/src/components/ShareComicModal.jsx
+++ b/frontend/src/components/ShareComicModal.jsx
@@ -11,14 +11,21 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Check, Copy, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
-import { isValidShareEmail } from "@/lib/sharing";
+import {
+  SHARE_RESPONSIBILITY_ACK_LABEL,
+  SHARE_RESPONSIBILITY_NOTICE,
+  buildInvitationRequest,
+  canSendInvitation,
+} from "@/lib/sharing";
 
 export function ShareComicModal({ isOpen, onClose, comicId, comicTitle, onShared }) {
   const [recipientEmail, setRecipientEmail] = useState("");
+  const [responsibilityAccepted, setResponsibilityAccepted] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [invitationUrl, setInvitationUrl] = useState(null);
@@ -30,6 +37,7 @@ export function ShareComicModal({ isOpen, onClose, comicId, comicTitle, onShared
       // Allow the close animation to finish before wiping the contents.
       const timeout = setTimeout(() => {
         setRecipientEmail("");
+        setResponsibilityAccepted(false);
         setIsLoading(false);
         setError(null);
         setInvitationUrl(null);
@@ -42,12 +50,20 @@ export function ShareComicModal({ isOpen, onClose, comicId, comicTitle, onShared
     setError(null);
     setInvitationUrl(null);
     setCopied(false);
+    // Unticked for every share, including a second one opened straight after
+    // the first. The acknowledgement is about this comic going to this person,
+    // so carrying it over would record an agreement nobody made.
+    setResponsibilityAccepted(false);
     return undefined;
   }, [isOpen, comicId]);
 
   const handleShare = async () => {
-    if (!isValidShareEmail(recipientEmail)) {
-      setError("Please enter a valid email address.");
+    if (!canSendInvitation({ email: recipientEmail, responsibilityAccepted })) {
+      setError(
+        responsibilityAccepted
+          ? "Please enter a valid email address."
+          : "Please confirm that you understand you are responsible for what you share."
+      );
       return;
     }
 
@@ -55,9 +71,10 @@ export function ShareComicModal({ isOpen, onClose, comicId, comicTitle, onShared
     setError(null);
 
     try {
-      const data = await api.post(`/api/shares/comics/${comicId}/invitations`, {
-        email: recipientEmail.trim(),
-      });
+      const data = await api.post(
+        `/api/shares/comics/${comicId}/invitations`,
+        buildInvitationRequest({ email: recipientEmail, responsibilityAccepted })
+      );
 
       // Shown rather than auto-closing: this is the only moment the link
       // exists in a readable form, because the server keeps only its hash.
@@ -135,6 +152,25 @@ export function ShareComicModal({ isOpen, onClose, comicId, comicTitle, onShared
                 disabled={isLoading}
               />
             </div>
+
+            {/* Next to the address and the Send button rather than in the
+                dialog's preamble: this has to be read at the moment of sending,
+                not skimmed on the way in. */}
+            <div className="space-y-3 rounded-md border p-3">
+              <p className="text-sm text-muted-foreground">{SHARE_RESPONSIBILITY_NOTICE}</p>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="share-responsibility"
+                  checked={responsibilityAccepted}
+                  onCheckedChange={(checked) => setResponsibilityAccepted(checked === true)}
+                  disabled={isLoading}
+                />
+                <Label htmlFor="share-responsibility" className="cursor-pointer text-sm font-medium">
+                  {SHARE_RESPONSIBILITY_ACK_LABEL}
+                </Label>
+              </div>
+            </div>
+
             {error && <p className="text-sm text-destructive">{error}</p>}
           </div>
         )}
@@ -146,7 +182,9 @@ export function ShareComicModal({ isOpen, onClose, comicId, comicTitle, onShared
           {!invitationUrl && (
             <Button
               onClick={handleShare}
-              disabled={isLoading || !isValidShareEmail(recipientEmail)}
+              disabled={
+                isLoading || !canSendInvitation({ email: recipientEmail, responsibilityAccepted })
+              }
             >
               {isLoading ? (
                 <>

--- a/frontend/src/components/ShareComicModal.test.jsx
+++ b/frontend/src/components/ShareComicModal.test.jsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ShareComicModal } from "./ShareComicModal";
+import { api } from "@/lib/api";
+import { SHARE_RESPONSIBILITY_NOTICE } from "@/lib/sharing";
+
+vi.mock("@/lib/api", () => ({ api: { post: vi.fn() } }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+
+const renderModal = (props = {}) => render(
+  <MemoryRouter>
+    <ShareComicModal
+      isOpen
+      onClose={() => {}}
+      comicId={7}
+      comicTitle="Sandman"
+      {...props}
+    />
+  </MemoryRouter>
+);
+
+const sendButton = () => screen.getByRole("button", { name: /send invitation/i });
+const acknowledgement = () => screen.getByRole("checkbox", { name: /i understand/i });
+
+describe("ShareComicModal", () => {
+  beforeEach(() => {
+    vi.mocked(api.post).mockReset();
+    vi.mocked(api.post).mockResolvedValue({ invitationUrl: "https://example.test/share/invitation/abc" });
+  });
+
+  it("states that the sender is responsible for what they share", () => {
+    renderModal();
+
+    // Asserted against the exported copy rather than a paraphrase, so the
+    // notice cannot be watered down in the component without this failing.
+    expect(screen.getByText(SHARE_RESPONSIBILITY_NOTICE)).toBeInTheDocument();
+    expect(screen.getByText(SHARE_RESPONSIBILITY_NOTICE))
+      .toHaveTextContent("Explicit content (18+)");
+  });
+
+  it("starts with the acknowledgement unticked", () => {
+    renderModal();
+
+    expect(acknowledgement()).not.toBeChecked();
+    expect(sendButton()).toBeDisabled();
+  });
+
+  it("keeps Send disabled while only one of the two conditions is met", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/recipient email/i), "jane@example.com");
+    // A well-formed address is not consent.
+    expect(sendButton()).toBeDisabled();
+
+    await user.clear(screen.getByLabelText(/recipient email/i));
+    await user.click(acknowledgement());
+    expect(acknowledgement()).toBeChecked();
+    // And consent is not an address.
+    expect(sendButton()).toBeDisabled();
+  });
+
+  it("enables Send only once the address is valid and the box is ticked", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/recipient email/i), "jane@example.com");
+    await user.click(acknowledgement());
+
+    expect(sendButton()).toBeEnabled();
+  });
+
+  it("sends the acknowledgement with the invitation", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/recipient email/i), "  jane@example.com  ");
+    await user.click(acknowledgement());
+    await user.click(sendButton());
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/shares/comics/7/invitations",
+      { email: "jane@example.com", senderResponsibilityAccepted: true }
+    );
+  });
+
+  it("cannot send without the acknowledgement even if the button is reached anyway", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/recipient email/i), "jane@example.com");
+    // Firing the click on a disabled button is what a stale render or a
+    // programmatic caller would do; the handler has to refuse on its own.
+    await user.click(sendButton());
+
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("unticks the acknowledgement when the modal is opened for another comic", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderModal();
+
+    await user.click(acknowledgement());
+    expect(acknowledgement()).toBeChecked();
+
+    // The acknowledgement is about this comic going to this person. Carrying it
+    // into the next share would record an agreement nobody made.
+    rerender(
+      <MemoryRouter>
+        <ShareComicModal isOpen onClose={() => {}} comicId={8} comicTitle="Preacher" />
+      </MemoryRouter>
+    );
+
+    expect(acknowledgement()).not.toBeChecked();
+    expect(sendButton()).toBeDisabled();
+  });
+});

--- a/frontend/src/lib/sharing.js
+++ b/frontend/src/lib/sharing.js
@@ -61,6 +61,21 @@ export function describeReceivedShare(share) {
       return "The owner has stopped sharing this comic with you.";
     case SHARE_STATUS.DECLINED:
       return "You declined this invitation.";
+    default:
+      break;
+  }
+
+  // After the endings, before the ordinary states. An age gate is something the
+  // recipient can act on, so it is worth saying — but only while there is still
+  // something behind it. Offering to unlock a share the owner has already
+  // withdrawn would be an invitation to a dead end.
+  if (share.requiresAdultConfirmation) {
+    return share.status === SHARE_STATUS.ACCEPTED
+      ? "This comic is marked 18+. Confirm your age to read it again."
+      : "This comic is marked 18+. Confirm your age to see what is being shared.";
+  }
+
+  switch (share.status) {
     case SHARE_STATUS.PENDING:
       return share.isExpired
         ? "This invitation expired before you answered it."
@@ -184,4 +199,95 @@ export function isValidShareEmail(email) {
   return trimmed.length <= 254
     && /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
       .test(trimmed);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Explicit content                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The wording for both halves of the classification feature, kept here rather
+ * than inline in the components.
+ *
+ * These sentences are the feature: they are what tells a sender what they are
+ * taking on and a recipient what they are about to open. Keeping them in one
+ * place is what lets them be asserted directly, and stops the share modal and
+ * the sharing page drifting into saying different things.
+ */
+export const SHARE_RESPONSIBILITY_NOTICE = "You are responsible for the content you share. "
+  + "Only share material you are allowed to distribute, and make sure adult or explicit comics "
+  + "are correctly marked as Explicit content (18+) before sending them.";
+
+export const SHARE_RESPONSIBILITY_ACK_LABEL = "I understand";
+
+export const SHARING_PAGE_RESPONSIBILITY_REMINDER =
+  "You are responsible for the content you share and for marking explicit material correctly.";
+
+export const EXPLICIT_FLAG_LABEL = "Explicit content (18+)";
+
+export const EXPLICIT_FLAG_DESCRIPTION = "Mark this comic as containing adult or explicit material. "
+  + "Recipients will have to confirm they are 18 or older before the comic is revealed or accepted.";
+
+export const EXPLICIT_GATE_TITLE = "Explicit content — 18+";
+
+export const EXPLICIT_GATE_BODY = "This shared comic has been marked by its owner as containing "
+  + "explicit adult content. You must be 18 or older to continue. The cover and comic details will "
+  + "remain hidden until you confirm.";
+
+export const EXPLICIT_GATE_CONFIRM_LABEL = "I am 18 or older — continue";
+
+/**
+ * Whether an invitation or share is still waiting on the recipient's age
+ * declaration.
+ *
+ * Reads the server's answer rather than deriving one from `explicitContent`:
+ * the backend is the thing that decides what it has withheld, and a client that
+ * worked it out separately could show a title the server had redacted, or hide
+ * one it had not.
+ */
+export function requiresAdultConfirmation(share) {
+  return share?.requiresAdultConfirmation === true;
+}
+
+/**
+ * What to call a comic whose title the server is withholding.
+ *
+ * There is genuinely nothing to show — the redaction is the point — so this
+ * names the state instead of leaving an empty heading.
+ */
+export function shareDisplayTitle(share) {
+  if (requiresAdultConfirmation(share)) {
+    // A dead entry stays redacted — the recipient never passed the gate, and
+    // the share ending is not the same as them having done so — but there is no
+    // longer anything to confirm, so it must not promise one.
+    return share?.isDead
+      ? "Hidden — explicit content (18+)"
+      : "Hidden until you confirm your age";
+  }
+
+  return share?.comicTitle || "Untitled comic";
+}
+
+/**
+ * Whether "Send invitation" may be pressed.
+ *
+ * Both conditions, always. The acknowledgement is not a formality the UI can
+ * skip once an address looks right — the backend rejects a share without it —
+ * and putting the rule here keeps the button and the request in agreement.
+ */
+export function canSendInvitation({ email, responsibilityAccepted }) {
+  return isValidShareEmail(email) && responsibilityAccepted === true;
+}
+
+/**
+ * The body of an invitation request.
+ *
+ * The acknowledgement goes on the wire as a literal `true`; the server accepts
+ * nothing else, and the timestamp it stores is its own.
+ */
+export function buildInvitationRequest({ email, responsibilityAccepted }) {
+  return {
+    email: typeof email === "string" ? email.trim() : "",
+    senderResponsibilityAccepted: responsibilityAccepted === true,
+  };
 }

--- a/frontend/src/lib/sharing.test.js
+++ b/frontend/src/lib/sharing.test.js
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
+  EXPLICIT_FLAG_LABEL,
+  SHARE_RESPONSIBILITY_ACK_LABEL,
+  SHARE_RESPONSIBILITY_NOTICE,
   SHARE_STATUS,
+  SHARING_PAGE_RESPONSIBILITY_REMINDER,
+  buildInvitationRequest,
+  canSendInvitation,
   describeBulkShareImpactOfDeletion,
   describeDeadShareCleanup,
   describeReceivedShare,
   describeShareImpactOfDeletion,
   groupReceivedShares,
   isValidShareEmail,
+  requiresAdultConfirmation,
+  shareDisplayTitle,
   summariseRecipients,
   tombstoneExplanation,
 } from "./sharing";
@@ -198,5 +206,159 @@ describe("isValidShareEmail", () => {
 
   it("rejects an address past the RFC 5321 length limit", () => {
     expect(isValidShareEmail(`${"a".repeat(250)}@example.com`)).toBe(false);
+  });
+});
+
+describe("the sender responsibility acknowledgement", () => {
+  it("is worded as a statement about the sender's own obligations", () => {
+    // The wording is the feature. It has to say who is responsible and what
+    // they are being asked to have done, not merely that rules exist.
+    expect(SHARE_RESPONSIBILITY_NOTICE).toContain("You are responsible for the content you share");
+    expect(SHARE_RESPONSIBILITY_NOTICE).toContain("allowed to distribute");
+    expect(SHARE_RESPONSIBILITY_NOTICE).toContain(EXPLICIT_FLAG_LABEL);
+    expect(SHARE_RESPONSIBILITY_ACK_LABEL).toBe("I understand");
+  });
+
+  it("is reflected on the sharing page as a reminder", () => {
+    expect(SHARING_PAGE_RESPONSIBILITY_REMINDER)
+      .toContain("You are responsible for the content you share");
+    expect(SHARING_PAGE_RESPONSIBILITY_REMINDER).toContain("marking explicit material correctly");
+  });
+});
+
+describe("canSendInvitation", () => {
+  it("needs both a valid address and the acknowledgement", () => {
+    expect(canSendInvitation({ email: "jane@example.com", responsibilityAccepted: true })).toBe(true);
+  });
+
+  it("refuses a valid address without the acknowledgement", () => {
+    // The whole point of the tick box: a well-formed address is not consent.
+    expect(canSendInvitation({ email: "jane@example.com", responsibilityAccepted: false })).toBe(false);
+    expect(canSendInvitation({ email: "jane@example.com" })).toBe(false);
+  });
+
+  it("refuses an acknowledgement without a valid address", () => {
+    expect(canSendInvitation({ email: "jane@", responsibilityAccepted: true })).toBe(false);
+    expect(canSendInvitation({ email: "", responsibilityAccepted: true })).toBe(false);
+  });
+
+  it("treats anything other than a literal true as unacknowledged", () => {
+    expect(canSendInvitation({ email: "jane@example.com", responsibilityAccepted: "true" })).toBe(false);
+    expect(canSendInvitation({ email: "jane@example.com", responsibilityAccepted: 1 })).toBe(false);
+  });
+});
+
+describe("buildInvitationRequest", () => {
+  it("sends the trimmed address and the acknowledgement", () => {
+    expect(buildInvitationRequest({ email: "  jane@example.com ", responsibilityAccepted: true }))
+      .toEqual({ email: "jane@example.com", senderResponsibilityAccepted: true });
+  });
+
+  it("never claims an acknowledgement that was not given", () => {
+    expect(buildInvitationRequest({ email: "jane@example.com" }).senderResponsibilityAccepted)
+      .toBe(false);
+    expect(
+      buildInvitationRequest({ email: "jane@example.com", responsibilityAccepted: "yes" })
+        .senderResponsibilityAccepted
+    ).toBe(false);
+  });
+
+  it("carries no timestamp of its own", () => {
+    // Both acknowledgement timestamps are the server's. A client that sent one
+    // would be writing its own audit trail.
+    expect(Object.keys(buildInvitationRequest({ email: "jane@example.com", responsibilityAccepted: true })))
+      .toEqual(["email", "senderResponsibilityAccepted"]);
+  });
+});
+
+describe("requiresAdultConfirmation", () => {
+  it("follows the server's answer rather than deriving one", () => {
+    // Only the backend knows what it redacted, so an explicit comic that has
+    // already been confirmed for is not gated, and nothing here second-guesses
+    // that from `explicitContent` alone.
+    expect(requiresAdultConfirmation({ explicitContent: true, requiresAdultConfirmation: true })).toBe(true);
+    expect(requiresAdultConfirmation({ explicitContent: true, requiresAdultConfirmation: false })).toBe(false);
+    expect(requiresAdultConfirmation({ explicitContent: false })).toBe(false);
+    expect(requiresAdultConfirmation(null)).toBe(false);
+  });
+});
+
+describe("shareDisplayTitle", () => {
+  it("names the redaction rather than showing an empty heading", () => {
+    expect(shareDisplayTitle({ requiresAdultConfirmation: true, comicTitle: null }))
+      .toBe("Hidden until you confirm your age");
+  });
+
+  it("uses the title once the server is willing to send one", () => {
+    expect(shareDisplayTitle({ requiresAdultConfirmation: false, comicTitle: "Sandman" }))
+      .toBe("Sandman");
+    expect(shareDisplayTitle({ comicTitle: "" })).toBe("Untitled comic");
+  });
+});
+
+describe("describeReceivedShare, for explicit shares", () => {
+  it("asks a pending invitation's recipient to confirm before anything is revealed", () => {
+    const line = describeReceivedShare(share({
+      status: SHARE_STATUS.PENDING,
+      requiresAdultConfirmation: true,
+      comicTitle: null,
+    }));
+
+    expect(line).toContain("marked 18+");
+    expect(line).toContain("Confirm your age");
+  });
+
+  it("explains a comic that was re-gated after being accepted", () => {
+    // The owner marked an already-shared comic explicit. The share survived;
+    // reading it did not, until the recipient confirms again.
+    const line = describeReceivedShare(share({
+      status: SHARE_STATUS.ACCEPTED,
+      requiresAdultConfirmation: true,
+    }));
+
+    expect(line).toContain("Confirm your age to read it again");
+  });
+
+  it("says nothing extra once the gate is passed", () => {
+    expect(describeReceivedShare(share({
+      status: SHARE_STATUS.ACCEPTED,
+      explicitContent: true,
+      requiresAdultConfirmation: false,
+    }))).toBe("In your collection.");
+  });
+
+  it("still explains a tombstone rather than the gate", () => {
+    // Nothing can be confirmed for a comic that is gone; the recipient needs
+    // the explanation, which is all the tombstone has left.
+    expect(describeReceivedShare(share({
+      isTombstoned: true,
+      tombstoneReason: "owner_deleted",
+      requiresAdultConfirmation: true,
+    }))).toContain("no longer available");
+  });
+});
+
+describe("explicit shares that have ended", () => {
+  it("explains the ending rather than offering a gate that leads nowhere", () => {
+    // Confirming an age for a share the owner has withdrawn achieves nothing;
+    // saying so would be an invitation to a dead end.
+    expect(describeReceivedShare(share({
+      status: SHARE_STATUS.REVOKED,
+      isDead: true,
+      requiresAdultConfirmation: true,
+    }))).toContain("The owner has stopped sharing");
+
+    expect(describeReceivedShare(share({
+      status: SHARE_STATUS.DECLINED,
+      isDead: true,
+      requiresAdultConfirmation: true,
+    }))).toContain("You declined");
+  });
+
+  it("stays redacted without promising a confirmation", () => {
+    // The recipient never passed the gate, and the share ending is not the same
+    // as them having done so.
+    expect(shareDisplayTitle({ requiresAdultConfirmation: true, isDead: true }))
+      .toBe("Hidden — explicit content (18+)");
   });
 });

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -171,6 +171,7 @@ export default function Dashboard() {
             publisher: updatedComic.publisher,
             description: updatedComic.description,
             tags: updatedComic.tags,
+            explicitContent: updatedComic.explicitContent === true,
           },
         }],
       });

--- a/frontend/src/pages/ShareInvitation.jsx
+++ b/frontend/src/pages/ShareInvitation.jsx
@@ -6,10 +6,17 @@ import { useComicLibrary } from "@/hooks/use-comic-library";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { AlertCircle, BookOpen, Loader2 } from "lucide-react";
+import { AlertCircle, BookOpen, Loader2, ShieldAlert } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import {
+  EXPLICIT_GATE_BODY,
+  EXPLICIT_GATE_CONFIRM_LABEL,
+  EXPLICIT_GATE_TITLE,
+  requiresAdultConfirmation,
+  shareDisplayTitle,
+} from "@/lib/sharing";
 
 /**
  * The page an invitation link opens.
@@ -62,6 +69,27 @@ export default function ShareInvitation() {
   useEffect(() => {
     loadInvitation();
   }, [loadInvitation]);
+
+  /**
+   * Make the age declaration, then redisplay whatever the server chooses to
+   * reveal in response.
+   *
+   * The preview is reloaded rather than patched from local state: the unlocked
+   * metadata only exists because the backend decided to send it, and rendering
+   * it any earlier would be the client deciding instead.
+   */
+  const confirmAdult = async () => {
+    setIsAnswering(true);
+    setError(null);
+    try {
+      await api.post(`/api/shares/invitations/${token}/confirm-adult`, { adultConfirmed: true });
+      await loadInvitation();
+    } catch (err) {
+      setError(err.message || "Your age could not be confirmed.");
+    } finally {
+      setIsAnswering(false);
+    }
+  };
 
   const answer = async (decision) => {
     setIsAnswering(true);
@@ -140,8 +168,22 @@ export default function ShareInvitation() {
 
     if (!invitation) return null;
 
+    const gated = requiresAdultConfirmation(invitation);
+
+    const explicitWarning = (
+      <Alert>
+        <ShieldAlert className="h-5 w-5" />
+        <AlertTitle>{EXPLICIT_GATE_TITLE}</AlertTitle>
+        <AlertDescription>{EXPLICIT_GATE_BODY}</AlertDescription>
+      </Alert>
+    );
+
     const preview = (
       <div className="flex gap-4">
+        {/* A neutral placeholder, never the real cover behind a blur: blurring
+            still sends the cover, and the point of the gate is that those bytes
+            do not leave the server until somebody has confirmed. The backend
+            withholds the URL entirely, so there is nothing here to blur. */}
         {invitation.coverImagePath ? (
           <img
             src={invitation.coverImagePath}
@@ -150,11 +192,13 @@ export default function ShareInvitation() {
           />
         ) : (
           <div className="flex h-40 w-28 flex-none items-center justify-center rounded bg-muted">
-            <BookOpen className="h-8 w-8 text-muted-foreground" />
+            {gated
+              ? <ShieldAlert className="h-8 w-8 text-muted-foreground" />
+              : <BookOpen className="h-8 w-8 text-muted-foreground" />}
           </div>
         )}
         <div className="min-w-0 space-y-1">
-          <h1 className="font-comic text-2xl">{invitation.comicTitle}</h1>
+          <h1 className="font-comic text-2xl">{shareDisplayTitle(invitation)}</h1>
           {invitation.comicAuthor && (
             <p className="text-sm text-muted-foreground">{invitation.comicAuthor}</p>
           )}
@@ -179,6 +223,10 @@ export default function ShareInvitation() {
         <Card className="w-full max-w-lg">
           <CardContent className="space-y-4 p-6">
             {preview}
+            {/* Holding the link is not an age declaration — nobody has said who
+                they are yet — so a signed-out visitor is told what the
+                invitation is and nothing about the comic. */}
+            {gated && explicitWarning}
             <p className="rounded bg-muted p-3 text-sm text-muted-foreground">
               This comic remains owned by {invitation.ownerName}. It may become unavailable if the
               owner removes it or stops sharing it.
@@ -212,6 +260,29 @@ export default function ShareInvitation() {
             <Button variant="outline" onClick={() => navigate("/dashboard")}>
               Go to my collection
             </Button>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    // The recipient, signed in, on an explicit comic they have not confirmed
+    // for. Accepting is not offered at all here: it is the age declaration that
+    // has to come first, and the backend refuses an accept without it anyway.
+    if (gated) {
+      return (
+        <Card className="w-full max-w-lg">
+          <CardContent className="space-y-4 p-6">
+            {preview}
+            {explicitWarning}
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Button disabled={isAnswering} onClick={confirmAdult}>
+                {isAnswering && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {EXPLICIT_GATE_CONFIRM_LABEL}
+              </Button>
+              <Button variant="outline" disabled={isAnswering} onClick={() => answer("decline")}>
+                Decline
+              </Button>
+            </div>
           </CardContent>
         </Card>
       );

--- a/frontend/src/pages/ShareInvitation.test.jsx
+++ b/frontend/src/pages/ShareInvitation.test.jsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ShareInvitation from "./ShareInvitation";
+import { api } from "@/lib/api";
+import { EXPLICIT_GATE_BODY, EXPLICIT_GATE_TITLE } from "@/lib/sharing";
+
+const auth = { isAuthenticated: true, loading: false };
+
+vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => auth }));
+vi.mock("@/hooks/use-sharing", () => ({ useSharing: () => ({ refreshSummary: vi.fn() }) }));
+vi.mock("@/hooks/use-comic-library", () => ({
+  useComicLibrary: () => ({ loadLibrary: vi.fn() }),
+}));
+
+/** What the backend returns for an explicit comic nobody has confirmed for. */
+const gatedInvitation = {
+  comicTitle: null,
+  comicAuthor: null,
+  pageCount: null,
+  coverImagePath: null,
+  ownerName: "Alex Owner",
+  recipientEmail: "jane@example.com",
+  expiresAt: "2026-09-01T00:00:00+00:00",
+  isForCurrentUser: true,
+  explicitContent: true,
+  requiresAdultConfirmation: true,
+  adultConfirmed: false,
+};
+
+const unlockedInvitation = {
+  ...gatedInvitation,
+  comicTitle: "Now Visible",
+  comicAuthor: "Some Author",
+  pageCount: 42,
+  coverImagePath: "/api/comics/cover/1/2/cover.png",
+  requiresAdultConfirmation: false,
+  adultConfirmed: true,
+};
+
+const ordinaryInvitation = {
+  ...unlockedInvitation,
+  comicTitle: "Ordinary Comic",
+  explicitContent: false,
+  requiresAdultConfirmation: false,
+  adultConfirmed: false,
+};
+
+const renderPage = () => render(
+  <MemoryRouter initialEntries={["/share/invitation/tok123"]}>
+    <Routes>
+      <Route path="/share/invitation/:token" element={<ShareInvitation />} />
+    </Routes>
+  </MemoryRouter>
+);
+
+describe("ShareInvitation explicit-content gate", () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockReset();
+    vi.mocked(api.post).mockReset();
+    auth.isAuthenticated = true;
+    auth.loading = false;
+  });
+
+  it("shows only the warning and a placeholder for an unconfirmed explicit comic", async () => {
+    vi.mocked(api.get).mockResolvedValue({ invitation: gatedInvitation });
+    renderPage();
+
+    expect(await screen.findByText(EXPLICIT_GATE_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(EXPLICIT_GATE_BODY)).toBeInTheDocument();
+    expect(screen.getByText("Hidden until you confirm your age")).toBeInTheDocument();
+    // Nothing that identifies the comic, and no cover to blur — the backend
+    // sent no URL, so there are no bytes here to expose.
+    expect(screen.queryByText("Now Visible")).not.toBeInTheDocument();
+    expect(screen.queryByText("42 pages")).not.toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    // The owner and the expiry are still enough to decide with.
+    expect(screen.getByText("Alex Owner")).toBeInTheDocument();
+  });
+
+  it("offers the age declaration instead of Accept", async () => {
+    vi.mocked(api.get).mockResolvedValue({ invitation: gatedInvitation });
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /i am 18 or older/i })).toBeInTheDocument();
+    // Accepting is refused by the backend until the declaration is made, so the
+    // page must not offer it as though it would work.
+    expect(screen.queryByRole("button", { name: /add to my collection/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /decline/i })).toBeInTheDocument();
+  });
+
+  it("reveals the comic only after the backend accepts the declaration", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ invitation: gatedInvitation })
+      .mockResolvedValueOnce({ invitation: unlockedInvitation });
+    vi.mocked(api.post).mockResolvedValue({ share: {} });
+
+    renderPage();
+    await user.click(await screen.findByRole("button", { name: /i am 18 or older/i }));
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/shares/invitations/tok123/confirm-adult",
+      { adultConfirmed: true }
+    );
+    // The unlocked metadata exists because the server chose to send it. The
+    // page re-reads rather than revealing anything it decided for itself.
+    expect(await screen.findByText("Now Visible")).toBeInTheDocument();
+    expect(screen.getByText("42 pages")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add to my collection/i })).toBeInTheDocument();
+  });
+
+  it("keeps the comic hidden when the declaration is refused", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValue({ invitation: gatedInvitation });
+    vi.mocked(api.post).mockRejectedValue(new Error("This invitation has expired."));
+
+    renderPage();
+    await user.click(await screen.findByRole("button", { name: /i am 18 or older/i }));
+
+    expect(await screen.findByText("This invitation has expired.")).toBeInTheDocument();
+    expect(screen.queryByText("Now Visible")).not.toBeInTheDocument();
+  });
+
+  it("warns a signed-out visitor without naming the comic", async () => {
+    auth.isAuthenticated = false;
+    vi.mocked(api.get).mockResolvedValue({
+      invitation: { ...gatedInvitation, isForCurrentUser: false, recipientEmail: null },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(EXPLICIT_GATE_TITLE)).toBeInTheDocument();
+    // Holding the link is not an age declaration; nobody has said who they are.
+    expect(screen.getByRole("button", { name: /log in to continue/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /i am 18 or older/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Now Visible")).not.toBeInTheDocument();
+  });
+
+  it("adds no extra step to an ordinary invitation", async () => {
+    vi.mocked(api.get).mockResolvedValue({ invitation: ordinaryInvitation });
+    renderPage();
+
+    expect(await screen.findByText("Ordinary Comic")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add to my collection/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText(EXPLICIT_GATE_TITLE)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /i am 18 or older/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Sharing.jsx
+++ b/frontend/src/pages/Sharing.jsx
@@ -13,7 +13,17 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { BookOpen, Loader2, RotateCcw, Share2Icon, Trash2, Undo2, UserPlus, XCircle } from "lucide-react";
+import {
+  BookOpen,
+  Loader2,
+  RotateCcw,
+  Share2Icon,
+  ShieldAlert,
+  Trash2,
+  Undo2,
+  UserPlus,
+  XCircle,
+} from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
@@ -21,11 +31,17 @@ import { ShareComicModal } from "@/components/ShareComicModal";
 import { useSharingLists } from "@/hooks/use-sharing";
 import { useComicLibrary } from "@/hooks/use-comic-library";
 import {
+  EXPLICIT_FLAG_LABEL,
+  EXPLICIT_GATE_CONFIRM_LABEL,
+  EXPLICIT_GATE_TITLE,
   SHARE_STATUS,
   SHARE_STATUS_LABELS,
+  SHARING_PAGE_RESPONSIBILITY_REMINDER,
   describeDeadShareCleanup,
   describeReceivedShare,
   groupReceivedShares,
+  requiresAdultConfirmation,
+  shareDisplayTitle,
   summariseRecipients,
 } from "@/lib/sharing";
 
@@ -36,11 +52,15 @@ const STATUS_VARIANTS = {
   [SHARE_STATUS.REVOKED]: "outline",
 };
 
-function ShareCover({ src, title }) {
+function ShareCover({ src, title, gated = false }) {
   if (!src) {
     return (
       <div className="flex h-24 w-16 flex-none items-center justify-center rounded bg-muted">
-        <BookOpen className="h-6 w-6 text-muted-foreground" />
+        {/* No cover URL and none coming: for a gated share the server withheld
+            it, so this placeholder stands in rather than a blurred real one. */}
+        {gated
+          ? <ShieldAlert className="h-6 w-6 text-muted-foreground" />
+          : <BookOpen className="h-6 w-6 text-muted-foreground" />}
       </div>
     );
   }
@@ -107,18 +127,37 @@ export default function Sharing() {
 
   const cleanupCopy = describeDeadShareCleanup(dead.length);
 
+  /**
+   * The sender-side reminder.
+   *
+   * Informational only — the acknowledgement that actually goes on the record
+   * is the tick box in the share modal, once per share. This is here so the
+   * expectation is visible while somebody is looking at what they have already
+   * handed out, not only at the moment they hand out the next one.
+   */
+  const responsibilityReminder = (
+    <Alert className="mb-4">
+      <ShieldAlert className="h-5 w-5" />
+      <AlertDescription>{SHARING_PAGE_RESPONSIBILITY_REMINDER}</AlertDescription>
+    </Alert>
+  );
+
   const renderSharedByMe = () => {
     if (sharedByMe.length === 0) {
       return (
-        <p className="py-12 text-center text-muted-foreground">
-          You have not shared any comics yet. Use the share action on a comic in{" "}
-          <Link to="/dashboard" className="text-primary hover:underline">your library</Link>.
-        </p>
+        <>
+          {responsibilityReminder}
+          <p className="py-12 text-center text-muted-foreground">
+            You have not shared any comics yet. Use the share action on a comic in{" "}
+            <Link to="/dashboard" className="text-primary hover:underline">your library</Link>.
+          </p>
+        </>
       );
     }
 
     return (
       <div className="space-y-4">
+        {responsibilityReminder}
         {sharedByMe.map((group) => {
           const counts = summariseRecipients(group.recipients);
 
@@ -130,6 +169,9 @@ export default function Sharing() {
                   <div className="min-w-0 flex-1">
                     <h3 className="truncate font-bold">{group.title}</h3>
                     <p className="truncate text-sm text-muted-foreground">{group.author}</p>
+                    {group.explicitContent && (
+                      <Badge variant="outline" className="mt-1">{EXPLICIT_FLAG_LABEL}</Badge>
+                    )}
                     <p className="mt-1 text-sm text-muted-foreground">
                       {counts.total} {counts.total === 1 ? "recipient" : "recipients"}
                       {" · "}
@@ -222,23 +264,54 @@ export default function Sharing() {
     );
   };
 
+  /**
+   * Record the age declaration for one share and reload.
+   *
+   * The same endpoint the invitation page uses, because it is the same
+   * declaration: the gate follows the share, not the screen it is met on.
+   */
+  const confirmAdult = (share) => runAction(
+    share.id,
+    () => api.post(`/api/shares/${share.id}/confirm-adult`, { adultConfirmed: true }),
+    "Age confirmed."
+  );
+
   const renderReceivedList = (shares, { showActions }) => (
     <ul className="space-y-3">
-      {shares.map((share) => (
+      {shares.map((share) => {
+        const gated = requiresAdultConfirmation(share);
+
+        return (
         <li key={share.id}>
           <Card>
             <CardContent className="flex gap-4 p-4">
-              <ShareCover src={share.coverImagePath} title={share.comicTitle} />
+              <ShareCover src={share.coverImagePath} title={shareDisplayTitle(share)} gated={gated} />
               <div className="min-w-0 flex-1">
-                <h3 className="truncate font-bold">{share.comicTitle}</h3>
+                <h3 className="truncate font-bold">{shareDisplayTitle(share)}</h3>
                 <p className="truncate text-sm text-muted-foreground">
                   Shared by {share.ownerName}
                   {share.comicAuthor ? ` · ${share.comicAuthor}` : ""}
                 </p>
+                {gated && (
+                  <p className="mt-1 flex items-center gap-1 text-sm font-medium text-destructive">
+                    <ShieldAlert className="h-4 w-4" />
+                    {EXPLICIT_GATE_TITLE}
+                  </p>
+                )}
                 <p className="mt-1 text-sm text-muted-foreground">{describeReceivedShare(share)}</p>
               </div>
               {showActions && (
                 <div className="flex flex-none flex-col gap-2">
+                  {gated && !share.isDead && (
+                    <Button
+                      size="sm"
+                      disabled={busyShareId === share.id}
+                      onClick={() => confirmAdult(share)}
+                    >
+                      {busyShareId === share.id && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                      {EXPLICIT_GATE_CONFIRM_LABEL}
+                    </Button>
+                  )}
                   {share.canRead && (
                     <Button size="sm" onClick={() => navigate(`/read/${share.comicId}`)}>
                       <BookOpen className="mr-2 h-4 w-4" />
@@ -296,7 +369,8 @@ export default function Sharing() {
             </CardContent>
           </Card>
         </li>
-      ))}
+        );
+      })}
     </ul>
   );
 
@@ -315,35 +389,60 @@ export default function Sharing() {
           <section>
             <h2 className="mb-3 text-lg font-semibold">Pending invitations</h2>
             <ul className="space-y-3">
-              {invitations.map((share) => (
+              {invitations.map((share) => {
+                const gated = requiresAdultConfirmation(share);
+
+                return (
                 <li key={share.id}>
                   <Card>
                     <CardContent className="flex gap-4 p-4">
-                      <ShareCover src={share.coverImagePath} title={share.comicTitle} />
+                      <ShareCover
+                        src={share.coverImagePath}
+                        title={shareDisplayTitle(share)}
+                        gated={gated}
+                      />
                       <div className="min-w-0 flex-1">
-                        <h3 className="truncate font-bold">{share.comicTitle}</h3>
+                        <h3 className="truncate font-bold">{shareDisplayTitle(share)}</h3>
                         <p className="truncate text-sm text-muted-foreground">
                           {share.ownerName} wants to share this with you.
                         </p>
+                        {gated && (
+                          <p className="mt-1 flex items-center gap-1 text-sm font-medium text-destructive">
+                            <ShieldAlert className="h-4 w-4" />
+                            {EXPLICIT_GATE_TITLE}
+                          </p>
+                        )}
                         <p className="mt-1 text-sm text-muted-foreground">
                           {describeReceivedShare(share)}
                         </p>
                       </div>
                       {/* The emailed link is not the only way in: somebody
                           signed in and looking at their own invitation has
-                          already identified themselves. */}
+                          already identified themselves. That still is not an
+                          age declaration, so an explicit invitation offers the
+                          gate here instead of Accept. */}
                       <div className="flex flex-none flex-col gap-2">
-                        <Button
-                          size="sm"
-                          disabled={!share.canAnswer || busyShareId === share.id}
-                          onClick={() => runAction(
-                            share.id,
-                            () => api.post(`/api/shares/${share.id}/accept`, {}),
-                            "Comic added to your collection."
-                          )}
-                        >
-                          Add to my collection
-                        </Button>
+                        {gated ? (
+                          <Button
+                            size="sm"
+                            disabled={!share.canAnswer || busyShareId === share.id}
+                            onClick={() => confirmAdult(share)}
+                          >
+                            {EXPLICIT_GATE_CONFIRM_LABEL}
+                          </Button>
+                        ) : (
+                          <Button
+                            size="sm"
+                            disabled={!share.canAnswer || busyShareId === share.id}
+                            onClick={() => runAction(
+                              share.id,
+                              () => api.post(`/api/shares/${share.id}/accept`, {}),
+                              "Comic added to your collection."
+                            )}
+                          >
+                            Add to my collection
+                          </Button>
+                        )}
                         <Button
                           size="sm"
                           variant="outline"
@@ -360,7 +459,8 @@ export default function Sharing() {
                     </CardContent>
                   </Card>
                 </li>
-              ))}
+                );
+              })}
             </ul>
           </section>
         )}

--- a/frontend/src/pages/Sharing.test.jsx
+++ b/frontend/src/pages/Sharing.test.jsx
@@ -1,0 +1,169 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Sharing from "./Sharing";
+import { api } from "@/lib/api";
+import { EXPLICIT_GATE_TITLE, SHARING_PAGE_RESPONSIBILITY_REMINDER } from "@/lib/sharing";
+
+const lists = { sharedByMe: [], sharedWithMe: [], isLoading: false, error: null, reload: vi.fn() };
+
+vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("@/hooks/use-sharing", () => ({
+  useSharing: () => ({ refreshSummary: vi.fn() }),
+  useSharingLists: () => lists,
+}));
+vi.mock("@/hooks/use-comic-library", () => ({
+  useComicLibrary: () => ({ loadLibrary: vi.fn() }),
+}));
+
+const receivedShare = (overrides = {}) => ({
+  id: 11,
+  status: "pending",
+  comicId: null,
+  comicTitle: null,
+  comicAuthor: null,
+  pageCount: null,
+  coverImagePath: null,
+  ownerName: "Alex Owner",
+  explicitContent: true,
+  requiresAdultConfirmation: true,
+  adultConfirmed: false,
+  isExpired: false,
+  isTombstoned: false,
+  isDead: false,
+  canAnswer: true,
+  canRead: false,
+  canRemove: false,
+  canRestore: false,
+  removedFromCollection: null,
+  tombstoneReason: null,
+  ...overrides,
+});
+
+const renderPage = () => render(<MemoryRouter><Sharing /></MemoryRouter>);
+
+/** Move to the owner's half of the page. */
+const openSharedByMe = async (user) => {
+  await user.click(screen.getByRole("tab", { name: /shared by me/i }));
+};
+
+describe("Sharing page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lists.sharedByMe = [];
+    lists.sharedWithMe = [];
+    lists.isLoading = false;
+    lists.error = null;
+  });
+
+  it("reminds the sender that shared content is their responsibility", async () => {
+    const user = userEvent.setup();
+    lists.sharedByMe = [{
+      comicId: 5,
+      title: "Sandman",
+      author: "Neil Gaiman",
+      coverImagePath: null,
+      explicitContent: false,
+      recipients: [{ id: 1, recipientEmail: "jane@example.com", status: "pending" }],
+    }];
+
+    renderPage();
+    await openSharedByMe(user);
+
+    expect(screen.getByText(SHARING_PAGE_RESPONSIBILITY_REMINDER)).toBeInTheDocument();
+  });
+
+  it("shows the reminder even when nothing has been shared yet", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await openSharedByMe(user);
+
+    // The expectation is worth stating before the first share, not only after.
+    expect(screen.getByText(SHARING_PAGE_RESPONSIBILITY_REMINDER)).toBeInTheDocument();
+  });
+
+  it("badges the owner's own explicit comics without hiding them", async () => {
+    const user = userEvent.setup();
+    lists.sharedByMe = [{
+      comicId: 5,
+      title: "Owner Can See This",
+      author: "Someone",
+      coverImagePath: null,
+      explicitContent: true,
+      recipients: [{ id: 1, recipientEmail: "jane@example.com", status: "pending" }],
+    }];
+
+    renderPage();
+    await openSharedByMe(user);
+
+    // An age gate protects a recipient from content they have not agreed to
+    // see. It is not a lock on somebody's own library.
+    expect(screen.getByText("Owner Can See This")).toBeInTheDocument();
+    expect(screen.getByText("Explicit content (18+)")).toBeInTheDocument();
+  });
+
+  it("gates a pending explicit invitation instead of offering to accept it", () => {
+    lists.sharedWithMe = [receivedShare()];
+    renderPage();
+
+    expect(screen.getByText("Hidden until you confirm your age")).toBeInTheDocument();
+    expect(screen.getAllByText(EXPLICIT_GATE_TITLE).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /i am 18 or older/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add to my collection/i })).not.toBeInTheDocument();
+    // Declining never needs an age declaration.
+    expect(screen.getByRole("button", { name: /decline/i })).toBeInTheDocument();
+  });
+
+  it("gates an accepted share the owner has since marked explicit", () => {
+    lists.sharedWithMe = [receivedShare({ status: "accepted", canAnswer: false, canRemove: true })];
+    renderPage();
+
+    // The relationship survived; reading did not, until they confirm again.
+    expect(screen.getByText(/confirm your age to read it again/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /i am 18 or older/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^read$/i })).not.toBeInTheDocument();
+  });
+
+  it("records the declaration against that share and reloads", async () => {
+    const user = userEvent.setup();
+    lists.sharedWithMe = [receivedShare({ id: 42 })];
+    vi.mocked(api.post).mockResolvedValue({ share: {} });
+
+    renderPage();
+    await user.click(screen.getByRole("button", { name: /i am 18 or older/i }));
+
+    expect(api.post).toHaveBeenCalledWith("/api/shares/42/confirm-adult", { adultConfirmed: true });
+    await waitFor(() => expect(lists.reload).toHaveBeenCalled());
+  });
+
+  it("explains a dead explicit share rather than offering a gate to nowhere", () => {
+    lists.sharedWithMe = [receivedShare({ status: "revoked", isDead: true, canAnswer: false })];
+    renderPage();
+
+    expect(screen.getByText(/the owner has stopped sharing/i)).toBeInTheDocument();
+    // Confirming for a share the owner has withdrawn achieves nothing.
+    expect(screen.queryByRole("button", { name: /i am 18 or older/i })).not.toBeInTheDocument();
+    // It stays redacted: the recipient never passed the gate, and the share
+    // ending is not the same as them having done so.
+    expect(screen.getByText("Hidden — explicit content (18+)")).toBeInTheDocument();
+  });
+
+  it("leaves a non-explicit share entirely alone", () => {
+    lists.sharedWithMe = [receivedShare({
+      comicId: 5,
+      comicTitle: "Ordinary Comic",
+      explicitContent: false,
+      requiresAdultConfirmation: false,
+    })];
+
+    renderPage();
+
+    const card = screen.getByText("Ordinary Comic").closest("li");
+    expect(within(card).getByRole("button", { name: /add to my collection/i })).toBeInTheDocument();
+    expect(screen.queryByText(EXPLICIT_GATE_TITLE)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+/**
+ * What jsdom has to be told about before Radix will render.
+ *
+ * These are not conveniences. Radix's dialog, checkbox and popover primitives
+ * call each of them during a normal mount, and jsdom implements none of them —
+ * so without these stubs the components under test throw before a single
+ * assertion runs, and the failure looks like a bug in the component rather than
+ * a gap in the environment.
+ */
+if (!window.matchMedia) {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+for (const name of ["ResizeObserver", "IntersectionObserver"]) {
+  if (!globalThis[name]) {
+    globalThis[name] = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    };
+  }
+}
+
+// Pointer capture is how Radix tracks a press that leaves the element it began
+// on. jsdom has no pointer model at all, so these answer "nothing is captured".
+const elementStubs = {
+  hasPointerCapture: () => false,
+  setPointerCapture: () => {},
+  releasePointerCapture: () => {},
+  scrollIntoView: () => {},
+};
+
+for (const [name, stub] of Object.entries(elementStubs)) {
+  if (!Element.prototype[name]) {
+    Element.prototype[name] = stub;
+  }
+}
+
+// Auto-cleanup only registers itself when Vitest's globals are on, and they are
+// deliberately off here — so unmounting between tests is ours to do. Without it
+// a second render finds the previous dialog still in the document and every
+// query becomes ambiguous.
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -27,4 +27,37 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    // No implicit globals. Every test imports describe/it/expect by name, and
+    // adding component tests is not a reason for that to stop being true.
+    globals: false,
+    // Split by extension, because the two kinds of test genuinely differ and
+    // the file name should say which one you are writing:
+    //
+    //   *.test.js   pure logic — no DOM, so no jsdom to stand up
+    //   *.test.jsx  a rendered component — jsdom, plus the Radix stubs
+    //
+    // Standing a DOM up for the helper tests would cost seconds per file to
+    // give them something none of them touch.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          environment: "node",
+          include: ["src/**/*.test.js"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "dom",
+          environment: "jsdom",
+          include: ["src/**/*.test.jsx"],
+          setupFiles: ["./src/test/setup.js"],
+          css: false,
+        },
+      },
+    ],
+  },
 }));


### PR DESCRIPTION
Closes #62.

## The rule this replaces

A hidden tag was standing in for an adult warning. It cannot: hiding a comic from your library is a shelving preference, and somebody may do it for a dozen reasons that say nothing about what is inside. Classification is now a deliberate, comic-level flag its owner sets, and nothing — no tag, global or hidden — infers one on their behalf.

## Two acknowledgements, one row

Both live on the same `ComicShare`, so one record is the whole audit trail for one relationship. Neither timestamp is ever read off the request.

| Field | Written when | Required |
|---|---|---|
| `senderResponsibilityAcceptedAt` | the invitation is created | every new share |
| `adultConfirmedAt` | the recipient declares they are 18+ | explicit comics only |

`POST /api/shares/comics/{id}/invitations` rejects anything but a literal `true` for `senderResponsibilityAccepted`, with `400 share_responsibility_acknowledgement_required`. `POST /api/shares/{id}/confirm-adult` and `POST /api/shares/invitations/{token}/confirm-adult` record the age declaration and are idempotent — a repeat keeps the original timestamp, because confirming twice is a retry and not a new declaration.

Resending preserves both. Re-inviting after a decline, revoke or lapse reuses the row but takes a fresh sender acknowledgement and clears any age declaration: that is a new offer of the comic as it is now.

## The gate is one query, not one check per endpoint

`ComicShareRepository::readableQueryBuilder()` defines "a share that lets this user read this comic" as accepted **and** `explicitContent = false OR adultConfirmedAt IS NOT NULL`. `findAccessFor`, `findAccessIndexedByComic` and `findVisibleCollectionShares` all build on it, so `COMIC_VIEW` fails closed for metadata, cover, pages and progress alike — no per-endpoint check to forget. `accept()`/`acceptShare()` refuse separately with `403 adult_confirmation_required`, so a direct API call cannot put an unconfirmed explicit comic into somebody's collection.

Until confirmation, recipient and invitation payloads withhold `comicId`, `comicTitle`, `comicAuthor`, `pageCount` and `coverImagePath`. The id goes with the rest because it is the key to every endpoint that serves bytes. The email names no explicit comic either — an inbox is previewed on lock screens and read by scanners — and the client shows a neutral placeholder rather than the real cover blurred, since blurring still sends it.

## Two things the issue didn't ask for

- **`explicitContentSnapshot` on `ComicShare`.** Without it: mark explicit → recipient never confirms → owner deletes the comic → the tombstone's title snapshot leaks exactly the detail the gate was holding back. Tested.
- **Dead shares stay redacted but stop offering the gate.** Confirming for a revoked or declined share would 409, so the copy explains the ending instead.

## Re-gating

Marking an already-shared comic explicit fails closed: every live share loses its confirmation in the same unit of work as the reclassification, on both the single-comic route and the dashboard's batch update. Those recipients agreed to read something that was not classified 18+, and an old silence is not a declaration about the comic as it is now. The relationship, status and the recipient's place in their collection all survive — reading stops, the share does not. Unmarking restores access immediately.

## Frontend testing

This branch adds DOM testing, which the repo had none of. Vitest is split into two projects by extension, because the two kinds of test genuinely differ:

- `*.test.js` → `node`, for pure logic
- `*.test.jsx` → `jsdom` + `src/test/setup.js`, for rendered components

Standing a DOM up for the helper tests would cost seconds per file to give them something none of them touch. The setup file stubs what Radix calls during a normal mount and jsdom does not implement (`matchMedia`, `ResizeObserver`, `IntersectionObserver`, `scrollIntoView`, pointer capture) — without them a dialog throws before a single assertion runs. Copy is asserted against the constants exported from `lib/sharing.js`, so the responsibility notice and the 18+ warning cannot be watered down in a component without a test noticing.

## Testing

- **Backend: 208/208 pass**, including a new `ExplicitShareControllerTest` (25 tests) covering all 20 scenarios listed on the issue. Migration applies, reverses and re-applies cleanly; `doctrine:schema:validate` is green.
- **Frontend: 169/169 pass** (28 new: 4 component files + 23 helper cases), lint and build clean, `npm run audit:production` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mark comics as explicit content when creating or editing them.
  - Share invitations require sender responsibility acknowledgement.
  - Recipients must confirm adulthood before viewing or accepting explicit-content shares.
  - Explicit-content previews hide titles, covers, and metadata until confirmation.
  - Added badges, warnings, and age-gate messaging throughout sharing workflows.
  - Access is automatically re-gated when a shared comic becomes explicit.

- **Bug Fixes**
  - Improved sharing error messages and consistent protection for gated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->