### PR TITLE
Fix production propagation of security/audit deployment settings

### DIFF
--- a/scripts/.env.deploy.example
+++ b/scripts/.env.deploy.example
@@ -3,124 +3,67 @@
 # =============================================================================
 # Copy this file to scripts/.env.deploy and fill in the real values.
 # scripts/.env.deploy is GIT-IGNORED — never commit it.
-#
-# All variables are read by:
-#   - scripts/build-release.sh   (PROD_* values bake into the release)
-#   - scripts/deploy-ftp.sh      (FTP_*  values drive the FTP upload)
-#   - scripts/deploy-ssh.sh      (SSH_*  values drive the SSH/git deploy)
-#   - scripts/post-deploy.sh     (POST_DEPLOY_* values trigger migrations,
-#                                 SSH_* values used in --ssh mode)
-# =============================================================================
 
-
-# -----------------------------------------------------------------------------
 # FTP target
-# -----------------------------------------------------------------------------
 FTP_HOST=ftp.yourdomain.com
 FTP_USER=your-ftp-user
 FTP_PASSWORD=your-ftp-password
-# Use 'ftps' for FTP-over-TLS (recommended) or 'ftp' for plain FTP.
 FTP_PROTOCOL=ftps
-# Port (21 for FTP/FTPS explicit, 990 for FTPS implicit).
 FTP_PORT=21
-# Keep certificate validation enabled. Set to 0 only for a temporary,
-# explicitly accepted troubleshooting session with a self-signed endpoint.
 FTP_VERIFY_CERTIFICATE=1
-
-# Remote root where the release will be mirrored.
-# Typical shared-hosting layouts:
-#   /                 -> if your FTP user is chrooted to the project root
-#   /htdocs           -> some hosts
-#   /www              -> some hosts
-#   /domains/yourdomain.com/public_html
-# IMPORTANT: this is the directory that contains 'backend/' (NOT inside it).
 FTP_REMOTE_ROOT=/
-
-# Number of parallel FTP connections (3-5 is a good balance).
 FTP_PARALLEL=3
 
-
-# -----------------------------------------------------------------------------
-# SSH target (used by scripts/deploy-ssh.sh and scripts/post-deploy.sh --ssh)
-# -----------------------------------------------------------------------------
+# SSH target
 SSH_HOST=server.yourdomain.com
 SSH_USER=deploy
 SSH_PORT=22
-# Optional: path to the private key used to authenticate. Leave empty to use
-# your default ssh-agent / ~/.ssh/id_*.
 SSH_KEY=
-
-# Absolute path on the server where the project is checked out.
-# This directory must contain backend/ (and optionally frontend/).
 SSH_REMOTE_PATH=/var/www/comics
-
-# Branch that the server should track (deploy-ssh.sh runs `git pull --ff-only origin <branch>`).
 SSH_GIT_BRANCH=main
-
-# Linux user the web server runs as (used to chown var/cache and var/log
-# after composer install). Common values: www-data, nginx, http, apache.
 SSH_WEB_USER=www-data
 SSH_WEB_GROUP=www-data
-
-# Optional command run AFTER cache:warmup. Leave empty if you don't have
-# permission to reload PHP-FPM. Examples:
-#   sudo systemctl reload php8.2-fpm
-#   sudo service php-fpm reload
 SSH_POST_DEPLOY_HOOK=
-
-# Required for upgrades with existing user data. This command runs on the
-# server before code or database changes and must back up both the database and
-# backend/public/uploads. It must exit non-zero if either backup fails.
-# Use the shipped script (path on the server), or a symlink of it:
-#   sudo ln -sf /var/www/comics/scripts/server/backup-comics.sh /usr/local/bin/backup-comics
 SSH_BACKUP_COMMAND=/var/www/comics/scripts/server/backup-comics.sh
 
-
-# -----------------------------------------------------------------------------
-# The one public application URL. It is used for post-deploy calls, absolute
-# application links, canonical metadata, robots.txt and sitemap.xml.
-# -----------------------------------------------------------------------------
+# Public URL and post-deploy
 PUBLIC_URL=https://comics.yourdomain.com
-# FTP-only migrations cannot create a server backup. Set this to 1 only after
-# independently verifying a current database + uploads backup.
 BACKUP_CONFIRMED=0
-
-
-# -----------------------------------------------------------------------------
-# Post-deploy token
-# -----------------------------------------------------------------------------
-# Random secret protecting public/_post-deploy.php.
-# Generate with:  openssl rand -hex 32
-# This MUST also be set as DEPLOY_TOKEN inside backend/.env.prod.local.
 POST_DEPLOY_TOKEN=replace-me-with-openssl-rand-hex-32
 
-
-# -----------------------------------------------------------------------------
-# Production env values that the build will bake into backend/.env.prod.local
-# (gitignored, generated only inside release/).
-#
-# These end up consolidated into backend/.env.local.php by 'composer dump-env prod'.
-# -----------------------------------------------------------------------------
+# Production environment values baked into backend/.env.local.php
 PROD_APP_SECRET=replace-me-with-openssl-rand-hex-32
-# Generate once with `openssl rand -base64 32`, back it up securely, and never
-# rotate it without re-encrypting existing Dropbox credentials first.
 PROD_APP_DATA_KEY=replace-me-with-openssl-rand-base64-32
-# Use the exact version reported by SELECT VERSION() on the production server.
-# DSN format: mysql://USER:PASS@HOST:3306/DB?serverVersion=8.0.32&charset=utf8mb4
 PROD_DATABASE_URL='mysql://prod_user:prod_pass@prod-db-host:3306/cbz_reader?serverVersion=8.0.32&charset=utf8mb4'
-# Same regex format as nelmio/cors-bundle expects.
-PROD_CORS_ALLOW_ORIGIN=^https://comics\.yourdomain\.com$
+PROD_CORS_ALLOW_ORIGIN=^https://comics\\.yourdomain\\.com$
+# Leave empty when the application sees the real client address directly.
+# Behind Cloudflare/reverse proxies, configure only addresses you actually trust.
+PROD_TRUSTED_PROXIES=
+
 PROD_MAILER_DSN=smtp://smtp_user:smtp_pass@smtp.yourdomain.com:587
 PROD_MAILER_FROM_ADDRESS=noreply@yourdomain.com
 PROD_MAILER_FROM_NAME="Comic Reader"
 PROD_PRIVACY_OPERATOR="Panel Page Flip site operator"
 PROD_PRIVACY_EMAIL=privacy@yourdomain.com
-# Optional; the defaults shown are what build-release.sh bakes in when unset.
 PROD_MAILER_TRANSPORT=smtp
 PROD_MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
-# Parallel chunk uploads allowed per user. Shared hosting is usually happier
-# with a lower number than the development default.
+PROD_LOCK_DSN=flock
 PROD_MAX_CONCURRENT_UPLOADS=3
+
+# Security/audit log retention. app:cleanup-logs must be scheduled separately.
+PROD_APP_LOG_RETENTION_DAYS=30
+PROD_SECURITY_LOG_RETENTION_DAYS=365
+PROD_AUDIT_LOG_RETENTION_DAYS=365
+
+# Administrator security alerts. Keep disabled until MAILER_DSN is verified.
+PROD_SECURITY_ALERTS_ENABLED=0
+# Prefer a dedicated operational mailbox. Comma-separated if there are several.
+PROD_SECURITY_ALERT_EMAILS=security@yourdomain.com
+PROD_SECURITY_ALERT_WINDOW_MINUTES=15
+PROD_SECURITY_ALERT_FAILED_LOGIN_THRESHOLD=10
+PROD_SECURITY_ALERT_AUTHZ_THRESHOLD=10
+
+# Dropbox integration (optional)
 PROD_DROPBOX_APP_KEY=
 PROD_DROPBOX_APP_SECRET=
 PROD_DROPBOX_REDIRECT_URI=https://comics.yourdomain.com/api/dropbox/callback

--- a/scripts/.env.deploy.example
+++ b/scripts/.env.deploy.example
@@ -3,67 +3,144 @@
 # =============================================================================
 # Copy this file to scripts/.env.deploy and fill in the real values.
 # scripts/.env.deploy is GIT-IGNORED — never commit it.
+#
+# All variables are read by:
+#   - scripts/build-release.sh   (PROD_* values bake into the release)
+#   - scripts/deploy-ftp.sh      (FTP_*  values drive the FTP upload)
+#   - scripts/deploy-ssh.sh      (SSH_*  values drive the SSH/git deploy)
+#   - scripts/post-deploy.sh     (POST_DEPLOY_* values trigger migrations,
+#                                 SSH_* values used in --ssh mode)
+# =============================================================================
 
+
+# -----------------------------------------------------------------------------
 # FTP target
+# -----------------------------------------------------------------------------
 FTP_HOST=ftp.yourdomain.com
 FTP_USER=your-ftp-user
 FTP_PASSWORD=your-ftp-password
+# Use 'ftps' for FTP-over-TLS (recommended) or 'ftp' for plain FTP.
 FTP_PROTOCOL=ftps
+# Port (21 for FTP/FTPS explicit, 990 for FTPS implicit).
 FTP_PORT=21
+# Keep certificate validation enabled. Set to 0 only for a temporary,
+# explicitly accepted troubleshooting session with a self-signed endpoint.
 FTP_VERIFY_CERTIFICATE=1
+
+# Remote root where the release will be mirrored.
+# Typical shared-hosting layouts:
+#   /                 -> if your FTP user is chrooted to the project root
+#   /htdocs           -> some hosts
+#   /www              -> some hosts
+#   /domains/yourdomain.com/public_html
+# IMPORTANT: this is the directory that contains 'backend/' (NOT inside it).
 FTP_REMOTE_ROOT=/
+
+# Number of parallel FTP connections (3-5 is a good balance).
 FTP_PARALLEL=3
 
-# SSH target
+
+# -----------------------------------------------------------------------------
+# SSH target (used by scripts/deploy-ssh.sh and scripts/post-deploy.sh --ssh)
+# -----------------------------------------------------------------------------
 SSH_HOST=server.yourdomain.com
 SSH_USER=deploy
 SSH_PORT=22
+# Optional: path to the private key used to authenticate. Leave empty to use
+# your default ssh-agent / ~/.ssh/id_*.
 SSH_KEY=
+
+# Absolute path on the server where the project is checked out.
+# This directory must contain backend/ (and optionally frontend/).
 SSH_REMOTE_PATH=/var/www/comics
+
+# Branch that the server should track (deploy-ssh.sh runs `git pull --ff-only origin <branch>`).
 SSH_GIT_BRANCH=main
+
+# Linux user the web server runs as (used to chown var/cache and var/log
+# after composer install). Common values: www-data, nginx, http, apache.
 SSH_WEB_USER=www-data
 SSH_WEB_GROUP=www-data
+
+# Optional command run AFTER cache:warmup. Leave empty if you don't have
+# permission to reload PHP-FPM. Examples:
+#   sudo systemctl reload php8.2-fpm
+#   sudo service php-fpm reload
 SSH_POST_DEPLOY_HOOK=
+
+# Required for upgrades with existing user data. This command runs on the
+# server before code or database changes and must back up both the database and
+# backend/public/uploads. It must exit non-zero if either backup fails.
+# Use the shipped script (path on the server), or a symlink of it:
+#   sudo ln -sf /var/www/comics/scripts/server/backup-comics.sh /usr/local/bin/backup-comics
 SSH_BACKUP_COMMAND=/var/www/comics/scripts/server/backup-comics.sh
 
-# Public URL and post-deploy
+
+# -----------------------------------------------------------------------------
+# The one public application URL. It is used for post-deploy calls, absolute
+# application links, canonical metadata, robots.txt and sitemap.xml.
+# -----------------------------------------------------------------------------
 PUBLIC_URL=https://comics.yourdomain.com
+# FTP-only migrations cannot create a server backup. Set this to 1 only after
+# independently verifying a current database + uploads backup.
 BACKUP_CONFIRMED=0
+
+
+# -----------------------------------------------------------------------------
+# Post-deploy token
+# -----------------------------------------------------------------------------
+# Random secret protecting public/_post-deploy.php.
+# Generate with:  openssl rand -hex 32
+# This MUST also be set as DEPLOY_TOKEN inside backend/.env.prod.local.
 POST_DEPLOY_TOKEN=replace-me-with-openssl-rand-hex-32
 
-# Production environment values baked into backend/.env.local.php
-PROD_APP_SECRET=replace-me-with-openssl-rand-hex-32
-PROD_APP_DATA_KEY=replace-me-with-openssl-rand-base64-32
-PROD_DATABASE_URL='mysql://prod_user:prod_pass@prod-db-host:3306/cbz_reader?serverVersion=8.0.32&charset=utf8mb4'
-PROD_CORS_ALLOW_ORIGIN=^https://comics\\.yourdomain\\.com$
-# Leave empty when the application sees the real client address directly.
-# Behind Cloudflare/reverse proxies, configure only addresses you actually trust.
-PROD_TRUSTED_PROXIES=
 
+# -----------------------------------------------------------------------------
+# Production env values that the build will bake into backend/.env.prod.local
+# (gitignored, generated only inside release/).
+#
+# These end up consolidated into backend/.env.local.php by 'composer dump-env prod'.
+# -----------------------------------------------------------------------------
+PROD_APP_SECRET=replace-me-with-openssl-rand-hex-32
+# Generate once with `openssl rand -base64 32`, back it up securely, and never
+# rotate it without re-encrypting existing Dropbox credentials first.
+PROD_APP_DATA_KEY=replace-me-with-openssl-rand-base64-32
+# Use the exact version reported by SELECT VERSION() on the production server.
+# DSN format: mysql://USER:PASS@HOST:3306/DB?serverVersion=8.0.32&charset=utf8mb4
+PROD_DATABASE_URL='mysql://prod_user:prod_pass@prod-db-host:3306/cbz_reader?serverVersion=8.0.32&charset=utf8mb4'
+# Same regex format as nelmio/cors-bundle expects.
+PROD_CORS_ALLOW_ORIGIN=^https://comics\\.yourdomain\\.com$
+# Leave empty when the app sees the real client address directly. Configure
+# only proxies you actually trust when sitting behind Cloudflare or another
+# reverse proxy, otherwise rate limiting and alert scopes can use the proxy IP.
+PROD_TRUSTED_PROXIES=
 PROD_MAILER_DSN=smtp://smtp_user:smtp_pass@smtp.yourdomain.com:587
 PROD_MAILER_FROM_ADDRESS=noreply@yourdomain.com
 PROD_MAILER_FROM_NAME="Comic Reader"
 PROD_PRIVACY_OPERATOR="Panel Page Flip site operator"
 PROD_PRIVACY_EMAIL=privacy@yourdomain.com
+# Optional; the defaults shown are what build-release.sh bakes in when unset.
 PROD_MAILER_TRANSPORT=smtp
 PROD_MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 PROD_LOCK_DSN=flock
+# Parallel chunk uploads allowed per user. Shared hosting is usually happier
+# with a lower number than the development default.
 PROD_MAX_CONCURRENT_UPLOADS=3
 
-# Security/audit log retention. app:cleanup-logs must be scheduled separately.
+# Security/audit retention. The values only define policy; app:cleanup-logs
+# must also be scheduled on the server for deletion to happen.
 PROD_APP_LOG_RETENTION_DAYS=30
 PROD_SECURITY_LOG_RETENTION_DAYS=365
 PROD_AUDIT_LOG_RETENTION_DAYS=365
 
-# Administrator security alerts. Keep disabled until MAILER_DSN is verified.
+# Administrator security alerts. Keep disabled until MAILER_DSN has been
+# verified in production. SECURITY_ALERT_EMAILS may be comma-separated.
 PROD_SECURITY_ALERTS_ENABLED=0
-# Prefer a dedicated operational mailbox. Comma-separated if there are several.
 PROD_SECURITY_ALERT_EMAILS=security@yourdomain.com
 PROD_SECURITY_ALERT_WINDOW_MINUTES=15
 PROD_SECURITY_ALERT_FAILED_LOGIN_THRESHOLD=10
 PROD_SECURITY_ALERT_AUTHZ_THRESHOLD=10
 
-# Dropbox integration (optional)
 PROD_DROPBOX_APP_KEY=
 PROD_DROPBOX_APP_SECRET=
 PROD_DROPBOX_REDIRECT_URI=https://comics.yourdomain.com/api/dropbox/callback

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -38,6 +38,7 @@
 
 set -euo pipefail
 
+# --- locate repo root ---------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
@@ -47,6 +48,7 @@ RELEASE_DIR="$REPO_ROOT/release"
 PHP_VERSION_DEFAULT="8.2"
 NODE_VERSION_DEFAULT="20"
 
+# --- helpers ------------------------------------------------------------------
 log()  { printf "\033[1;36m[build]\033[0m %s\n" "$*"; }
 warn() { printf "\033[1;33m[warn]\033[0m  %s\n" "$*"; }
 fail() { printf "\033[1;31m[fail]\033[0m  %s\n" "$*" >&2; exit 1; }
@@ -57,6 +59,7 @@ require_command() {
     fi
 }
 
+# --- parse args ---------------------------------------------------------------
 DO_FRONTEND=1
 DO_BACKEND=1
 DO_TARBALL=0
@@ -74,17 +77,20 @@ for arg in "$@"; do
     esac
 done
 
+# --- preflight ----------------------------------------------------------------
 require_command docker
 
 if [ ! -f "$ENV_FILE" ]; then
     fail "Missing $ENV_FILE — copy scripts/.env.deploy.example and fill it in."
 fi
 
+# Load PROD_* / POST_DEPLOY_TOKEN safely.
 set -a
 # shellcheck disable=SC1090
 source "$ENV_FILE"
 set +a
 
+# Try to read PHP_VERSION / NODE_VERSION from the project's .env if present.
 if [ -f "$REPO_ROOT/.env" ]; then
     # shellcheck disable=SC1091
     source <(grep -E '^(PHP_VERSION|NODE_VERSION)=' "$REPO_ROOT/.env" || true)
@@ -92,6 +98,7 @@ fi
 PHP_VERSION="${PHP_VERSION:-$PHP_VERSION_DEFAULT}"
 NODE_VERSION="${NODE_VERSION:-$NODE_VERSION_DEFAULT}"
 
+# Required PROD_* values for backend env baking.
 REQUIRED_PROD_VARS=(
     PROD_APP_SECRET
     PROD_APP_DATA_KEY
@@ -105,12 +112,20 @@ for v in "${REQUIRED_PROD_VARS[@]}"; do
     fi
 done
 
+# --- clean ---------------------------------------------------------------------
 log "Cleaning $RELEASE_DIR"
 rm -rf "$RELEASE_DIR"
 mkdir -p "$RELEASE_DIR/backend/public"
 
+# =============================================================================
+# Frontend
+# =============================================================================
 if [ "$DO_FRONTEND" = "1" ]; then
     log "Building frontend with node:${NODE_VERSION}-alpine"
+    # The development container can leave generated dist files owned by root.
+    # Remove only that disposable build output before switching to the host UID.
+    # Do not bind-mount scripts/ here: it can contain .env.deploy with
+    # FTP/production secrets, and the Vite build only needs the route manifest.
     docker run --rm \
         -v "$REPO_ROOT/frontend":/app \
         -w /app \
@@ -146,6 +161,9 @@ else
     warn "Skipping frontend build (--skip-frontend)"
 fi
 
+# =============================================================================
+# Backend
+# =============================================================================
 if [ "$DO_BACKEND" = "1" ]; then
     log "Copying backend sources to release/"
     rsync -a \
@@ -171,14 +189,22 @@ if [ "$DO_BACKEND" = "1" ]; then
         --exclude='/compose.override.yaml' \
         "$REPO_ROOT/backend/" "$RELEASE_DIR/backend/"
 
+    # public/comic.png is deliberately kept: ComicController serves it as the
+    # cover placeholder when a comic's own cover file is missing. Excluding it
+    # turned that fallback into a 404 and a broken image in the library.
+
+    # Recreate var/ structure expected by Symfony.
     mkdir -p "$RELEASE_DIR/backend/var/cache" "$RELEASE_DIR/backend/var/log"
 
+    # Drop the .htaccess so Apache shared hosting routes to index.php.
     log "Installing public/.htaccess"
     cp "$SCRIPT_DIR/deploy/htaccess.dist" "$RELEASE_DIR/backend/public/.htaccess"
 
+    # Drop the post-deploy runner.
     log "Installing public/_post-deploy.php"
     cp "$SCRIPT_DIR/deploy/_post-deploy.php.dist" "$RELEASE_DIR/backend/public/_post-deploy.php"
 
+    # Generate .env.prod.local from PROD_* vars (will be consolidated by dump-env).
     log "Writing temporary .env.prod.local"
     PROD_ENV_FILE="$RELEASE_DIR/backend/.env.prod.local"
     : > "$PROD_ENV_FILE"
@@ -229,6 +255,8 @@ if [ "$DO_BACKEND" = "1" ]; then
     chmod 600 "$PROD_ENV_FILE"
 
     log "Running composer install --no-dev inside php:${PHP_VERSION}-cli"
+    # The official php:X-cli image already has a base; we add zip+intl which
+    # Symfony often needs at composer-time, then install Composer.
     docker run --rm \
         -v "$RELEASE_DIR/backend":/app \
         -w /app \
@@ -252,6 +280,8 @@ if [ "$DO_BACKEND" = "1" ]; then
             php bin/console cache:warmup --env=prod --no-debug
         '
 
+    # The .env.prod.local has been consolidated into .env.local.php. Drop the
+    # raw file so the production server never sees secrets in plaintext.
     if [ -f "$RELEASE_DIR/backend/.env.local.php" ]; then
         log "Removing raw .env.prod.local (consolidated into .env.local.php)"
         rm -f "$PROD_ENV_FILE"
@@ -259,11 +289,15 @@ if [ "$DO_BACKEND" = "1" ]; then
         warn ".env.local.php was NOT generated. Composer dump-env prod may have failed."
     fi
 
+    # Strip dev-only profiler cache if it sneaked in.
     rm -rf "$RELEASE_DIR/backend/var/cache/dev" "$RELEASE_DIR/backend/var/log/dev.log"
 else
     warn "Skipping backend build (--skip-backend)"
 fi
 
+# =============================================================================
+# Tarball (optional)
+# =============================================================================
 if [ "$DO_TARBALL" = "1" ]; then
     log "Creating release.tar.gz"
     tar -C "$RELEASE_DIR" \
@@ -271,6 +305,9 @@ if [ "$DO_TARBALL" = "1" ]; then
         -czf "$REPO_ROOT/release.tar.gz" .
 fi
 
+# =============================================================================
+# Summary
+# =============================================================================
 log "Release ready in: $RELEASE_DIR"
 RELEASE_SIZE=$(du -sh "$RELEASE_DIR" | cut -f1)
 log "Total size:      $RELEASE_SIZE"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -220,6 +220,10 @@ if [ "$DO_BACKEND" = "1" ]; then
         printf '%s="%s"\n' "$key" "$escaped" >> "$PROD_ENV_FILE"
     }
 
+    if [ "${PROD_SECURITY_ALERTS_ENABLED:-0}" != "0" ] && [ -z "${PROD_MAILER_DSN:-}" ]; then
+        fail "PROD_MAILER_DSN must be set when PROD_SECURITY_ALERTS_ENABLED is enabled."
+    fi
+
     write_dotenv APP_ENV prod
     write_dotenv APP_DEBUG 0
     write_dotenv APP_SECRET "$PROD_APP_SECRET"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -38,7 +38,6 @@
 
 set -euo pipefail
 
-# --- locate repo root ---------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
@@ -48,7 +47,6 @@ RELEASE_DIR="$REPO_ROOT/release"
 PHP_VERSION_DEFAULT="8.2"
 NODE_VERSION_DEFAULT="20"
 
-# --- helpers ------------------------------------------------------------------
 log()  { printf "\033[1;36m[build]\033[0m %s\n" "$*"; }
 warn() { printf "\033[1;33m[warn]\033[0m  %s\n" "$*"; }
 fail() { printf "\033[1;31m[fail]\033[0m  %s\n" "$*" >&2; exit 1; }
@@ -59,7 +57,6 @@ require_command() {
     fi
 }
 
-# --- parse args ---------------------------------------------------------------
 DO_FRONTEND=1
 DO_BACKEND=1
 DO_TARBALL=0
@@ -77,20 +74,17 @@ for arg in "$@"; do
     esac
 done
 
-# --- preflight ----------------------------------------------------------------
 require_command docker
 
 if [ ! -f "$ENV_FILE" ]; then
     fail "Missing $ENV_FILE — copy scripts/.env.deploy.example and fill it in."
 fi
 
-# Load PROD_* / POST_DEPLOY_TOKEN safely.
 set -a
 # shellcheck disable=SC1090
 source "$ENV_FILE"
 set +a
 
-# Try to read PHP_VERSION / NODE_VERSION from the project's .env if present.
 if [ -f "$REPO_ROOT/.env" ]; then
     # shellcheck disable=SC1091
     source <(grep -E '^(PHP_VERSION|NODE_VERSION)=' "$REPO_ROOT/.env" || true)
@@ -98,7 +92,6 @@ fi
 PHP_VERSION="${PHP_VERSION:-$PHP_VERSION_DEFAULT}"
 NODE_VERSION="${NODE_VERSION:-$NODE_VERSION_DEFAULT}"
 
-# Required PROD_* values for backend env baking.
 REQUIRED_PROD_VARS=(
     PROD_APP_SECRET
     PROD_APP_DATA_KEY
@@ -112,20 +105,12 @@ for v in "${REQUIRED_PROD_VARS[@]}"; do
     fi
 done
 
-# --- clean ---------------------------------------------------------------------
 log "Cleaning $RELEASE_DIR"
 rm -rf "$RELEASE_DIR"
 mkdir -p "$RELEASE_DIR/backend/public"
 
-# =============================================================================
-# Frontend
-# =============================================================================
 if [ "$DO_FRONTEND" = "1" ]; then
     log "Building frontend with node:${NODE_VERSION}-alpine"
-    # The development container can leave generated dist files owned by root.
-    # Remove only that disposable build output before switching to the host UID.
-    # Do not bind-mount scripts/ here: it can contain .env.deploy with
-    # FTP/production secrets, and the Vite build only needs the route manifest.
     docker run --rm \
         -v "$REPO_ROOT/frontend":/app \
         -w /app \
@@ -161,9 +146,6 @@ else
     warn "Skipping frontend build (--skip-frontend)"
 fi
 
-# =============================================================================
-# Backend
-# =============================================================================
 if [ "$DO_BACKEND" = "1" ]; then
     log "Copying backend sources to release/"
     rsync -a \
@@ -189,22 +171,14 @@ if [ "$DO_BACKEND" = "1" ]; then
         --exclude='/compose.override.yaml' \
         "$REPO_ROOT/backend/" "$RELEASE_DIR/backend/"
 
-    # public/comic.png is deliberately kept: ComicController serves it as the
-    # cover placeholder when a comic's own cover file is missing. Excluding it
-    # turned that fallback into a 404 and a broken image in the library.
-
-    # Recreate var/ structure expected by Symfony.
     mkdir -p "$RELEASE_DIR/backend/var/cache" "$RELEASE_DIR/backend/var/log"
 
-    # Drop the .htaccess so Apache shared hosting routes to index.php.
     log "Installing public/.htaccess"
     cp "$SCRIPT_DIR/deploy/htaccess.dist" "$RELEASE_DIR/backend/public/.htaccess"
 
-    # Drop the post-deploy runner.
     log "Installing public/_post-deploy.php"
     cp "$SCRIPT_DIR/deploy/_post-deploy.php.dist" "$RELEASE_DIR/backend/public/_post-deploy.php"
 
-    # Generate .env.prod.local from PROD_* vars (will be consolidated by dump-env).
     log "Writing temporary .env.prod.local"
     PROD_ENV_FILE="$RELEASE_DIR/backend/.env.prod.local"
     : > "$PROD_ENV_FILE"
@@ -227,6 +201,7 @@ if [ "$DO_BACKEND" = "1" ]; then
     write_dotenv APP_URL "${PUBLIC_URL%/}"
     write_dotenv DATABASE_URL "$PROD_DATABASE_URL"
     write_dotenv CORS_ALLOW_ORIGIN "${PROD_CORS_ALLOW_ORIGIN:-^https://.*$}"
+    write_dotenv TRUSTED_PROXIES "${PROD_TRUSTED_PROXIES:-}"
     write_dotenv MAILER_DSN "${PROD_MAILER_DSN:-null://null}"
     write_dotenv MAILER_FROM_ADDRESS "${PROD_MAILER_FROM_ADDRESS:-noreply@example.com}"
     write_dotenv MAILER_FROM_NAME "${PROD_MAILER_FROM_NAME:-Comic Reader}"
@@ -234,7 +209,16 @@ if [ "$DO_BACKEND" = "1" ]; then
     write_dotenv PRIVACY_EMAIL "${PROD_PRIVACY_EMAIL:-${PROD_MAILER_FROM_ADDRESS:-noreply@example.com}}"
     write_dotenv MAILER_TRANSPORT "${PROD_MAILER_TRANSPORT:-smtp}"
     write_dotenv MESSENGER_TRANSPORT_DSN "${PROD_MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=0}"
+    write_dotenv LOCK_DSN "${PROD_LOCK_DSN:-flock}"
     write_dotenv MAX_CONCURRENT_UPLOADS "${PROD_MAX_CONCURRENT_UPLOADS:-3}"
+    write_dotenv APP_LOG_RETENTION_DAYS "${PROD_APP_LOG_RETENTION_DAYS:-30}"
+    write_dotenv SECURITY_LOG_RETENTION_DAYS "${PROD_SECURITY_LOG_RETENTION_DAYS:-365}"
+    write_dotenv AUDIT_LOG_RETENTION_DAYS "${PROD_AUDIT_LOG_RETENTION_DAYS:-365}"
+    write_dotenv SECURITY_ALERTS_ENABLED "${PROD_SECURITY_ALERTS_ENABLED:-0}"
+    write_dotenv SECURITY_ALERT_EMAILS "${PROD_SECURITY_ALERT_EMAILS:-}"
+    write_dotenv SECURITY_ALERT_WINDOW_MINUTES "${PROD_SECURITY_ALERT_WINDOW_MINUTES:-15}"
+    write_dotenv SECURITY_ALERT_FAILED_LOGIN_THRESHOLD "${PROD_SECURITY_ALERT_FAILED_LOGIN_THRESHOLD:-10}"
+    write_dotenv SECURITY_ALERT_AUTHZ_THRESHOLD "${PROD_SECURITY_ALERT_AUTHZ_THRESHOLD:-10}"
     write_dotenv DROPBOX_APP_KEY "${PROD_DROPBOX_APP_KEY:-}"
     write_dotenv DROPBOX_APP_SECRET "${PROD_DROPBOX_APP_SECRET:-}"
     write_dotenv DROPBOX_REDIRECT_URI "${PROD_DROPBOX_REDIRECT_URI:-${PUBLIC_URL%/}/api/dropbox/callback}"
@@ -245,8 +229,6 @@ if [ "$DO_BACKEND" = "1" ]; then
     chmod 600 "$PROD_ENV_FILE"
 
     log "Running composer install --no-dev inside php:${PHP_VERSION}-cli"
-    # The official php:X-cli image already has a base; we add zip+intl which
-    # Symfony often needs at composer-time, then install Composer.
     docker run --rm \
         -v "$RELEASE_DIR/backend":/app \
         -w /app \
@@ -270,8 +252,6 @@ if [ "$DO_BACKEND" = "1" ]; then
             php bin/console cache:warmup --env=prod --no-debug
         '
 
-    # The .env.prod.local has been consolidated into .env.local.php. Drop the
-    # raw file so the production server never sees secrets in plaintext.
     if [ -f "$RELEASE_DIR/backend/.env.local.php" ]; then
         log "Removing raw .env.prod.local (consolidated into .env.local.php)"
         rm -f "$PROD_ENV_FILE"
@@ -279,15 +259,11 @@ if [ "$DO_BACKEND" = "1" ]; then
         warn ".env.local.php was NOT generated. Composer dump-env prod may have failed."
     fi
 
-    # Strip dev-only profiler cache if it sneaked in.
     rm -rf "$RELEASE_DIR/backend/var/cache/dev" "$RELEASE_DIR/backend/var/log/dev.log"
 else
     warn "Skipping backend build (--skip-backend)"
 fi
 
-# =============================================================================
-# Tarball (optional)
-# =============================================================================
 if [ "$DO_TARBALL" = "1" ]; then
     log "Creating release.tar.gz"
     tar -C "$RELEASE_DIR" \
@@ -295,9 +271,6 @@ if [ "$DO_TARBALL" = "1" ]; then
         -czf "$REPO_ROOT/release.tar.gz" .
 fi
 
-# =============================================================================
-# Summary
-# =============================================================================
 log "Release ready in: $RELEASE_DIR"
 RELEASE_SIZE=$(du -sh "$RELEASE_DIR" | cut -f1)
 log "Total size:      $RELEASE_SIZE"


### PR DESCRIPTION
## Why this PR exists

This came out of a pre-deployment audit of `main` against the production release path.

The application now supports security/audit logging, retention, throttled administrator alerts, trusted-proxy handling and a configurable lock store. Those settings exist in Symfony's committed `.env`/service configuration, but the FTP release builder did not copy their production overrides from `scripts/.env.deploy` into the generated `.env.prod.local` / `.env.local.php`.

That creates configuration drift: the code is correct and CI is green, but an operator can configure the new feature in the deployment file and the produced release silently ignores it.

## Root cause

`build-release.sh` explicitly whitelists every production variable it writes. The security/audit feature added new Symfony environment variables, but the release whitelist and `scripts/.env.deploy.example` were not updated at the same time.

Because `composer dump-env prod` compiles the committed defaults when no override is written:

- security alerts remain disabled even if the operator intended to enable them;
- alert recipients/thresholds/window cannot be set through the normal FTP deployment configuration;
- log retention cannot be customized through that configuration;
- `TRUSTED_PROXIES` cannot be propagated, which matters if production is behind a CDN/reverse proxy because rate-limit and security-alert scopes rely on the client address;
- `LOCK_DSN` cannot be propagated, even though the alert throttling relies on locking for concurrent requests.

This is primarily a deployment correctness issue rather than an application logic vulnerability, but the proxy case can materially reduce the usefulness of rate limiting/alert correlation if the app sees only a proxy address.

## Fix

`build-release.sh` now writes production overrides for:

- `TRUSTED_PROXIES`
- `LOCK_DSN`
- `APP_LOG_RETENTION_DAYS`
- `SECURITY_LOG_RETENTION_DAYS`
- `AUDIT_LOG_RETENTION_DAYS`
- `SECURITY_ALERTS_ENABLED`
- `SECURITY_ALERT_EMAILS`
- `SECURITY_ALERT_WINDOW_MINUTES`
- `SECURITY_ALERT_FAILED_LOGIN_THRESHOLD`
- `SECURITY_ALERT_AUTHZ_THRESHOLD`

`scripts/.env.deploy.example` documents the corresponding `PROD_*` values and their safe defaults.

Alerts still default to **disabled**. This PR therefore does not introduce surprise mail traffic on the next deployment; it only makes the production release honor an explicit operator choice.

## Deployment notes

Before the next production deploy:

1. Copy the new variables into the real gitignored `scripts/.env.deploy` as appropriate.
2. If production is directly exposed (no reverse proxy/CDN in front of the app), leave `PROD_TRUSTED_PROXIES` empty.
3. If it is behind a proxy/CDN, configure only the proxy addresses/ranges that are actually trusted. Do not use a broad untrusted value just to make forwarded headers work.
4. Keep `PROD_SECURITY_ALERTS_ENABLED=0` until the production `MAILER_DSN` has been verified. Then enable it deliberately and preferably use a dedicated operational mailbox.
5. Schedule `php bin/console app:cleanup-logs --env=prod` daily; retention values define the policy but do not delete files on their own.

## Wider audit context

The current `main` head has a successful full `Validate Application` workflow covering frontend dependency audit, lint, tests, route/tool/SEO validation and production build, plus backend Composer audit, Symfony container lint, Doctrine schema validation and PHPUnit.

The release contains several database migrations added since the likely previous production deploy, notably the sharing schema, explicit-content fields and reading-progress uniqueness migration. There are no shared comics in production, so the legacy sharing-token cutover has no practical data-loss impact there. The reading-progress migration intentionally deduplicates existing rows before adding its unique index and includes retry handling for a live-site race.

This PR addresses the concrete deployment drift found during that audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now support configurable trusted proxies, distributed locking, mail, privacy, and transport settings.
  * Added configurable retention periods for application, security, and audit logs.
  * Added administrator security alerts for failed logins and authorization failures, including email notifications.
  * Production environments retain support for concurrent uploads with a default limit of three.

* **Bug Fixes**
  * Improved parsing of configured CORS origin patterns during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->