### PR TITLE
fix: speed up re-gating explicit shares and improve ComicEditDialog accessibility

### DIFF
--- a/backend/src/Repository/ComicShareRepository.php
+++ b/backend/src/Repository/ComicShareRepository.php
@@ -149,6 +149,29 @@ class ComicShareRepository extends ServiceEntityRepository
     }
 
     /**
+     * Close the adult gate for every live share without hydrating each row.
+     *
+     * Reclassification is a single database update even when a popular comic
+     * has many recipients. Shares which are already closed are excluded so the
+     * affected-row count remains useful to callers and the database does not
+     * rewrite unchanged records.
+     */
+    public function resetAdultConfirmationsForComic(Comic $comic): int
+    {
+        return $this->createQueryBuilder('s')
+            ->update()
+            ->set('s.adultConfirmedAt', 'NULL')
+            ->andWhere('s.comic = :comic')
+            ->andWhere('s.unavailableAt IS NULL')
+            ->andWhere('s.status IN (:live)')
+            ->andWhere('s.adultConfirmedAt IS NOT NULL')
+            ->setParameter('comic', $comic)
+            ->setParameter('live', [ComicShare::STATUS_PENDING, ComicShare::STATUS_ACCEPTED])
+            ->getQuery()
+            ->execute();
+    }
+
+    /**
      * How many people each of these comics is actively shared with, indexed by
      * comic id. Batched because the library endpoint needs it for every card.
      *

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -328,18 +328,7 @@ class ComicShareService
      */
     public function regateSharesForComic(Comic $comic): int
     {
-        $regated = 0;
-
-        foreach ($this->shareRepository->findLiveSharesForComic($comic) as $share) {
-            if ($share->getAdultConfirmedAt() === null) {
-                continue;
-            }
-
-            $share->resetAdultConfirmation();
-            ++$regated;
-        }
-
-        return $regated;
+        return $this->shareRepository->resetAdultConfirmationsForComic($comic);
     }
 
     /** Withdraw one recipient's access. Takes effect on the next request. */

--- a/frontend/src/components/ComicEditDialog.jsx
+++ b/frontend/src/components/ComicEditDialog.jsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -109,6 +116,9 @@ export function ComicEditDialog({ comic, isOpen, onClose, onSave }) {
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>Edit Comic Details</DialogTitle>
+          <DialogDescription>
+            Update the information fans see for this comic, including its 18+ classification.
+          </DialogDescription>
         </DialogHeader>
         
         <div className="grid gap-4 py-4">


### PR DESCRIPTION
### Motivation

- Reclassification of a comic to explicit can touch many recipient shares, so re-gating must be fast and avoid hydrating each row to remain snappy for popular comics.
- The Comic edit dialog emitted an accessibility warning and lacked an explicit description; improve clarity for non-technical users and screen-reader consumers. 
- Keep the explicit-content gating logic robust and centralized to protect recipients and prevent accidental leaks of identifying data.

### Description

- Added `ComicShareRepository::resetAdultConfirmationsForComic(Comic $comic)` that issues a single filtered DB `UPDATE` to set `adultConfirmedAt = NULL` for live shares on a comic without hydrating all rows, avoiding per-row object updates. 
- Updated `ComicShareService::regateSharesForComic()` to delegate to the new repository method, replacing the loop that iterated and reset each share one-by-one. 
- Improved accessibility/UX for the comic edit dialog by adding a `DialogDescription` explaining the 18+ classification field so screen readers and users understand the control's purpose. 
- Minor commit: consolidated imports/formatting for the dialog component. 

### Testing

- Frontend: ran `npm test` (Vitest) — all component and unit tests passed (169/169); `eslint` lint passed; `vite build` succeeded; `npm run audit:production` completed (allowed advisory list applied). 
- Backend: PHP syntax checks `php -l` for modified files passed. 
- Backend unit tests: ran `vendor/bin/phpunit tests/Unit` and observed 45 unit tests executed with 5 errors tied to missing Sodium constants in the environment (crypto constants/extension not available), not related to these changes. 
- Backend full functional suite: attempted `vendor/bin/phpunit` but test run errored in this environment due to database hostname resolution in the test container (CI/test environment DB not reachable), so full functional results are unavailable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7628a31f508332946e6248ee039f01)