### PR TITLE
Improve sharing UX with privacy-safe recipient reuse, bulk sharing and sharing codes

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -41,6 +41,7 @@ This document provides detailed information for developers working on the projec
 - **ShareInvitationToken Entity**: Defined in `ShareInvitationToken.php`. Only a SHA-256 hash of each invitation link is stored. One link per invitation, good for a single claim within two months; accepting spends it and revokes every other token for that share, and resending mints a new one and retires the old link
 - **ComicVoter**: `Security/Voter/ComicVoter.php` answers `COMIC_VIEW`, `COMIC_EDIT`, `COMIC_DELETE` and `COMIC_SHARE` for every endpoint that touches a comic
 - **Share Controller**: `ShareController.php` under `/api/shares` — invite, resend, revoke, stop sharing, preview, accept, decline, remove, restore and tombstone cleanup
+- **Sharing Codes**: `SharingCodeService.php` issues and resolves the permanent per-account receiver code; `ShareClaimCodeService.php` mints and redeems the disposable owner-issued claim code. See [Sharing codes](#sharing-codes)
 - **Sharing Workflow**: `SharingWorkflowController.php` and `SharingWorkflowService.php` add `GET /api/shares/recent-recipients` and `POST /api/shares/invitations/bulk` — the convenience layer behind the Sharing page's **Share comics** flow. Recipients come only from the caller's own share history and never from the user directory; bulk sharing is a permission gate in front of `ComicShareService::inviteMany()` and creates one ordinary `ComicShare` per comic. See [Privacy: registered users are never discoverable](#privacy-registered-users-are-never-discoverable)
 - **Tombstones**: Deleting a comic nulls the relationship and records `unavailableAt` plus a `tombstoneReason`, so recipients are told why a comic disappeared. They are recipient-only — the owner caused the deletion, has no comic left to manage, and the comic leaves their sharing list entirely
 - **Email Notifications**: One "Review invitation" link per invitation; the link only previews, because mail scanners follow links on the recipient's behalf. A bulk share sends one grouped email carrying a link per comic, so twenty comics are not twenty messages
@@ -103,7 +104,8 @@ Full guide, including retention, alert thresholds and the rules for adding an ev
 
 #### ✅ Comic Sharing
 - **Sharing Page**: `Sharing.jsx` at `/sharing` — where shares are both started and managed, with "Shared with me" and "Shared by me" tabs for invitations, access and tombstones
-- **Share Comics Dialog**: `ShareComicsDialog.jsx` is the multi-comic flow behind **Share comics** and **Share another comic** — an owned-only picker with search, previously used recipients, and one grouped invitation email per action. It lists no registered users and searches none
+- **Share Comics Dialog**: `ShareComicsDialog.jsx` is the multi-comic flow behind **Share comics** and **Share another comic** — an owned-only picker with search, previously used recipients, and one grouped invitation email per action. Step 2 offers three ways to name a recipient: an email address, their sharing code, or no one at all (a claim code anybody can redeem). It lists no registered users and searches none
+- **Sharing Codes Card**: `SharingCodesCard.jsx` on `/sharing` — the account's own permanent receiver code with a copy action, and the field for redeeming a code somebody sent
 - **Share Comic Modal**: `ShareComicModal.jsx` is the one-comic shortcut from a comic card, and the only path that shows the invitation link once, since only its hash is stored
 - **Invitation Preview**: `ShareInvitation.jsx` at `/share/invitation/:token` loads the invitation through a safe `GET` and only accepts or declines on a button press
 - **Pending Shares Alert**: `PendingSharesAlert.jsx`, now a one-line prompt on the dashboard rather than a card per invitation
@@ -326,10 +328,104 @@ search is worthless if the API answers anyway.
   endpoint cannot be used to enumerate accounts. The UI behaves the same in both
   cases: the recipient may simply have to register before they can accept
 
-Private opaque **Sharing IDs** are a possible future phase. If they are built,
-they must stay an address-book identifier — high-entropy, revocable, rate limited
-on resolution, granting nothing on their own — and must never become a public
-searchable username.
+### Sharing codes
+
+Two codes, in opposite directions. Both are written in the same format —
+`SharingCodeFormat`, twelve characters of Crockford base32 shown as
+`XXXX-XXXX-XXXX` — because somebody copying one out of a chat window should not
+have to know which kind they were given. What a code *means* is decided by the
+field it is pasted into.
+
+Neither is a login. Neither reveals an email address. Neither grants access to
+anything on its own.
+
+#### The receiver code — "this is me, share with me"
+
+One per account, on `user.sharing_code`, issued the first time it is asked for
+and **permanent** from that moment. Nothing changes it: not a profile edit, not
+an admin screen, and there is no regenerate endpoint to add one to. An address
+book entry that rotates is one that stops working in every conversation it was
+ever pasted into.
+
+That permanence is a trade, and it is only affordable because the code is so
+weak: it authenticates nobody, and the worst a stranger holding it can do is
+offer you a comic you decline. It is stored **in the clear**, unlike an
+invitation token, precisely because it is an address rather than a capability —
+its owner has to be able to read it back and hand it out again.
+
+| Endpoint | Answers |
+|---|---|
+| `GET /api/shares/my-code` | this account's code and display name |
+| `POST /api/shares/resolve-code` | the display name behind a code — nothing else |
+
+Sharing by code is the ordinary bulk invitation with the recipient named
+differently: `POST /api/shares/invitations/bulk` takes `sharingCode` in place of
+`email`, resolves it server-side, and addresses the invitation to the account it
+found. **The sender never learns the address.** `comic_share` carries
+`recipient_alias_name` and `recipient_sharing_code` for exactly that reason, and
+the owner-facing serializer returns `recipientEmail: null` with a `recipientLabel`
+in its place. Recent recipients list such a person by name and code too — putting
+the withheld address back on the picker would undo the feature.
+
+#### The claim code — "these are mine, come and get them"
+
+`ShareClaimCode`, for when the owner does not know and should not have to ask for
+the other person's address. This one *is* a capability, so it is treated like
+one:
+
+- **Hashed at rest**, like an invitation token. The plaintext is returned once,
+  when it is created, and nothing can reproduce it afterwards
+- **Dead in a day.** A code pasted into a group chat is out of its owner's hands
+  the moment it is sent
+- **Spent as it is used**, between 1 and 10 times, chosen when it is made, so the
+  owner decides up front how far it may travel
+- **Worth nothing without an account.** Redeeming requires being signed in
+
+| Endpoint | Does |
+|---|---|
+| `POST /api/shares/claim-codes` | mint one over comics the owner may share |
+| `GET /api/shares/claim-codes` | list live codes — never the codes themselves |
+| `DELETE /api/shares/claim-codes/{id}` | withdraw one |
+| `POST /api/shares/claim-codes/redeem` | claim the comics behind one |
+
+Redeeming is the recipient's own deliberate act, so it stands in for accepting an
+invitation — with one exception it cannot wave through. **An explicit comic is
+left pending behind the age gate**, decided before the share is accepted rather
+than undone afterwards, so there is no moment where an unconfirmed recipient
+holds an accepted share. Everything downstream is the ordinary model: the same
+`ComicShare`, the same revocation, the same tombstones. Withdrawing a code does
+not touch the shares it already produced; those are ordinary relationships now.
+
+A code whose comics have all been deleted stops being redeemable on its own —
+the join table cascades on both sides and `isRedeemable()` requires at least one
+comic — so there is no second piece of state to keep in step with a deletion.
+
+#### Why this is not a user directory
+
+Resolving a code is the only place in the application where an identifier
+somebody typed is turned into a person, so it is the only enumeration surface
+sharing has, and it is built to be a bad one:
+
+- **60 bits of entropy** over an alphabet with no ambiguous characters
+- **One generic answer** for every code that does not resolve — malformed, spent,
+  expired, revoked or imaginary alike. Telling them apart would say whether a
+  guess had ever been real
+- **A `sharing_code_lookup` allowance** charged only for lookups that find
+  nothing, so pasting a code never meets it and grinding through candidates does.
+  Exhausting it raises `security.share.sharing_code_enumeration_attempt`
+- **Name only** on success. Not the address, not the id, not whether the account
+  is verified, active or an administrator. Somebody holding a code is entitled to
+  know they reached the right person; everything past that is the account's own
+
+Minting claim codes has its own `share_claim_code` allowance, because it sends no
+mail and the invitation limiter would never see it.
+
+#### Still out of scope
+
+Consent-based **sharing contacts** — where an accepted recipient lets the sender
+remember them by name without an address — remain future work. They need their
+own design for consent, removal, blocking, account deletion and export, and must
+not be implemented implicitly on top of recent recipients.
 
 #### Answering
 1. The email carries a single **Review invitation** link, good for one claim

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -105,7 +105,8 @@ Full guide, including retention, alert thresholds and the rules for adding an ev
 #### ✅ Comic Sharing
 - **Sharing Page**: `Sharing.jsx` at `/sharing` — where shares are both started and managed, with "Shared with me" and "Shared by me" tabs for invitations, access and tombstones
 - **Share Comics Dialog**: `ShareComicsDialog.jsx` is the multi-comic flow behind **Share comics** and **Share another comic** — an owned-only picker with search, previously used recipients, and one grouped invitation email per action. Step 2 offers three ways to name a recipient: an email address, their sharing code, or no one at all (a claim code anybody can redeem). It lists no registered users and searches none
-- **Sharing Codes Card**: `SharingCodesCard.jsx` on `/sharing` — the account's own permanent receiver code with a copy action, the field for redeeming a code somebody sent, and the list of codes handed out with a **Withdraw** action on each live one
+- **Sharing Codes Card**: `SharingCodesCard.jsx` on `/sharing` — the account's own receiver code with copy and **Replace** actions (the latter behind a confirmation, since the old code breaks everywhere at once), the field for redeeming a code somebody sent, and the list of codes handed out with a **Withdraw** action on each live one
+- **Admin Sharing Code Rotation**: `AdminUserDetails.jsx` can replace a user's receiver code on their behalf, behind a confirmation. The new code is never shown to the administrator — the user reads it off their own Sharing page
 - **Share Comic Modal**: `ShareComicModal.jsx` is the one-comic shortcut from a comic card, and the only path that shows the invitation link once, since only its hash is stored
 - **Invitation Preview**: `ShareInvitation.jsx` at `/share/invitation/:token` loads the invitation through a safe `GET` and only accepts or declines on a button press
 - **Pending Shares Alert**: `PendingSharesAlert.jsx`, now a one-line prompt on the dashboard rather than a card per invitation
@@ -246,6 +247,22 @@ permanent second copy the model exists to avoid.
    `ComicShare`, mints a token and emails the link — all one unit of work, so a
    send that fails rolls the invitation back rather than showing the owner a
    recipient who was never contacted
+
+   > **The limit of that guarantee.** An SMTP call is not a participant in a
+   > database transaction and no arrangement of this code makes it one. What
+   > holds is one direction: a failed send leaves no invitation behind. The
+   > reverse does not — if the send succeeds and the commit then fails, the
+   > recipient holds links to relationships that no longer exist and will be
+   > told the invitation is not valid. Ordering it the other way trades that for
+   > invitations nobody was told about, recoverable by resending but happening
+   > on every transport hiccup rather than on the rarer commit failure. Making
+   > both impossible needs a transactional outbox — shares and a pending
+   > notification committed together, a worker sending after the commit — which
+   > is a change to how the whole application delivers mail rather than to this
+   > path. `ComicShareService::inviteMany()` will not convert a send failure
+   > into per-comic results when a caller owns the transaction, because nothing
+   > was rolled back and that caller's commit would otherwise persist rows
+   > already reported as failed.
 3. The link is `{appUrl}/share/invitation/{token}` and is returned once in
    the response for the owner to copy
 
@@ -341,22 +358,45 @@ anything on its own.
 
 #### The receiver code — "this is me, share with me"
 
-One per account, on `user.sharing_code`, issued the first time it is asked for
-and **permanent** from that moment. Nothing changes it: not a profile edit, not
-an admin screen, and there is no regenerate endpoint to add one to. An address
-book entry that rotates is one that stops working in every conversation it was
-ever pasted into.
+One per account, on `user.sharing_code`, issued the first time it is asked for.
+It is stored **in the clear**, unlike an invitation token, precisely because it
+is an address rather than a capability — its owner has to be able to read it
+back and hand it out again. It authenticates nobody, and the worst a stranger
+holding it can do is offer you a comic you decline.
 
-That permanence is a trade, and it is only affordable because the code is so
-weak: it authenticates nobody, and the worst a stranger holding it can do is
-offer you a comic you decline. It is stored **in the clear**, unlike an
-invitation token, precisely because it is an address rather than a capability —
-its owner has to be able to read it back and hand it out again.
+**Stable, but not permanent.** A code lives in chats, forums and group threads,
+which is exactly the kind of place a thing escapes from, and an identifier its
+owner cannot retire after that is one they are stuck with. Rotation is theirs to
+trigger, and an administrator's on their behalf when they ask support for it.
+Nothing rotates it on its own, because everybody holding the old one has to be
+told the new one.
 
 | Endpoint | Answers |
 |---|---|
 | `GET /api/shares/my-code` | this account's code and display name |
 | `POST /api/shares/resolve-code` | the display name behind a code — nothing else |
+| `POST /api/shares/my-code/rotate` | retires the current code and returns a new one |
+| `POST /api/users/{id}/sharing-code/rotate` | the same, admin-only, and does **not** return the new code |
+
+Rotation changes the identifier and nothing else. Every share already made
+through the old code is a relationship, not an address: pending invitations stay
+pending, accepted ones stay accepted, and nobody loses a comic. It is rate
+limited (`sharing_code_rotation`) — not for load, but so a script or a stuck
+retry cannot quietly make somebody uncontactable — and audited with ids only.
+Neither the old code nor the new one is ever written to a log; a code somebody
+rotated *because* it leaked is the last thing to write down.
+
+**What rotation means for stored codes.** `comic_share.recipient_sharing_code`
+records how a relationship began and goes stale the moment the recipient
+rotates. Nothing treats it as a live handle. The owner's Sharing page and their
+recent-recipient list both resolve the recipient's *current* code through
+`ComicShare::recipientUser` — which is why a share made by code links the
+account immediately rather than waiting for acceptance. A recipient whose
+account has gone keeps their name and loses the code rather than falling back to
+the address, because falling back would hand over the one thing the code existed
+to withhold. That lookup is the single place this feature joins `User`, and it
+is allowed because the rows are already restricted to people the owner shares
+with: it resolves a known correspondent, it does not search the directory.
 
 Sharing by code is the ordinary bulk invitation with the recipient named
 differently: `POST /api/shares/invitations/bulk` takes `sharingCode` in place of
@@ -375,13 +415,22 @@ one:
 
 - **Hashed at rest**, like an invitation token. The plaintext is returned once,
   when it is created, and nothing can reproduce it afterwards
-- **Unique**, checked against both `share_claim_code.code_hash` and
-  `user.sharing_code` before one is kept, so no code of either kind is ever
-  issued twice. The unique index is the authority behind that check
+- **Unique across both kinds.** `SharingCodeService::allocateUniqueCode()` is the
+  only place either kind is generated, and it checks `user.sharing_code` *and*
+  `share_claim_code.code_hash` before a candidate is kept. Two unique indexes
+  cannot enforce uniqueness across two tables, so each is authoritative inside
+  its own table and this allocator is what upholds the invariant between them
 - **Dead in a day.** A code pasted into a group chat is out of its owner's hands
   the moment it is sent
 - **Spent as it is used**, between 1 and 10 times, chosen when it is made, so the
-  owner decides up front how far it may travel
+  owner decides up front how far it may travel. A use means *a person*, not a
+  request: `share_claim_code_redemption` records which account claimed which
+  code, with a unique index on the pair, so one recipient submitting the same
+  code ten times spends one use and a repeat is answered idempotently. Without
+  it, one person could exhaust an offer advertised to ten, and the owner's
+  "claimed 10 of 10" would be counting requests rather than the audience it
+  names. The rows are never exposed to the owner — they are told how many people
+  took the offer up, which is what they asked
 - **Withdrawable at any point** before that, from the Sharing page. Withdrawing
   takes effect on the next redemption attempt and does not touch the shares the
   code already produced
@@ -410,11 +459,27 @@ are ordinary relationships and outlive it entirely.
 | `DELETE /api/shares/claim-codes/{id}` | withdraw one |
 | `POST /api/shares/claim-codes/redeem` | claim the comics behind one |
 
-Redeeming is the recipient's own deliberate act, so it stands in for accepting an
-invitation — with one exception it cannot wave through. **An explicit comic is
-left pending behind the age gate**, decided before the share is accepted rather
-than undone afterwards, so there is no moment where an unconfirmed recipient
-holds an accepted share. Everything downstream is the ordinary model: the same
+Redemption goes through `ComicShareService::claimFromCode()`, not through a
+second copy of the share lifecycle. **One service owns what a `ComicShare` is
+and how it changes**, whatever transport created it — a transport that grew its
+own transitions would drift from the canonical rules, and the acknowledgement
+timestamp being recreated at redemption time is exactly the bug that follows.
+Claiming emits the same `SHARE_CREATED` and `SHARE_ACCEPTED` audit records an
+emailed invitation does, tagged `via: claim_code`, alongside the aggregate
+`SHARE_CLAIM_CODE_REDEEMED`.
+
+It differs from an emailed invitation in three deliberate ways: no token and no
+email, because the recipient is right there; redeeming counts as accepting,
+because typing a code somebody gave you is an affirmative act; and the sender's
+acknowledgement is **inherited from the code, not stamped now** — the owner
+acknowledged responsibility when they created it, possibly hours earlier, and
+`ComicShare::senderResponsibilityAcceptedAt` is the canonical evidence of when
+they did.
+
+The one rule redemption cannot wave through is the age gate. **An explicit comic
+is left pending**, decided before the share is accepted rather than undone
+afterwards, so there is no moment where an unconfirmed recipient holds an
+accepted share. Everything downstream is the ordinary model: the same
 `ComicShare`, the same revocation, the same tombstones. Withdrawing a code does
 not touch the shares it already produced; those are ordinary relationships now.
 
@@ -443,6 +508,13 @@ Minting claim codes has its own `share_claim_code` allowance, because it sends n
 mail and the invitation limiter would never see it.
 
 #### Still out of scope
+
+There is no **admin management surface** for issued claim codes: no list, no
+filters, no forced revocation, and no way to run the retention cleanup from the
+UI. Operators have the CLI (`app:cleanup-expired-shares`) and the audit stream.
+That is a gap worth closing, but it is an operations feature rather than a
+defect in the sharing model, so it is tracked separately rather than held
+against this work.
 
 Consent-based **sharing contacts** — where an accepted recipient lets the sender
 remember them by name without an address — remain future work. They need their

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -447,7 +447,11 @@ single guarantee the count exists to make.
 **Retention.** A dead code — withdrawn, expired, used up or left with no comics —
 is kept for **30 days past its expiry** and then deleted by
 `app:cleanup-expired-shares`, alongside the expired invitations that command
-already sweeps. It cannot be redeemed again the moment it dies, so keeping it is
+already sweeps. That command has to be **scheduled on the server**; nothing runs
+it on its own, and an instance without the cron keeps every dead code for ever
+(see [SSH-deploy.md §7](SSH-deploy.md#7-background-jobs-cron--systemd-timers)).
+An administrator can run the same sweep by hand from **Admin → Sharing codes**,
+which is a fallback for a broken cron rather than a substitute for one. It cannot be redeemed again the moment it dies, so keeping it is
 not a risk; but its owner is still asking how many people took it up and which
 comics went with it, and that question outlives the code by rather more than a
 day. `ShareClaimCode::RETENTION_AFTER_EXPIRY` is the one place that window is

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -41,8 +41,9 @@ This document provides detailed information for developers working on the projec
 - **ShareInvitationToken Entity**: Defined in `ShareInvitationToken.php`. Only a SHA-256 hash of each invitation link is stored. One link per invitation, good for a single claim within two months; accepting spends it and revokes every other token for that share, and resending mints a new one and retires the old link
 - **ComicVoter**: `Security/Voter/ComicVoter.php` answers `COMIC_VIEW`, `COMIC_EDIT`, `COMIC_DELETE` and `COMIC_SHARE` for every endpoint that touches a comic
 - **Share Controller**: `ShareController.php` under `/api/shares` — invite, resend, revoke, stop sharing, preview, accept, decline, remove, restore and tombstone cleanup
+- **Sharing Workflow**: `SharingWorkflowController.php` and `SharingWorkflowService.php` add `GET /api/shares/recent-recipients` and `POST /api/shares/invitations/bulk` — the convenience layer behind the Sharing page's **Share comics** flow. Recipients come only from the caller's own share history and never from the user directory; bulk sharing is a permission gate in front of `ComicShareService::inviteMany()` and creates one ordinary `ComicShare` per comic. See [Privacy: registered users are never discoverable](#privacy-registered-users-are-never-discoverable)
 - **Tombstones**: Deleting a comic nulls the relationship and records `unavailableAt` plus a `tombstoneReason`, so recipients are told why a comic disappeared. They are recipient-only — the owner caused the deletion, has no comic left to manage, and the comic leaves their sharing list entirely
-- **Email Notifications**: One "Review invitation" link per email; the link only previews, because mail scanners follow links on the recipient's behalf
+- **Email Notifications**: One "Review invitation" link per invitation; the link only previews, because mail scanners follow links on the recipient's behalf. A bulk share sends one grouped email carrying a link per comic, so twenty comics are not twenty messages
 - **Cleanup Command**: `CleanupExpiredSharesCommand` deletes pending invitations that expired unanswered
 
 #### ✅ Dropbox Integration System
@@ -101,8 +102,9 @@ Full guide, including retention, alert thresholds and the rules for adding an ev
 - **Upload Comic**: Comic upload interface implemented in `UploadComic.jsx` with chunked upload support, progress tracking, and tag management
 
 #### ✅ Comic Sharing
-- **Sharing Page**: `Sharing.jsx` at `/sharing`, with "Shared with me" and "Shared by me" tabs — the management surface for invitations, access and tombstones
-- **Share Comic Modal**: `ShareComicModal.jsx` invites a recipient and shows the invitation link once, since only its hash is stored
+- **Sharing Page**: `Sharing.jsx` at `/sharing` — where shares are both started and managed, with "Shared with me" and "Shared by me" tabs for invitations, access and tombstones
+- **Share Comics Dialog**: `ShareComicsDialog.jsx` is the multi-comic flow behind **Share comics** and **Share another comic** — an owned-only picker with search, previously used recipients, and one grouped invitation email per action. It lists no registered users and searches none
+- **Share Comic Modal**: `ShareComicModal.jsx` is the one-comic shortcut from a comic card, and the only path that shows the invitation link once, since only its hash is stored
 - **Invitation Preview**: `ShareInvitation.jsx` at `/share/invitation/:token` loads the invitation through a safe `GET` and only accepts or declines on a button press
 - **Pending Shares Alert**: `PendingSharesAlert.jsx`, now a one-line prompt on the dashboard rather than a card per invitation
 - **Sharing Hooks**: `use-sharing.jsx` — `SharingProvider` holds the pending count for the header badge and the dashboard alert; `useSharingLists` loads both halves of the Sharing page
@@ -253,6 +255,81 @@ by a write, and concurrent requests can all read the same figure and all decide
 they are under the limit. The allowance is claimed immediately before an
 invitation is issued, so a request rejected as a duplicate, by permissions, or
 by validation does not spend it.
+
+**One send is one claim.** The limiter counts messages, not relationships, so a
+bulk share of twenty comics costs the same one allowance as a single invitation —
+it is one email. That keeps what the limiter protects, how much mail one account
+can put in somebody's inbox, exactly where it was before bulk sharing existed.
+
+#### Starting a share from `/sharing`
+
+`/sharing` is the entry point for new shares as well as the management surface
+for existing ones. **Share comics** is on the page header and in the empty state,
+and each existing recipient has a **Share another comic** shortcut that opens the
+same dialog with the recipient already chosen.
+
+`ShareComicsDialog.jsx` picks owned comics (`GET /api/comics?ownership=mine`,
+filtered again on `canShare`), offers previously used recipients, and posts one
+request:
+
+| Endpoint | Returns |
+|---|---|
+| `GET /api/shares/recent-recipients` | up to 20 addresses this owner has shared with before, most recent first |
+| `POST /api/shares/invitations/bulk` | a per-comic result for up to 20 comics — `created`, `skipped`, `rate_limited`, `failed` or `not_available` |
+
+`SharingWorkflowService` is only the permission gate: it resolves each id, asks
+`ComicVoter::SHARE` about it, and hands what is left to
+`ComicShareService::inviteMany()`. So the duplicate rules, the acknowledgement,
+the tokens, the audit records and the rate limiting are the same code a single
+invitation runs, and a bulk share cannot grant access a single one would refuse.
+
+**Every comic still gets its own `ComicShare`**, its own token, its own status
+and its own revocation. What is shared across a batch is the notice and the
+allowance:
+
+- **One email.** `templates/emails/share_comics.html.twig` lists the comics with
+  a separate **Review invitation** link each, because each invitation is still
+  answered on its own. A batch of one falls back to the ordinary single-comic
+  template. The 18+ gate is applied per comic exactly as it is for a single
+  invitation, so an explicit comic in a batch is announced without its title
+- **All or nothing on the send.** The grouped email is the only notice the
+  recipient gets, so a failed send rolls every relationship in the batch back
+  rather than leaving invitations nobody will hear about
+- **A refused batch creates nothing.** An exhausted allowance, a missing
+  acknowledgement or an address the sender may not invite is answered as one
+  error with its real status, before any comic is touched
+
+A comic that is missing and a comic belonging to somebody else both come back as
+`not_available` with the same message. The picker only ever sends owned ids, but
+a hand-written request must not turn the endpoint into a comic-id oracle.
+
+### Privacy: registered users are never discoverable
+
+> Making sharing easier must never make registered users discoverable.
+
+This is a security requirement, not a UI choice — a frontend that declines to
+search is worthless if the API answers anyway.
+
+- There is **no normal-user endpoint** that searches or lists users by email,
+  username, display name, account id or any other identifier, and none may be
+  added. `/api/users` is admin-only and stays that way
+- **Recent recipients are not a user search.** The query reads `ComicShare` rows
+  whose `owner` is the caller and returns nothing but the normalised addresses
+  the caller typed in themselves. It never joins `User`, so it cannot say whether
+  an address has an account behind it
+- **Incoming shares are not a contact list.** Somebody sharing a comic with you
+  does not put their address in your recipient picker. The sender chose to reveal
+  it for that one invitation; inferring a reciprocal relationship from it would
+  disclose something the recipient was never entitled to
+- **Inviting reveals nothing either way.** The response for an address that
+  belongs to an account and one that does not is identical, so the invitation
+  endpoint cannot be used to enumerate accounts. The UI behaves the same in both
+  cases: the recipient may simply have to register before they can accept
+
+Private opaque **Sharing IDs** are a possible future phase. If they are built,
+they must stay an address-book identifier — high-entropy, revocable, rate limited
+on resolution, granting nothing on their own — and must never become a public
+searchable username.
 
 #### Answering
 1. The email carries a single **Review invitation** link, good for one claim

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -45,7 +45,8 @@ This document provides detailed information for developers working on the projec
 - **Sharing Workflow**: `SharingWorkflowController.php` and `SharingWorkflowService.php` add `GET /api/shares/recent-recipients` and `POST /api/shares/invitations/bulk` — the convenience layer behind the Sharing page's **Share comics** flow. Recipients come only from the caller's own share history and never from the user directory; bulk sharing is a permission gate in front of `ComicShareService::inviteMany()` and creates one ordinary `ComicShare` per comic. See [Privacy: registered users are never discoverable](#privacy-registered-users-are-never-discoverable)
 - **Tombstones**: Deleting a comic nulls the relationship and records `unavailableAt` plus a `tombstoneReason`, so recipients are told why a comic disappeared. They are recipient-only — the owner caused the deletion, has no comic left to manage, and the comic leaves their sharing list entirely
 - **Email Notifications**: One "Review invitation" link per invitation; the link only previews, because mail scanners follow links on the recipient's behalf. A bulk share sends one grouped email carrying a link per comic, so twenty comics are not twenty messages
-- **Cleanup Command**: `CleanupExpiredSharesCommand` deletes pending invitations that expired unanswered, and sharing codes that have been dead for over a month
+- **Cleanup Command**: `CleanupExpiredSharesCommand` deletes pending invitations that expired unanswered, and sharing codes that have been dead for over a month. The work itself is in `ExpiredShareCleanupService`, because an administrator can run the same sweep from the admin page and a deletion rule that exists twice will eventually disagree with itself
+- **Admin Sharing Codes**: `AdminShareCodeController.php` under `/api/admin/sharing-codes` — a paginated, filterable view of every issued claim code, forced revocation, and a manual run of the retention sweep. It can never show a code, take back a claimed comic, or delete a live record
 
 #### ✅ Dropbox Integration System
 - **DropboxController**: Handles OAuth flow, connection status, file listing, and individual comic import
@@ -107,6 +108,7 @@ Full guide, including retention, alert thresholds and the rules for adding an ev
 - **Share Comics Dialog**: `ShareComicsDialog.jsx` is the multi-comic flow behind **Share comics** and **Share another comic** — an owned-only picker with search, previously used recipients, and one grouped invitation email per action. Step 2 offers three ways to name a recipient: an email address, their sharing code, or no one at all (a claim code anybody can redeem). It lists no registered users and searches none
 - **Sharing Codes Card**: `SharingCodesCard.jsx` on `/sharing` — the account's own receiver code with copy and **Replace** actions (the latter behind a confirmation, since the old code breaks everywhere at once), the field for redeeming a code somebody sent, and the list of codes handed out with a **Withdraw** action on each live one
 - **Admin Sharing Code Rotation**: `AdminUserDetails.jsx` can replace a user's receiver code on their behalf, behind a confirmation. The new code is never shown to the administrator — the user reads it off their own Sharing page
+- **Admin Sharing Codes Tab**: `AdminSharingCodesList.jsx` under **Admin → Sharing codes** — every issued claim code with status/owner/date filters and pagination, a **Withdraw** action, and a **Run cleanup** button. Both destructive actions state what they will *not* touch before they run
 - **Share Comic Modal**: `ShareComicModal.jsx` is the one-comic shortcut from a comic card, and the only path that shows the invitation link once, since only its hash is stored
 - **Invitation Preview**: `ShareInvitation.jsx` at `/share/invitation/:token` loads the invitation through a safe `GET` and only accepts or declines on a button press
 - **Pending Shares Alert**: `PendingSharesAlert.jsx`, now a one-line prompt on the dashboard rather than a card per invitation
@@ -507,14 +509,45 @@ sharing has, and it is built to be a bad one:
 Minting claim codes has its own `share_claim_code` allowance, because it sends no
 mail and the invitation limiter would never see it.
 
-#### Still out of scope
+#### Operating them
 
-There is no **admin management surface** for issued claim codes: no list, no
-filters, no forced revocation, and no way to run the retention cleanup from the
-UI. Operators have the CLI (`app:cleanup-expired-shares`) and the audit stream.
-That is a gap worth closing, but it is an operations feature rather than a
-defect in the sharing model, so it is tracked separately rather than held
-against this work.
+Claim codes are capabilities that leave the building, so **Admin → Sharing
+codes** exists to see what is outstanding and stop one without going to the
+database.
+
+| Endpoint | Does |
+|---|---|
+| `GET /api/admin/sharing-codes` | one page of issued codes, filtered by status, owner, or created/expiry range |
+| `POST /api/admin/sharing-codes/{id}/revoke` | withdraw somebody else's code |
+| `POST /api/admin/sharing-codes/cleanup` | run the retention sweep by hand |
+
+The table is paginated because it grows continuously between sweeps, and the
+status filters (`active`, `expired`, `exhausted`, `withdrawn`) are expressed as
+predicates over the row and the clock rather than read from a stored column —
+a second column saying so would be one more thing to keep in step.
+
+Three things this surface deliberately cannot do:
+
+- **show a code.** Only the hash is stored, so there is nothing to show and
+  nothing to recover, not even for an administrator
+- **take back a comic.** Withdrawing closes the way in and never the access
+  already granted, exactly as it does when the owner withdraws their own code.
+  Removing a share is moderation — a different decision, on a different screen
+- **delete a live record.** The button runs `ExpiredShareCleanupService`, the
+  same service the scheduled command runs, so it can only remove what the
+  nightly job would have removed anyway
+
+Revocation goes through `ShareClaimCodeService`, so the admin path cannot grow
+its own idea of what withdrawing means, and both it and the manual sweep are
+audited with the acting administrator, the target and the counts. The scheduled
+command is deliberately *not* audited: a cron job reporting its own quiet runs
+is noise, and what it removed is visible in what is no longer there. A person
+deleting records from other people's accounts is a different matter.
+
+Receiver codes are not managed here. Their lifecycle is rotation, which lives on
+the admin **user** page beside the account it identifies.
+
+#### Still out of scope
 
 Consent-based **sharing contacts** — where an accepted recipient lets the sender
 remember them by name without an address — remain future work. They need their

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -45,7 +45,7 @@ This document provides detailed information for developers working on the projec
 - **Sharing Workflow**: `SharingWorkflowController.php` and `SharingWorkflowService.php` add `GET /api/shares/recent-recipients` and `POST /api/shares/invitations/bulk` — the convenience layer behind the Sharing page's **Share comics** flow. Recipients come only from the caller's own share history and never from the user directory; bulk sharing is a permission gate in front of `ComicShareService::inviteMany()` and creates one ordinary `ComicShare` per comic. See [Privacy: registered users are never discoverable](#privacy-registered-users-are-never-discoverable)
 - **Tombstones**: Deleting a comic nulls the relationship and records `unavailableAt` plus a `tombstoneReason`, so recipients are told why a comic disappeared. They are recipient-only — the owner caused the deletion, has no comic left to manage, and the comic leaves their sharing list entirely
 - **Email Notifications**: One "Review invitation" link per invitation; the link only previews, because mail scanners follow links on the recipient's behalf. A bulk share sends one grouped email carrying a link per comic, so twenty comics are not twenty messages
-- **Cleanup Command**: `CleanupExpiredSharesCommand` deletes pending invitations that expired unanswered
+- **Cleanup Command**: `CleanupExpiredSharesCommand` deletes pending invitations that expired unanswered, and sharing codes that have been dead for over a month
 
 #### ✅ Dropbox Integration System
 - **DropboxController**: Handles OAuth flow, connection status, file listing, and individual comic import
@@ -105,7 +105,7 @@ Full guide, including retention, alert thresholds and the rules for adding an ev
 #### ✅ Comic Sharing
 - **Sharing Page**: `Sharing.jsx` at `/sharing` — where shares are both started and managed, with "Shared with me" and "Shared by me" tabs for invitations, access and tombstones
 - **Share Comics Dialog**: `ShareComicsDialog.jsx` is the multi-comic flow behind **Share comics** and **Share another comic** — an owned-only picker with search, previously used recipients, and one grouped invitation email per action. Step 2 offers three ways to name a recipient: an email address, their sharing code, or no one at all (a claim code anybody can redeem). It lists no registered users and searches none
-- **Sharing Codes Card**: `SharingCodesCard.jsx` on `/sharing` — the account's own permanent receiver code with a copy action, and the field for redeeming a code somebody sent
+- **Sharing Codes Card**: `SharingCodesCard.jsx` on `/sharing` — the account's own permanent receiver code with a copy action, the field for redeeming a code somebody sent, and the list of codes handed out with a **Withdraw** action on each live one
 - **Share Comic Modal**: `ShareComicModal.jsx` is the one-comic shortcut from a comic card, and the only path that shows the invitation link once, since only its hash is stored
 - **Invitation Preview**: `ShareInvitation.jsx` at `/share/invitation/:token` loads the invitation through a safe `GET` and only accepts or declines on a button press
 - **Pending Shares Alert**: `PendingSharesAlert.jsx`, now a one-line prompt on the dashboard rather than a card per invitation
@@ -375,16 +375,38 @@ one:
 
 - **Hashed at rest**, like an invitation token. The plaintext is returned once,
   when it is created, and nothing can reproduce it afterwards
+- **Unique**, checked against both `share_claim_code.code_hash` and
+  `user.sharing_code` before one is kept, so no code of either kind is ever
+  issued twice. The unique index is the authority behind that check
 - **Dead in a day.** A code pasted into a group chat is out of its owner's hands
   the moment it is sent
 - **Spent as it is used**, between 1 and 10 times, chosen when it is made, so the
   owner decides up front how far it may travel
+- **Withdrawable at any point** before that, from the Sharing page. Withdrawing
+  takes effect on the next redemption attempt and does not touch the shares the
+  code already produced
 - **Worth nothing without an account.** Redeeming requires being signed in
+
+Redemption is one unit of work with a pessimistic write lock taken on the row
+before the remaining uses are read. "Check the count, then decrement it" is a
+read followed by a write, and two redemptions arriving together would otherwise
+both see the last use — so a one-use code would let two people in, which is the
+single guarantee the count exists to make.
+
+**Retention.** A dead code — withdrawn, expired, used up or left with no comics —
+is kept for **30 days past its expiry** and then deleted by
+`app:cleanup-expired-shares`, alongside the expired invitations that command
+already sweeps. It cannot be redeemed again the moment it dies, so keeping it is
+not a risk; but its owner is still asking how many people took it up and which
+comics went with it, and that question outlives the code by rather more than a
+day. `ShareClaimCode::RETENTION_AFTER_EXPIRY` is the one place that window is
+stated. Only the code rows and their join rows go — the shares a code produced
+are ordinary relationships and outlive it entirely.
 
 | Endpoint | Does |
 |---|---|
 | `POST /api/shares/claim-codes` | mint one over comics the owner may share |
-| `GET /api/shares/claim-codes` | list live codes — never the codes themselves |
+| `GET /api/shares/claim-codes` | list codes handed out, live and dead — never the codes themselves |
 | `DELETE /api/shares/claim-codes/{id}` | withdraw one |
 | `POST /api/shares/claim-codes/redeem` | claim the comics behind one |
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ docker compose exec php php bin/console cache:clear
 
 `app:cleanup-comics` moves orphaned files to recoverable quarantine storage. Run its dry-run mode first.
 
+### Scheduled maintenance
+
+Nothing in the application schedules itself. Retention periods in `.env.local`
+are **policy only** — they say how long something is kept, and a command has to
+run for anything to be deleted. A production instance needs these three:
+
+| Command | Cadence | If it never runs |
+|---|---|---|
+| `app:cleanup-logs` | daily | Log directories grow without limit; `*_LOG_RETENTION_DAYS` has no effect |
+| `app:cleanup-personal-data` | daily | Old audit rows, spent tokens, unverified accounts and uncollected export files are kept indefinitely |
+| `app:cleanup-expired-shares` | daily | Unanswered invitations keep the addresses of people who never had an account here, and dead sharing codes are never removed |
+
+`app:dropbox-sync` is additionally needed only if the instance uses Dropbox
+imports. Crontab examples, and how to check the schedule is actually firing, are
+in [SSH-deploy.md §7](SSH-deploy.md#7-background-jobs-cron--systemd-timers).
+
 ## Testing and quality checks
 
 ### Frontend

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ docker compose exec php php bin/console app:import-comics /path/to/comics user@e
 # Preview orphan cleanup without removing source files
 docker compose exec php php bin/console app:cleanup-comics --dry-run
 
-# Remove sharing invitations that expired unanswered
+# Remove sharing invitations that expired unanswered, and sharing codes that
+# have been dead for over a month
 docker compose exec php php bin/console app:cleanup-expired-shares
 
 # Clear the Symfony cache

--- a/SSH-deploy.md
+++ b/SSH-deploy.md
@@ -512,15 +512,52 @@ intentionally move to containers.
 
 ## 7. Background jobs (cron / systemd timers)
 
-These unit/cron fragments are also **server-side examples** (not repo files).
-Install them on the host if you need the corresponding job.
+These unit/cron fragments are **server-side examples** (not repo files). Install
+them on the host if you need the corresponding job.
+
+### 7.0 What has to be scheduled, and what breaks if it is not
+
+Nothing in this application schedules itself. Retention periods configured in
+`.env.local` are **policy only** — the value says how long something is kept,
+and a command has to run for anything to actually be deleted. An instance with
+no cron keeps everything for ever and never notices.
+
+| Command | Suggested cadence | Required? | If it never runs |
+|---|---|---|---|
+| `app:cleanup-logs` | daily | **Yes** | `var/log/app`, `var/log/security` and `var/log/audit` grow without limit. `*_LOG_RETENTION_DAYS` has no effect |
+| `app:cleanup-personal-data` | daily | **Yes** | Audit rows past 12 months, spent verification and reset tokens, unverified accounts older than 30 days and pending export files are all kept indefinitely. This is a data-protection obligation, not housekeeping |
+| `app:cleanup-expired-shares` | daily | **Yes** | Unanswered invitations keep the email addresses of people who never had an account here. Dead sharing codes are never removed, so the admin table grows for ever |
+| `app:dropbox-sync` | every 2 hours | Only with Dropbox | Users import by hand from the Dropbox page. Nothing else is affected |
+| `app:cleanup-comics` | never | **No** | Nothing. It quarantines orphaned files and is a manual tool — run `--dry-run` first and look at the output |
+
+The three required jobs are all idempotent, cheap when there is nothing to do,
+and safe to run more often than suggested. Stagger them by a few minutes rather
+than starting them all on the hour.
+
+> **The sharing cleanup is the one with a visible product consequence.** Dead
+> sharing codes are deliberately kept for 30 days past expiry so their owner can
+> still see how many people took them up. Without the cron they are kept for
+> ever instead, which is a growing table rather than a correctness problem — but
+> the expired *invitations* it also removes hold recipient email addresses, and
+> those should not outlive the invitation. See
+> [DEV_README.md](DEV_README.md#sharing-codes).
+
+An administrator can run the sharing sweep by hand from **Admin → Sharing
+codes → Run cleanup**. That is a fallback for a broken or unconfigured cron, not
+a replacement for one: it runs the same service with the same rules, but only
+when somebody remembers to press it.
 
 ### 7.1 Dropbox sync (every 2 hours)
 
+Only needed if the instance uses Dropbox imports.
+
 ```cron
 # crontab -e for the deploy user
-0 */2 * * * cd /var/www/comics/backend && php bin/console app:sync-dropbox-comics --env=prod >> /var/log/comics-dropbox.log 2>&1
+0 */2 * * * cd /var/www/comics/backend && php bin/console app:dropbox-sync --env=prod >> /var/log/comics-dropbox.log 2>&1
 ```
+
+Add `--limit=<n>` to cap how many files each user imports per run, and
+`--dry-run` to see what a run would do without importing anything.
 
 ### 7.2 Symfony Messenger consumer (if you switch from sync to async)
 
@@ -584,10 +621,44 @@ The glob is deliberately not recursive, so it matches only the files directly in
 
 ### 7.4 Retention and privacy cleanups
 
+Both are required. Together with `app:cleanup-logs` above, these three lines are
+the whole of what this application needs scheduled:
+
 ```cron
-0 3 * * * cd /var/www/comics/backend && php bin/console app:cleanup-personal-data --env=prod >> /var/log/comics-cleanup.log 2>&1
-5 3 * * * cd /var/www/comics/backend && php bin/console app:cleanup-expired-shares --env=prod >> /var/log/comics-cleanup.log 2>&1
+# crontab -e for the deploy user
+0  3 * * * cd /var/www/comics/backend && php bin/console app:cleanup-personal-data --env=prod >> /var/log/comics-cleanup.log 2>&1
+5  3 * * * cd /var/www/comics/backend && php bin/console app:cleanup-expired-shares --env=prod >> /var/log/comics-cleanup.log 2>&1
+15 3 * * * cd /var/www/comics/backend && php bin/console app:cleanup-logs --env=prod >> /var/log/comics-cleanup.log 2>&1
 ```
+
+`app:cleanup-personal-data` removes audit rows past 12 months, spent email
+verification and password reset tokens, unverified accounts older than 30 days,
+and personal-data export files that were never collected.
+
+`app:cleanup-expired-shares` removes invitations that expired unanswered — they
+hold the address of somebody who may never have had an account here — and
+sharing codes that died more than 30 days ago. It never touches a live record,
+and never the comics somebody claimed through a code.
+
+Both print what they removed. They are quiet by design when there is nothing to
+do, so an empty log line is the normal case rather than a sign the job failed.
+
+#### Checking the schedule is actually working
+
+```sh
+# Every job the deploy user has
+crontab -l
+
+# What the last runs did
+tail -n 50 /var/log/comics-cleanup.log
+
+# Prove a command runs at all under the deploy user's environment
+cd /var/www/comics/backend && php bin/console app:cleanup-expired-shares --env=prod
+```
+
+The usual reason a cron entry silently does nothing is `php` not being on
+`PATH` for a non-login shell. Use an absolute interpreter path
+(`/usr/bin/php`) if `crontab -l` looks right but the log stays empty.
 
 ---
 

--- a/backend/config/packages/rate_limiter.yaml
+++ b/backend/config/packages/rate_limiter.yaml
@@ -26,6 +26,25 @@ framework:
             policy: sliding_window
             limit: 10
             interval: '1 hour'
+        # Sharing codes are the only place an identifier somebody typed is
+        # turned into a person, so this is the only enumeration surface the
+        # sharing feature has. Charged per lookup that finds nothing, so
+        # pasting a code never meets it and grinding through candidates does.
+        # Sixty bits of entropy is what actually makes guessing hopeless; this
+        # is the ceiling that stops anybody trying at scale.
+        sharing_code_lookup:
+            policy: sliding_window
+            limit: 20
+            interval: '1 hour'
+        # Creating a claim code sends no mail, so the invitation limiter is the
+        # wrong control for it — but a code handed out ten times at a time is
+        # still access leaving the account, and it deserves a ceiling of its
+        # own. Redemption attempts that fail are charged against the lookup
+        # limiter above, for the same reason.
+        share_claim_code:
+            policy: sliding_window
+            limit: 10
+            interval: '1 hour'
 
 when@test:
     framework:

--- a/backend/config/packages/rate_limiter.yaml
+++ b/backend/config/packages/rate_limiter.yaml
@@ -45,6 +45,15 @@ framework:
             policy: sliding_window
             limit: 10
             interval: '1 hour'
+        # Replacing a receiver code is cheap for the account doing it and
+        # expensive for everybody holding the old one, so this is not about
+        # load — it is about a script or a stuck retry quietly making somebody
+        # uncontactable. Generous enough that a person who rotates, mistypes
+        # the new code to a friend and rotates again never notices it.
+        sharing_code_rotation:
+            policy: sliding_window
+            limit: 5
+            interval: '1 hour'
 
 when@test:
     framework:
@@ -56,4 +65,11 @@ when@test:
             forgot_password:
                 limit: 1000
             verification_resend:
+                limit: 1000
+            # Raised because the limiter is cache-backed while the database is
+            # rolled back between tests: user ids come round again and inherit
+            # an allowance a previous test spent. No test asserts this limit —
+            # the ones that do assert a limit are written to tolerate arriving
+            # at a key somebody else already used.
+            share_claim_code:
                 limit: 1000

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -67,8 +67,11 @@ security:
         # longer paths, which this pattern deliberately does not match.
         - { path: '^/api/shares/invitations/[^/]+$', methods: [GET], roles: PUBLIC_ACCESS }
 
-        # Admin routes (all methods)
-        - { path: ^/api/users(/[0-9]+)?$, roles: ROLE_ADMIN }
+        # Admin routes (all methods). Not anchored on the id, so sub-resources
+        # such as /api/users/{id}/verify and /api/users/{id}/sharing-code/rotate
+        # are covered by the firewall as well as by their own in-controller
+        # check, rather than falling through to plain authentication.
+        - { path: ^/api/users(/|$), roles: ROLE_ADMIN }
         - { path: ^/api/admin, roles: ROLE_ADMIN }
         
         # User routes (require authentication)

--- a/backend/migrations/Version20260809100000.php
+++ b/backend/migrations/Version20260809100000.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Sharing codes: the permanent address somebody shares with an account by, and
+ * the disposable code an owner hands out to give comics away.
+ *
+ * `user.sharing_code` is nullable and left empty here. Filling it for every
+ * existing row would mean generating a unique value per user inside a migration
+ * that has to run against a live installation over HTTP; the application issues
+ * one the first time an account asks for it instead, which is a single row and
+ * a single unique-index check. The column is still `UNIQUE`, so two accounts
+ * cannot end up on the same address however the value arrives.
+ *
+ * `comic_share.recipient_alias_name` and `recipient_sharing_code` are what the
+ * owner is shown in place of an address they were never given. Null for every
+ * existing row, because every existing share was made by typing an address.
+ */
+final class Version20260809100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add receiver sharing codes, claim codes, and code-recipient aliases on shares.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\AbstractMySQLPlatform,
+            'This migration targets MySQL.'
+        );
+
+        // Index names are the ones Doctrine derives from the table and column,
+        // because `doctrine:schema:validate` runs in CI and compares them.
+        $this->addSql('ALTER TABLE `user` ADD sharing_code VARCHAR(16) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649CFA8625F ON `user` (sharing_code)');
+
+        $this->addSql(
+            'ALTER TABLE comic_share
+                ADD recipient_alias_name VARCHAR(255) DEFAULT NULL,
+                ADD recipient_sharing_code VARCHAR(16) DEFAULT NULL'
+        );
+
+        $this->addSql(
+            'CREATE TABLE share_claim_code (
+                id INT AUTO_INCREMENT NOT NULL,
+                owner_id INT NOT NULL,
+                code_hash VARCHAR(64) NOT NULL,
+                max_uses INT NOT NULL,
+                uses_remaining INT NOT NULL,
+                created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+                expires_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+                revoked_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+                sender_responsibility_accepted_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+                UNIQUE INDEX UNIQ_DDFF9F7AE7530879 (code_hash),
+                INDEX IDX_DDFF9F7A7E3C61F9 (owner_id),
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB'
+        );
+
+        $this->addSql(
+            'ALTER TABLE share_claim_code
+                ADD CONSTRAINT FK_SHARE_CLAIM_CODE_OWNER
+                FOREIGN KEY (owner_id) REFERENCES `user` (id) ON DELETE CASCADE'
+        );
+
+        // The join rows cascade on both sides. A deleted comic leaves the code
+        // still offering whatever else was on it, and a deleted code takes only
+        // its own rows with it — never a comic.
+        $this->addSql(
+            'CREATE TABLE share_claim_code_comic (
+                share_claim_code_id INT NOT NULL,
+                comic_id INT NOT NULL,
+                INDEX IDX_73FD77C2E4FC5133 (share_claim_code_id),
+                INDEX IDX_73FD77C2D663094A (comic_id),
+                PRIMARY KEY(share_claim_code_id, comic_id)
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB'
+        );
+
+        $this->addSql(
+            'ALTER TABLE share_claim_code_comic
+                ADD CONSTRAINT FK_SHARE_CLAIM_CODE_COMIC_CODE
+                FOREIGN KEY (share_claim_code_id) REFERENCES share_claim_code (id) ON DELETE CASCADE'
+        );
+        $this->addSql(
+            'ALTER TABLE share_claim_code_comic
+                ADD CONSTRAINT FK_SHARE_CLAIM_CODE_COMIC_COMIC
+                FOREIGN KEY (comic_id) REFERENCES comic (id) ON DELETE CASCADE'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE share_claim_code_comic DROP FOREIGN KEY FK_SHARE_CLAIM_CODE_COMIC_CODE');
+        $this->addSql('ALTER TABLE share_claim_code_comic DROP FOREIGN KEY FK_SHARE_CLAIM_CODE_COMIC_COMIC');
+        $this->addSql('DROP TABLE share_claim_code_comic');
+        $this->addSql('ALTER TABLE share_claim_code DROP FOREIGN KEY FK_SHARE_CLAIM_CODE_OWNER');
+        $this->addSql('DROP TABLE share_claim_code');
+        $this->addSql('ALTER TABLE comic_share DROP recipient_alias_name, DROP recipient_sharing_code');
+        $this->addSql('DROP INDEX UNIQ_8D93D649CFA8625F ON `user`');
+        $this->addSql('ALTER TABLE `user` DROP sharing_code');
+    }
+}

--- a/backend/migrations/Version20260809140000.php
+++ b/backend/migrations/Version20260809140000.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Who has claimed a sharing code, so a use means a person rather than a request.
+ *
+ * `share_claim_code.uses_remaining` on its own cannot say what "ten uses" means:
+ * decrementing on every redemption lets one recipient submit the same code ten
+ * times and exhaust an offer advertised to ten people. The unique index here is
+ * what makes one account cost at most one use, including when two of their
+ * requests arrive together.
+ *
+ * Both foreign keys cascade. A deleted code takes its redemption history with
+ * it, and a deleted account stops being counted — neither returns a spent use,
+ * because the offer was made and taken.
+ */
+final class Version20260809140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Record which account redeemed which sharing code, one use per account.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\AbstractMySQLPlatform,
+            'This migration targets MySQL.'
+        );
+
+        // Index names are the ones Doctrine derives from the table and columns,
+        // because `doctrine:schema:validate` runs in CI and compares them.
+        $this->addSql(
+            'CREATE TABLE share_claim_code_redemption (
+                id INT AUTO_INCREMENT NOT NULL,
+                claim_code_id INT NOT NULL,
+                recipient_id INT NOT NULL,
+                redeemed_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+                INDEX IDX_B75072CEB6211129 (claim_code_id),
+                INDEX IDX_B75072CEE92F8F78 (recipient_id),
+                UNIQUE INDEX uniq_claim_code_recipient (claim_code_id, recipient_id),
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB'
+        );
+
+        $this->addSql(
+            'ALTER TABLE share_claim_code_redemption
+                ADD CONSTRAINT FK_B75072CEB6211129
+                FOREIGN KEY (claim_code_id) REFERENCES share_claim_code (id) ON DELETE CASCADE'
+        );
+        $this->addSql(
+            'ALTER TABLE share_claim_code_redemption
+                ADD CONSTRAINT FK_B75072CEE92F8F78
+                FOREIGN KEY (recipient_id) REFERENCES `user` (id) ON DELETE CASCADE'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE share_claim_code_redemption DROP FOREIGN KEY FK_B75072CEB6211129');
+        $this->addSql('ALTER TABLE share_claim_code_redemption DROP FOREIGN KEY FK_B75072CEE92F8F78');
+        $this->addSql('DROP TABLE share_claim_code_redemption');
+    }
+}

--- a/backend/src/Command/CleanupExpiredSharesCommand.php
+++ b/backend/src/Command/CleanupExpiredSharesCommand.php
@@ -2,7 +2,9 @@
 
 namespace App\Command;
 
+use App\Entity\ShareClaimCode;
 use App\Repository\ComicShareRepository;
+use App\Repository\ShareClaimCodeRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -11,14 +13,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Delete invitations nobody answered before they expired.
+ * Delete invitations nobody answered before they expired, and sharing codes
+ * that have been dead long enough to stop being worth looking at.
  *
- * Only pending relationships are in scope. An accepted share has no expiry, and
- * a declined or revoked one is history somebody may still be looking at.
+ * For invitations, only pending relationships are in scope. An accepted share
+ * has no expiry, and a declined or revoked one is history somebody may still be
+ * looking at. An expired invitation is deleted rather than kept, because it
+ * holds the email address of somebody who may never have had an account here
+ * and who did not act on it.
  *
- * An expired invitation is deleted rather than kept, because it holds the email
- * address of somebody who may never have had an account here and who did not
- * act on it.
+ * Sharing codes are given a month past their expiry first. A dead code cannot
+ * be redeemed again the moment it dies, so keeping it is not a risk — but its
+ * owner is still asking how many people took it up and which comics went with
+ * it, and that question outlives the code by rather more than a day.
  *
  * Run periodically from cron:
  *
@@ -27,7 +34,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 #[AsCommand(
     name: 'app:cleanup-expired-shares',
-    description: 'Deletes share invitations that expired without being answered',
+    description: 'Deletes expired share invitations and long-dead sharing codes',
 )]
 class CleanupExpiredSharesCommand extends Command
 {
@@ -42,23 +49,48 @@ class CleanupExpiredSharesCommand extends Command
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly ComicShareRepository $shareRepository,
+        private readonly ShareClaimCodeRepository $claimCodeRepository,
     ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->setHelp('Removes pending share invitations whose expiry date has passed.');
+        $this->setHelp(
+            'Removes pending share invitations whose expiry date has passed, and sharing codes that '
+            . 'expired more than ' . ltrim(ShareClaimCode::RETENTION_AFTER_EXPIRY, '+') . ' ago.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $io->title('Cleaning up expired share invitations');
+        $io->title('Cleaning up expired shares and sharing codes');
 
         // Resolved once so a batch cannot pick up invitations that expire while
         // the command is still working through the backlog.
         $now = new \DateTimeImmutable();
+
+        $invitations = $this->purgeExpiredInvitations($now);
+        $codes = $this->purgeDeadClaimCodes($now);
+
+        if ($invitations === 0 && $codes === 0) {
+            $io->success('Nothing to clean up.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->success(sprintf(
+            'Removed %d expired invitation(s) and %d dead sharing code(s).',
+            $invitations,
+            $codes
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    private function purgeExpiredInvitations(\DateTimeImmutable $now): int
+    {
         $count = 0;
 
         while (($expired = $this->shareRepository->findExpiredPendingShares($now, self::BATCH_SIZE)) !== []) {
@@ -73,14 +105,35 @@ class CleanupExpiredSharesCommand extends Command
             $count += count($expired);
         }
 
-        if ($count === 0) {
-            $io->success('No expired invitations to clean up.');
+        return $count;
+    }
 
-            return Command::SUCCESS;
+    /**
+     * Delete codes that expired long enough ago to have answered every question
+     * their owner had about them.
+     *
+     * Withdrawn codes go the same way and on the same clock. Withdrawing one
+     * stops it working immediately; it does not make the record of what was
+     * offered any less interesting to the person who offered it.
+     *
+     * Only the code rows and their join rows go. The shares a code produced are
+     * ordinary relationships and outlive it entirely — that is the whole point
+     * of a code being a way in rather than the access itself.
+     */
+    private function purgeDeadClaimCodes(\DateTimeImmutable $now): int
+    {
+        $count = 0;
+
+        while (($dead = $this->claimCodeRepository->findDeletable($now, self::BATCH_SIZE)) !== []) {
+            foreach ($dead as $code) {
+                $this->entityManager->remove($code);
+            }
+
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+            $count += count($dead);
         }
 
-        $io->success(sprintf('Removed %d expired invitation(s).', $count));
-
-        return Command::SUCCESS;
+        return $count;
     }
 }

--- a/backend/src/Command/CleanupExpiredSharesCommand.php
+++ b/backend/src/Command/CleanupExpiredSharesCommand.php
@@ -3,9 +3,7 @@
 namespace App\Command;
 
 use App\Entity\ShareClaimCode;
-use App\Repository\ComicShareRepository;
-use App\Repository\ShareClaimCodeRepository;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Service\ExpiredShareCleanupService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,19 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Delete invitations nobody answered before they expired, and sharing codes
- * that have been dead long enough to stop being worth looking at.
+ * The scheduled retention sweep for sharing records.
  *
- * For invitations, only pending relationships are in scope. An accepted share
- * has no expiry, and a declined or revoked one is history somebody may still be
- * looking at. An expired invitation is deleted rather than kept, because it
- * holds the email address of somebody who may never have had an account here
- * and who did not act on it.
- *
- * Sharing codes are given a month past their expiry first. A dead code cannot
- * be redeemed again the moment it dies, so keeping it is not a risk — but its
- * owner is still asking how many people took it up and which comics went with
- * it, and that question outlives the code by rather more than a day.
+ * The work itself lives in {@see ExpiredShareCleanupService}, because an
+ * administrator can run the same sweep from the admin page and a deletion rule
+ * that exists twice is one that will eventually disagree with itself. This is
+ * the normal path; the button is the fallback for an installation whose cron is
+ * not running.
  *
  * Run periodically from cron:
  *
@@ -38,19 +30,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class CleanupExpiredSharesCommand extends Command
 {
-    /**
-     * Shares removed per flush. A cron job that has not run for a long time, or
-     * a bulk invitation import, would otherwise hydrate every expired share and
-     * its cascaded tokens into one unit of work — and run out of memory before
-     * deleting anything at all.
-     */
-    private const BATCH_SIZE = 200;
-
-    public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-        private readonly ComicShareRepository $shareRepository,
-        private readonly ShareClaimCodeRepository $claimCodeRepository,
-    ) {
+    public function __construct(private readonly ExpiredShareCleanupService $cleanup)
+    {
         parent::__construct();
     }
 
@@ -67,14 +48,13 @@ class CleanupExpiredSharesCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Cleaning up expired shares and sharing codes');
 
-        // Resolved once so a batch cannot pick up invitations that expire while
-        // the command is still working through the backlog.
-        $now = new \DateTimeImmutable();
+        // Deliberately not audited. A cron job reporting its own quiet runs is
+        // noise, and what it removed is already visible in what is no longer
+        // there. The admin button audits instead, because a person deleting
+        // records from other people's accounts should be answerable for it.
+        $removed = $this->cleanup->run();
 
-        $invitations = $this->purgeExpiredInvitations($now);
-        $codes = $this->purgeDeadClaimCodes($now);
-
-        if ($invitations === 0 && $codes === 0) {
+        if ($removed['invitations'] === 0 && $removed['claimCodes'] === 0) {
             $io->success('Nothing to clean up.');
 
             return Command::SUCCESS;
@@ -82,58 +62,10 @@ class CleanupExpiredSharesCommand extends Command
 
         $io->success(sprintf(
             'Removed %d expired invitation(s) and %d dead sharing code(s).',
-            $invitations,
-            $codes
+            $removed['invitations'],
+            $removed['claimCodes']
         ));
 
         return Command::SUCCESS;
-    }
-
-    private function purgeExpiredInvitations(\DateTimeImmutable $now): int
-    {
-        $count = 0;
-
-        while (($expired = $this->shareRepository->findExpiredPendingShares($now, self::BATCH_SIZE)) !== []) {
-            foreach ($expired as $share) {
-                // The invitation tokens go with it: they are mapped with
-                // orphanRemoval and a cascading foreign key.
-                $this->entityManager->remove($share);
-            }
-
-            $this->entityManager->flush();
-            $this->entityManager->clear();
-            $count += count($expired);
-        }
-
-        return $count;
-    }
-
-    /**
-     * Delete codes that expired long enough ago to have answered every question
-     * their owner had about them.
-     *
-     * Withdrawn codes go the same way and on the same clock. Withdrawing one
-     * stops it working immediately; it does not make the record of what was
-     * offered any less interesting to the person who offered it.
-     *
-     * Only the code rows and their join rows go. The shares a code produced are
-     * ordinary relationships and outlive it entirely — that is the whole point
-     * of a code being a way in rather than the access itself.
-     */
-    private function purgeDeadClaimCodes(\DateTimeImmutable $now): int
-    {
-        $count = 0;
-
-        while (($dead = $this->claimCodeRepository->findDeletable($now, self::BATCH_SIZE)) !== []) {
-            foreach ($dead as $code) {
-                $this->entityManager->remove($code);
-            }
-
-            $this->entityManager->flush();
-            $this->entityManager->clear();
-            $count += count($dead);
-        }
-
-        return $count;
     }
 }

--- a/backend/src/Controller/AdminShareCodeController.php
+++ b/backend/src/Controller/AdminShareCodeController.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\ShareClaimCode;
+use App\Entity\User;
+use App\Repository\ShareClaimCodeRepository;
+use App\Service\ExpiredShareCleanupService;
+use App\Service\Pagination\PaginationRequest;
+use App\Service\ShareClaimCodeService;
+use App\Service\ShareException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Operational tooling for the sharing codes an instance has issued.
+ *
+ * Claim codes are capabilities that leave the building — pasted into chats,
+ * forwarded, posted by mistake — so somebody has to be able to see what is
+ * outstanding and stop one without going to the database. This is that surface,
+ * and it is the whole of it: everything here reads metadata or calls a lifecycle
+ * method that already exists.
+ *
+ * Three things it deliberately cannot do. It cannot show a code, because only
+ * the hash is stored and there is nothing to show. It cannot revoke a share,
+ * because withdrawing a code stops the way in and never the access already
+ * granted — taking a comic back is moderation, which is a different decision on
+ * a different screen. And it cannot delete a live record, because the cleanup
+ * it runs is the retention sweep and nothing else.
+ *
+ * Receiver codes are not managed here. Their lifecycle is rotation, which
+ * belongs on the admin user page beside the account it identifies.
+ */
+#[Route('/api/admin/sharing-codes')]
+#[IsGranted('ROLE_ADMIN')]
+final class AdminShareCodeController extends AbstractController
+{
+    public function __construct(
+        private readonly ShareClaimCodeRepository $claimCodes,
+        private readonly ShareClaimCodeService $claimCodeService,
+        private readonly ExpiredShareCleanupService $cleanup,
+    ) {
+    }
+
+    #[Route('', name: 'app_admin_sharing_codes_list', methods: ['GET'])]
+    public function list(Request $request): JsonResponse
+    {
+        $pagination = PaginationRequest::fromRequest(
+            $request,
+            ShareClaimCodeRepository::ADMIN_SORT_FIELDS,
+            'createdAt'
+        );
+
+        $status = $request->query->get('status');
+        if (!in_array($status, ['active', 'expired', 'withdrawn', 'exhausted'], true)) {
+            $status = null;
+        }
+
+        $page = $this->claimCodes->findAdminPage($pagination, [
+            'status' => $status,
+            'ownerId' => $request->query->has('ownerId') ? $request->query->getInt('ownerId') : null,
+            'createdFrom' => $this->date($request->query->get('createdFrom')),
+            'createdTo' => $this->date($request->query->get('createdTo'), endOfDay: true),
+            'expiresFrom' => $this->date($request->query->get('expiresFrom')),
+            'expiresTo' => $this->date($request->query->get('expiresTo'), endOfDay: true),
+        ]);
+
+        return $this->json([
+            'items' => array_map(
+                static fn (ShareClaimCode $code): array => $code->toAdminPayload(),
+                $page->items
+            ),
+            'pagination' => $page->toArray(),
+            'retentionAfterExpiry' => ltrim(ShareClaimCode::RETENTION_AFTER_EXPIRY, '+'),
+        ]);
+    }
+
+    #[Route('/{id}/revoke', name: 'app_admin_sharing_codes_revoke', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function revoke(int $id): JsonResponse
+    {
+        /** @var User $admin */
+        $admin = $this->getUser();
+
+        try {
+            $code = $this->claimCodeService->revokeAsAdministrator($id, $admin);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json([
+            'message' => 'Sharing code withdrawn. Comics already claimed through it are unaffected.',
+            'claimCode' => $code->toAdminPayload(),
+        ]);
+    }
+
+    /**
+     * Run the retention sweep by hand.
+     *
+     * The scheduled command remains the normal path; this is for an
+     * installation whose cron is not running, or the first minutes after a
+     * deployment. Both call the same service, so an administrator pressing this
+     * cannot remove anything the nightly job would have left alone.
+     */
+    #[Route('/cleanup', name: 'app_admin_sharing_codes_cleanup', methods: ['POST'])]
+    public function runCleanup(): JsonResponse
+    {
+        /** @var User $admin */
+        $admin = $this->getUser();
+        $removed = $this->cleanup->runForAdministrator($admin);
+
+        return $this->json([
+            'message' => sprintf(
+                '%d expired invitation(s) and %d dead sharing code(s) removed.',
+                $removed['invitations'],
+                $removed['claimCodes']
+            ),
+            'invitationsRemoved' => $removed['invitations'],
+            'claimCodesRemoved' => $removed['claimCodes'],
+        ]);
+    }
+
+    /**
+     * A date filter from the query string, or null.
+     *
+     * Unparseable input is dropped rather than rejected: a filter the operator
+     * cannot see is not worth a 400, and showing the unfiltered table is the
+     * safer failure — it shows more than they asked for rather than silently
+     * less.
+     */
+    private function date(mixed $value, bool $endOfDay = false): ?\DateTimeImmutable
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            $date = new \DateTimeImmutable(trim($value));
+        } catch (\Exception) {
+            return null;
+        }
+
+        // A day given as a bare date means the whole of it, so "to 3 August"
+        // includes everything that happened on the 3rd.
+        return $endOfDay && !str_contains($value, ':') ? $date->setTime(23, 59, 59) : $date;
+    }
+}

--- a/backend/src/Controller/ShareClaimCodeController.php
+++ b/backend/src/Controller/ShareClaimCodeController.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Service\ShareClaimCodeService;
 use App\Service\ShareException;
 use App\Service\SharingCodeFormat;
+use App\Service\SharingWorkflowService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -61,6 +62,18 @@ final class ShareClaimCodeController extends AbstractController
         $rawComicIds = $data['comicIds'] ?? null;
         if (!is_array($rawComicIds) || $rawComicIds === []) {
             return $this->json(['message' => 'Select at least one comic to share.'], Response::HTTP_BAD_REQUEST);
+        }
+        // Refused on the raw count, before a single id is parsed or looked up,
+        // the same way the bulk invitation endpoint does it. Checking after the
+        // loop would mean a request carrying thousands of ids did thousands of
+        // lookups on its way to a 400.
+        if (count($rawComicIds) > SharingWorkflowService::MAX_BULK_COMICS) {
+            return $this->json([
+                'message' => sprintf(
+                    'A code can carry at most %d comics.',
+                    SharingWorkflowService::MAX_BULK_COMICS
+                ),
+            ], Response::HTTP_BAD_REQUEST);
         }
 
         $comicIds = [];

--- a/backend/src/Controller/ShareClaimCodeController.php
+++ b/backend/src/Controller/ShareClaimCodeController.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\ShareClaimCode;
+use App\Entity\User;
+use App\Service\ShareClaimCodeService;
+use App\Service\ShareException;
+use App\Service\SharingCodeFormat;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * Codes an owner hands out to give comics away without knowing an address.
+ *
+ * Every route here requires a signed-in account, including redemption. A code
+ * is an offer, not a key: it says who may be invited, and the invitation it
+ * produces is the ordinary kind, answered and revoked the ordinary way.
+ */
+#[Route('/api/shares/claim-codes')]
+final class ShareClaimCodeController extends AbstractController
+{
+    public function __construct(private readonly ShareClaimCodeService $claimCodes)
+    {
+    }
+
+    /** The codes this owner still has out, without the codes themselves. */
+    #[Route('', name: 'app_share_claim_codes_list', methods: ['GET'])]
+    public function list(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $this->json([
+            'codes' => array_map(
+                static fn (ShareClaimCode $code): array => $code->toOwnerPayload(),
+                $this->claimCodes->liveCodesFor($user)
+            ),
+            'maxUses' => ShareClaimCode::MAX_USES,
+            'minUses' => ShareClaimCode::MIN_USES,
+        ]);
+    }
+
+    #[Route('', name: 'app_share_claim_codes_create', methods: ['POST'])]
+    public function create(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['message' => 'Invalid request body.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $rawComicIds = $data['comicIds'] ?? null;
+        if (!is_array($rawComicIds) || $rawComicIds === []) {
+            return $this->json(['message' => 'Select at least one comic to share.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $comicIds = [];
+        foreach ($rawComicIds as $rawComicId) {
+            if (is_int($rawComicId)) {
+                $comicId = $rawComicId;
+            } elseif (is_string($rawComicId) && ctype_digit($rawComicId)) {
+                $comicId = (int) $rawComicId;
+            } else {
+                return $this->json(['message' => 'Comic ids must be positive integers.'], Response::HTTP_BAD_REQUEST);
+            }
+
+            if ($comicId <= 0) {
+                return $this->json(['message' => 'Comic ids must be positive integers.'], Response::HTTP_BAD_REQUEST);
+            }
+            $comicIds[] = $comicId;
+        }
+
+        $rawUses = $data['maxUses'] ?? null;
+        if (!is_int($rawUses) && !(is_string($rawUses) && ctype_digit($rawUses))) {
+            return $this->json(['message' => 'Choose how many times the code may be used.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            ['code' => $code, 'plaintext' => $plaintext] = $this->claimCodes->issue(
+                $comicIds,
+                $user,
+                (int) $rawUses,
+                // Strictly true, the same rule the emailed invitation applies:
+                // a missing key or a truthy string is not somebody having read
+                // the notice and ticked the box.
+                ($data['senderResponsibilityAccepted'] ?? null) === true
+            );
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json([
+            'message' => 'Sharing code created.',
+            // Returned once and never again — only the hash is stored, exactly
+            // as for an invitation link. An owner who loses it makes a new one.
+            'code' => SharingCodeFormat::forDisplay($plaintext),
+            'claimCode' => $code->toOwnerPayload(),
+        ], Response::HTTP_CREATED);
+    }
+
+    #[Route('/{id}', name: 'app_share_claim_codes_revoke', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    public function revoke(int $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            $this->claimCodes->revoke($id, $user);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json(['message' => 'Sharing code withdrawn.']);
+    }
+
+    /**
+     * Claim the comics behind a code.
+     *
+     * Authenticated, because a code grants nothing on its own and the shares it
+     * creates have to belong to somebody.
+     */
+    #[Route('/redeem', name: 'app_share_claim_codes_redeem', methods: ['POST'], priority: 1)]
+    public function redeem(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $code = is_array($data) ? ($data['code'] ?? null) : null;
+
+        if (!is_string($code)) {
+            return $this->json(['message' => 'A sharing code is required.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $result = $this->claimCodes->redeem($code, $user);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json($result);
+    }
+}

--- a/backend/src/Controller/ShareClaimCodeController.php
+++ b/backend/src/Controller/ShareClaimCodeController.php
@@ -29,7 +29,13 @@ final class ShareClaimCodeController extends AbstractController
     {
     }
 
-    /** The codes this owner still has out, without the codes themselves. */
+    /**
+     * The codes this owner has handed out, without the codes themselves.
+     *
+     * Dead ones stay in the list until the cleanup removes them a month after
+     * they expire, because "how many people took that one up?" is a question
+     * the owner asks after a code has stopped working, not while it still does.
+     */
     #[Route('', name: 'app_share_claim_codes_list', methods: ['GET'])]
     public function list(#[CurrentUser] ?User $user): JsonResponse
     {
@@ -40,7 +46,7 @@ final class ShareClaimCodeController extends AbstractController
         return $this->json([
             'codes' => array_map(
                 static fn (ShareClaimCode $code): array => $code->toOwnerPayload(),
-                $this->claimCodes->liveCodesFor($user)
+                $this->claimCodes->codesFor($user)
             ),
             'maxUses' => ShareClaimCode::MAX_USES,
             'minUses' => ShareClaimCode::MIN_USES,

--- a/backend/src/Controller/SharingWorkflowController.php
+++ b/backend/src/Controller/SharingWorkflowController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\ComicShare;
 use App\Entity\User;
+use App\Service\ShareException;
 use App\Service\SharingWorkflowService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -87,12 +88,20 @@ final class SharingWorkflowController extends AbstractController
             $comicIds[] = $comicId;
         }
 
-        $result = $this->workflow->inviteMany(
-            $comicIds,
-            $user,
-            $email,
-            true
-        );
+        try {
+            $result = $this->workflow->inviteMany(
+                $comicIds,
+                $user,
+                $email,
+                true
+            );
+        } catch (ShareException $exception) {
+            // The whole batch was refused before anything was created — an
+            // exhausted invitation allowance, or a recipient the sender may not
+            // invite. Reported as one failure with its real status rather than
+            // as a per-comic result, because nothing was attempted.
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
 
         $status = $result['created'] === $result['total']
             ? Response::HTTP_CREATED

--- a/backend/src/Controller/SharingWorkflowController.php
+++ b/backend/src/Controller/SharingWorkflowController.php
@@ -5,6 +5,8 @@ namespace App\Controller;
 use App\Entity\ComicShare;
 use App\Entity\User;
 use App\Service\ShareException;
+use App\Service\SharingCodeRecipient;
+use App\Service\SharingCodeService;
 use App\Service\SharingWorkflowService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -16,8 +18,10 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 #[Route('/api/shares')]
 final class SharingWorkflowController extends AbstractController
 {
-    public function __construct(private readonly SharingWorkflowService $workflow)
-    {
+    public function __construct(
+        private readonly SharingWorkflowService $workflow,
+        private readonly SharingCodeService $sharingCodes,
+    ) {
     }
 
     #[Route('/recent-recipients', name: 'app_shares_recent_recipients', methods: ['GET'])]
@@ -30,6 +34,70 @@ final class SharingWorkflowController extends AbstractController
         return $this->json([
             'recipients' => $this->workflow->recentRecipients($user),
         ]);
+    }
+
+    /**
+     * This account's own receiver code, issued on first use.
+     *
+     * Reads back the same value for ever after. There is no companion endpoint
+     * that changes it: everybody who was ever given it is holding the old one,
+     * and an address book entry that rotates is one that stops working in every
+     * conversation it was pasted into.
+     */
+    #[Route('/my-code', name: 'app_shares_my_code', methods: ['GET'])]
+    public function myCode(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            $this->sharingCodes->codeFor($user);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json($this->sharingCodes->describe($user));
+    }
+
+    /**
+     * Who a receiver code belongs to, so a sender can check they have the right
+     * person before handing anything over.
+     *
+     * A POST because it is rate limited and writes to that allowance, and
+     * because a code does not belong in a URL that ends up in logs and history.
+     * It answers with a display name and nothing else — never an address, an id,
+     * or whether the account exists when the code does not resolve.
+     */
+    #[Route('/resolve-code', name: 'app_shares_resolve_code', methods: ['POST'])]
+    public function resolveCode(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $code = is_array($data) ? ($data['sharingCode'] ?? null) : null;
+
+        if (!is_string($code)) {
+            return $this->json(['message' => 'A sharing code is required.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $recipient = $this->sharingCodes->resolve($code, $user);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        if ($recipient === null) {
+            return $this->json(['message' => 'That sharing code is not valid.'], Response::HTTP_NOT_FOUND);
+        }
+
+        if ($recipient->getId() === $user->getId()) {
+            return $this->json(['message' => 'That is your own sharing code.'], Response::HTTP_CONFLICT);
+        }
+
+        return $this->json(['recipient' => $this->sharingCodes->describe($recipient)]);
     }
 
     #[Route('/invitations/bulk', name: 'app_shares_bulk_invite', methods: ['POST'])]
@@ -50,13 +118,39 @@ final class SharingWorkflowController extends AbstractController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        $email = $data['email'] ?? null;
-        if (!is_string($email)) {
-            return $this->json(['message' => 'A recipient email address is required.'], Response::HTTP_BAD_REQUEST);
-        }
-        $email = ComicShare::normaliseEmail($email);
-        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            return $this->json(['message' => 'A valid recipient email address is required.'], Response::HTTP_BAD_REQUEST);
+        // Two ways to name a recipient, and exactly one of them per request. A
+        // sharing code resolves to an address the sender is never shown; an
+        // email is the address they typed themselves.
+        $rawSharingCode = $data['sharingCode'] ?? null;
+        $viaSharingCode = null;
+
+        if (is_string($rawSharingCode) && trim($rawSharingCode) !== '') {
+            try {
+                $recipient = $this->sharingCodes->resolve($rawSharingCode, $user);
+            } catch (ShareException $exception) {
+                return $this->json($exception->toPayload(), $exception->getStatusCode());
+            }
+
+            if ($recipient === null) {
+                return $this->json([
+                    'message' => 'That sharing code is not valid.',
+                ], Response::HTTP_NOT_FOUND);
+            }
+
+            $email = ComicShare::normaliseEmail((string) $recipient->getEmail());
+            $viaSharingCode = new SharingCodeRecipient(
+                (string) $recipient->getSharingCode(),
+                $recipient->getName()
+            );
+        } else {
+            $email = $data['email'] ?? null;
+            if (!is_string($email)) {
+                return $this->json(['message' => 'A recipient email address is required.'], Response::HTTP_BAD_REQUEST);
+            }
+            $email = ComicShare::normaliseEmail($email);
+            if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                return $this->json(['message' => 'A valid recipient email address is required.'], Response::HTTP_BAD_REQUEST);
+            }
         }
 
         $rawComicIds = $data['comicIds'] ?? null;
@@ -93,7 +187,8 @@ final class SharingWorkflowController extends AbstractController
                 $comicIds,
                 $user,
                 $email,
-                true
+                true,
+                $viaSharingCode
             );
         } catch (ShareException $exception) {
             // The whole batch was refused before anything was created — an

--- a/backend/src/Controller/SharingWorkflowController.php
+++ b/backend/src/Controller/SharingWorkflowController.php
@@ -61,6 +61,33 @@ final class SharingWorkflowController extends AbstractController
     }
 
     /**
+     * Retire this account's code and take a new one.
+     *
+     * A receiver code lives in chats, forums and group threads, so it is
+     * exactly the kind of thing that escapes further than intended. This is the
+     * way back from that. It changes nothing but the identifier: every share
+     * already made through the old code is a relationship, not an address, and
+     * survives untouched.
+     */
+    #[Route('/my-code/rotate', name: 'app_shares_rotate_my_code', methods: ['POST'])]
+    public function rotateMyCode(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            $this->sharingCodes->rotateCode($user);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        return $this->json([
+            'message' => 'Your sharing code has been replaced. The old one no longer works.',
+        ] + $this->sharingCodes->describe($user));
+    }
+
+    /**
      * Who a receiver code belongs to, so a sender can check they have the right
      * person before handing anything over.
      *
@@ -139,6 +166,7 @@ final class SharingWorkflowController extends AbstractController
 
             $email = ComicShare::normaliseEmail((string) $recipient->getEmail());
             $viaSharingCode = new SharingCodeRecipient(
+                $recipient,
                 (string) $recipient->getSharingCode(),
                 $recipient->getName()
             );

--- a/backend/src/Controller/SharingWorkflowController.php
+++ b/backend/src/Controller/SharingWorkflowController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\ComicShare;
+use App\Entity\User;
+use App\Service\SharingWorkflowService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+#[Route('/api/shares')]
+final class SharingWorkflowController extends AbstractController
+{
+    public function __construct(private readonly SharingWorkflowService $workflow)
+    {
+    }
+
+    #[Route('/recent-recipients', name: 'app_shares_recent_recipients', methods: ['GET'])]
+    public function recentRecipients(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $this->json([
+            'recipients' => $this->workflow->recentRecipients($user),
+        ]);
+    }
+
+    #[Route('/invitations/bulk', name: 'app_shares_bulk_invite', methods: ['POST'])]
+    public function bulkInvite(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['message' => 'Invalid request body.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if (($data['senderResponsibilityAccepted'] ?? null) !== true) {
+            return $this->json([
+                'message' => 'You must acknowledge responsibility for the content you share.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $email = $data['email'] ?? null;
+        if (!is_string($email)) {
+            return $this->json(['message' => 'A recipient email address is required.'], Response::HTTP_BAD_REQUEST);
+        }
+        $email = ComicShare::normaliseEmail($email);
+        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            return $this->json(['message' => 'A valid recipient email address is required.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $rawComicIds = $data['comicIds'] ?? null;
+        if (!is_array($rawComicIds) || $rawComicIds === []) {
+            return $this->json(['message' => 'Select at least one comic to share.'], Response::HTTP_BAD_REQUEST);
+        }
+        if (count($rawComicIds) > SharingWorkflowService::MAX_BULK_COMICS) {
+            return $this->json([
+                'message' => sprintf(
+                    'You can share at most %d comics in one action.',
+                    SharingWorkflowService::MAX_BULK_COMICS
+                ),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $comicIds = [];
+        foreach ($rawComicIds as $rawComicId) {
+            if (is_int($rawComicId)) {
+                $comicId = $rawComicId;
+            } elseif (is_string($rawComicId) && ctype_digit($rawComicId)) {
+                $comicId = (int) $rawComicId;
+            } else {
+                return $this->json(['message' => 'Comic ids must be positive integers.'], Response::HTTP_BAD_REQUEST);
+            }
+
+            if ($comicId <= 0) {
+                return $this->json(['message' => 'Comic ids must be positive integers.'], Response::HTTP_BAD_REQUEST);
+            }
+            $comicIds[] = $comicId;
+        }
+
+        $result = $this->workflow->inviteMany(
+            $comicIds,
+            $user,
+            $email,
+            true
+        );
+
+        $status = $result['created'] === $result['total']
+            ? Response::HTTP_CREATED
+            : Response::HTTP_MULTI_STATUS;
+
+        return $this->json($result, $status);
+    }
+}

--- a/backend/src/Controller/UserController.php
+++ b/backend/src/Controller/UserController.php
@@ -9,6 +9,8 @@ use App\Service\AdminAuditService;
 use App\Service\PasswordValidator;
 use App\Service\Pagination\PaginationRequest;
 use App\Service\SecurityAuditLogger;
+use App\Service\ShareException;
+use App\Service\SharingCodeService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -448,6 +450,53 @@ class UserController extends AbstractController
         }
 
         return $this->json(['message' => 'User deleted successfully']);
+    }
+
+    /**
+     * Replace a user's receiver sharing code on their behalf.
+     *
+     * Support's version of the button the user has on their own Sharing page,
+     * for when they report that the code has been posted somewhere they cannot
+     * take it back from. Nothing about the account changes but the identifier,
+     * and the shares made through the old code are untouched.
+     *
+     * The new code is deliberately not returned. An administrator has no reason
+     * to hold somebody's contact handle, and the user can read it off their own
+     * Sharing page the moment they look — which is also the only place it can
+     * reach them without passing through a support channel on the way.
+     */
+    #[Route('/{id}/sharing-code/rotate', name: 'rotate_sharing_code', methods: ['POST'])]
+    public function rotateSharingCode(
+        int $id,
+        EntityManagerInterface $entityManager,
+        AdminAuditService $auditService,
+        SharingCodeService $sharingCodes
+    ): JsonResponse {
+        $admin = $this->getUser();
+        if (!$admin instanceof User || !in_array('ROLE_ADMIN', $admin->getRoles(), true)) {
+            return $this->json(['message' => 'Access denied'], Response::HTTP_FORBIDDEN);
+        }
+
+        $targetUser = $entityManager->getRepository(User::class)->find($id);
+        if (!$targetUser) {
+            return $this->json(['message' => 'User not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        try {
+            // The service owns generation, uniqueness and the security record,
+            // so this path and the user's own cannot drift apart.
+            $sharingCodes->rotateCode($targetUser, $admin);
+        } catch (ShareException $exception) {
+            return $this->json($exception->toPayload(), $exception->getStatusCode());
+        }
+
+        // Ids only in the administrative trail as well — neither the old code
+        // nor the new one is written down anywhere.
+        $auditService->log($admin, 'user_sharing_code_rotate', 'user', $targetUser->getId());
+
+        return $this->json([
+            'message' => 'Sharing code replaced. The user can see the new one on their Sharing page.',
+        ]);
     }
 
     #[Route('/{id}/verify', name: 'verify', methods: ['POST'])]

--- a/backend/src/Entity/ComicShare.php
+++ b/backend/src/Entity/ComicShare.php
@@ -231,6 +231,21 @@ class ComicShare
         return $this;
     }
 
+    /**
+     * Stop hiding the address, because the owner supplied it themselves.
+     *
+     * Re-inviting reuses the row, so a relationship that began with a receiver
+     * code can be reopened by somebody typing the address — at which point
+     * withholding it would be withholding something they already have.
+     */
+    public function revealRecipientAddressToOwner(): self
+    {
+        $this->recipientSharingCode = null;
+        $this->recipientAliasName = null;
+
+        return $this;
+    }
+
     /** Whether the owner may be shown this recipient's address. */
     public function isRecipientAddressHiddenFromOwner(): bool
     {

--- a/backend/src/Entity/ComicShare.php
+++ b/backend/src/Entity/ComicShare.php
@@ -232,6 +232,25 @@ class ComicShare
     }
 
     /**
+     * Attach the account this share is for, before they have answered.
+     *
+     * Normally the link is made on acceptance, because an invitation may be
+     * addressed to somebody who has no account yet. A share made through a
+     * receiver code is the exception: the code *is* an account, so the
+     * relationship knows who it is for from the start.
+     *
+     * That link is what survives a rotation. `recipientSharingCode` records how
+     * this relationship began and goes stale the moment the recipient replaces
+     * their code; anything that needs their current handle asks the account.
+     */
+    public function linkRecipientUser(User $recipient): self
+    {
+        $this->recipientUser = $recipient;
+
+        return $this;
+    }
+
+    /**
      * Stop hiding the address, because the owner supplied it themselves.
      *
      * Re-inviting reuses the row, so a relationship that began with a receiver
@@ -381,6 +400,28 @@ class ComicShare
     public function acceptSenderResponsibility(): self
     {
         $this->senderResponsibilityAcceptedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    /**
+     * Carry an acknowledgement the owner already made onto this share.
+     *
+     * A share created by redeeming a claim code is not a moment the owner was
+     * present for: they acknowledged responsibility when they created the code,
+     * possibly hours earlier. Stamping "now" would put a timestamp in the
+     * canonical audit field for an act the audited party did not perform then —
+     * and an audit trail that records the wrong moment is worse than one that
+     * records nothing.
+     *
+     * Takes the timestamp rather than generating one, and is deliberately
+     * separate from {@see acceptSenderResponsibility()} so nothing can pass a
+     * request-supplied value in by accident: the only caller hands it the
+     * server-generated timestamp already stored on the claim code.
+     */
+    public function inheritSenderResponsibility(\DateTimeImmutable $acknowledgedAt): self
+    {
+        $this->senderResponsibilityAcceptedAt = $acknowledgedAt;
 
         return $this;
     }

--- a/backend/src/Entity/ComicShare.php
+++ b/backend/src/Entity/ComicShare.php
@@ -112,6 +112,25 @@ class ComicShare
     private string $ownerNameSnapshot = '';
 
     /**
+     * Set when the sender reached this recipient through their receiver code
+     * rather than by typing their address.
+     *
+     * The point of a receiver code is that the sender never learns the address,
+     * so the address they never learned must not be handed back to them by the
+     * page that lists what they shared. These two carry what the owner is shown
+     * instead: the recipient's name as it was, and the code they can use to
+     * offer them something else.
+     *
+     * Both null for an ordinary email invitation, where the sender typed the
+     * address themselves and there is nothing to withhold.
+     */
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $recipientAliasName = null;
+
+    #[ORM\Column(length: 16, nullable: true)]
+    private ?string $recipientSharingCode = null;
+
+    /**
      * Whether the comic was marked explicit when the snapshots were last taken.
      *
      * Kept alongside the title snapshot because a tombstone outlives the comic
@@ -196,6 +215,36 @@ class ComicShare
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    /**
+     * Record that this relationship was made through a receiver code.
+     *
+     * Called with the recipient's own name and code, both of which they published
+     * by handing the code out. Nothing else about them crosses over.
+     */
+    public function hideRecipientBehindSharingCode(string $sharingCode, ?string $recipientName): self
+    {
+        $this->recipientSharingCode = $sharingCode;
+        $this->recipientAliasName = $recipientName;
+
+        return $this;
+    }
+
+    /** Whether the owner may be shown this recipient's address. */
+    public function isRecipientAddressHiddenFromOwner(): bool
+    {
+        return $this->recipientSharingCode !== null;
+    }
+
+    public function getRecipientAliasName(): ?string
+    {
+        return $this->recipientAliasName;
+    }
+
+    public function getRecipientSharingCode(): ?string
+    {
+        return $this->recipientSharingCode;
     }
 
     public function getComic(): ?Comic

--- a/backend/src/Entity/ShareClaimCode.php
+++ b/backend/src/Entity/ShareClaimCode.php
@@ -38,6 +38,18 @@ class ShareClaimCode
     /** How long an unredeemed code stays live. */
     public const TTL = '+1 day';
 
+    /**
+     * How long a dead code is kept before it is deleted.
+     *
+     * Measured from expiry, and it applies to a withdrawn code as much as to
+     * one that simply ran out. The row is worthless as a code the moment it
+     * dies — it cannot be redeemed again — but it is not worthless to its
+     * owner, who is still looking at how many people took it up and which
+     * comics went with it. A month is long enough to answer that; keeping them
+     * for ever would just be a table that only grows.
+     */
+    public const RETENTION_AFTER_EXPIRY = '+30 days';
+
     public const MIN_USES = 1;
     public const MAX_USES = 10;
 
@@ -204,11 +216,48 @@ class ShareClaimCode
         return $this;
     }
 
+    /**
+     * Withdraw the code before it would have died on its own.
+     *
+     * Idempotent, so withdrawing twice keeps the moment it actually happened.
+     * The shares it already produced are untouched: those are ordinary
+     * relationships now, revoked from the Sharing page like any other.
+     */
     public function revoke(): self
     {
         $this->revokedAt ??= new \DateTimeImmutable();
 
         return $this;
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revokedAt !== null;
+    }
+
+    /** Why this code can no longer be used, for the owner's list. */
+    public function deadReason(): ?string
+    {
+        if ($this->revokedAt !== null) {
+            return 'withdrawn';
+        }
+        if ($this->isExpired()) {
+            return 'expired';
+        }
+        if ($this->usesRemaining <= 0) {
+            return 'used_up';
+        }
+        if ($this->comics->isEmpty()) {
+            return 'comics_removed';
+        }
+
+        return null;
+    }
+
+    /** When this row becomes rubbish worth deleting. */
+    public function deletableAfter(): \DateTimeImmutable
+    {
+        return $this->expiresAt->modify(self::RETENTION_AFTER_EXPIRY);
     }
 
     /**
@@ -235,10 +284,16 @@ class ShareClaimCode
             'comicCount' => count($titles),
             'maxUses' => $this->maxUses,
             'usesRemaining' => $this->usesRemaining,
+            // How many people took it up, which is the question the owner is
+            // actually asking when they look at this list.
+            'timesUsed' => $this->maxUses - $this->usesRemaining,
             'createdAt' => $this->createdAt->format('c'),
             'expiresAt' => $this->expiresAt->format('c'),
             'isExpired' => $this->isExpired(),
+            'isRevoked' => $this->isRevoked(),
             'isRedeemable' => $this->isRedeemable(),
+            'deadReason' => $this->deadReason(),
+            'deletableAfter' => $this->deletableAfter()->format('c'),
         ];
     }
 

--- a/backend/src/Entity/ShareClaimCode.php
+++ b/backend/src/Entity/ShareClaimCode.php
@@ -297,6 +297,41 @@ class ShareClaimCode
         ];
     }
 
+    /**
+     * What an administrator is shown about a code somebody else issued.
+     *
+     * The owner's payload plus the operational metadata support needs to act on
+     * a report: whose code it is, and which comics are behind it named rather
+     * than redacted. The 18+ redaction the owner's view applies is for the
+     * *recipient's* benefit and has no meaning here — an administrator handling
+     * an abuse report is precisely the person who needs to know what was being
+     * handed out.
+     *
+     * Still never the code. Only its hash is stored, so there is nothing to
+     * show and nothing to recover.
+     *
+     * @return array<string, mixed>
+     */
+    public function toAdminPayload(): array
+    {
+        $comics = [];
+        foreach ($this->comics as $comic) {
+            $comics[] = [
+                'id' => $comic->getId(),
+                'title' => $comic->getTitle(),
+                'explicitContent' => $comic->isExplicitContent(),
+            ];
+        }
+
+        return $this->toOwnerPayload() + [
+            'ownerId' => $this->owner?->getId(),
+            'ownerName' => $this->owner?->getName(),
+            'ownerEmail' => $this->owner?->getEmail(),
+            'comics' => $comics,
+            'revokedAt' => $this->revokedAt?->format('c'),
+        ];
+    }
+
     /** The grouped form of a plaintext code, for the one response that shows it. */
     public static function forDisplay(string $plaintext): string
     {

--- a/backend/src/Entity/ShareClaimCode.php
+++ b/backend/src/Entity/ShareClaimCode.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ShareClaimCodeRepository;
+use App\Service\SharingCodeFormat;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * An offer of some comics to whoever the owner hands the code to.
+ *
+ * The counterpart to a receiver code, and the opposite direction: a receiver
+ * code says "this is me, share with me", while this says "these are mine, come
+ * and get them". It exists for the case where the owner does not know, and
+ * should not have to ask for, the other person's address.
+ *
+ * It is a capability, so it is treated like one:
+ *
+ * - **Only the hash is stored.** The plaintext exists once, in the message the
+ *   owner sends, exactly like an invitation link
+ * - **It expires in a day.** A code pasted into a group chat is out of its
+ *   owner's hands the moment it is sent; a short life is what stops it from
+ *   still working weeks later
+ * - **It is spent as it is used**, at most ten times and as few as one, so the
+ *   owner decides up front how far it may travel
+ * - **It grants nothing by itself.** Redeeming requires being signed in, and
+ *   creates the same ordinary {@see ComicShare} an emailed invitation would.
+ *   Every rule that follows — the 18+ gate, revocation, tombstones — is
+ *   untouched by how the relationship started
+ */
+#[ORM\Entity(repositoryClass: ShareClaimCodeRepository::class)]
+#[ORM\Table(name: 'share_claim_code')]
+class ShareClaimCode
+{
+    /** How long an unredeemed code stays live. */
+    public const TTL = '+1 day';
+
+    public const MIN_USES = 1;
+    public const MAX_USES = 10;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $owner = null;
+
+    /** SHA-256 of the normalised plaintext. Unique, so a collision cannot hide. */
+    #[ORM\Column(length: 64, unique: true)]
+    private string $codeHash;
+
+    /**
+     * The comics on offer.
+     *
+     * Both sides of the join cascade, and only the join rows do. Deleting a
+     * comic takes it off every code that offered it without destroying a code
+     * that still carries others, and a code with nothing left on it stops being
+     * redeemable on its own — so there is no second piece of state to keep in
+     * step with a deletion, and nothing a stale code can hand out.
+     */
+    #[ORM\ManyToMany(targetEntity: Comic::class)]
+    #[ORM\JoinTable(name: 'share_claim_code_comic')]
+    #[ORM\JoinColumn(onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(onDelete: 'CASCADE')]
+    private Collection $comics;
+
+    #[ORM\Column]
+    private int $maxUses;
+
+    #[ORM\Column]
+    private int $usesRemaining;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $revokedAt = null;
+
+    /**
+     * The same acknowledgement an emailed invitation records, taken when the
+     * code is created because that is when the owner decides to hand the comics
+     * out. Redemption cannot ask for it: the person redeeming is not the sender.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $senderResponsibilityAcceptedAt;
+
+    /**
+     * @param list<Comic> $comics
+     */
+    public function __construct(User $owner, string $codeHash, array $comics, int $maxUses, \DateTimeImmutable $expiresAt)
+    {
+        $this->owner = $owner;
+        $this->codeHash = $codeHash;
+        $this->comics = new ArrayCollection($comics);
+        $this->maxUses = $maxUses;
+        $this->usesRemaining = $maxUses;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->expiresAt = $expiresAt;
+        $this->senderResponsibilityAcceptedAt = $this->createdAt;
+    }
+
+    public static function expiry(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable())->modify(self::TTL);
+    }
+
+    /** Whether a count of uses is one this entity will accept. */
+    public static function isUsableCount(int $maxUses): bool
+    {
+        return $maxUses >= self::MIN_USES && $maxUses <= self::MAX_USES;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function getCodeHash(): string
+    {
+        return $this->codeHash;
+    }
+
+    /** @return Collection<int, Comic> */
+    public function getComics(): Collection
+    {
+        return $this->comics;
+    }
+
+    public function removeComic(Comic $comic): self
+    {
+        $this->comics->removeElement($comic);
+
+        return $this;
+    }
+
+    public function getMaxUses(): int
+    {
+        return $this->maxUses;
+    }
+
+    public function getUsesRemaining(): int
+    {
+        return $this->usesRemaining;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getExpiresAt(): \DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getRevokedAt(): ?\DateTimeImmutable
+    {
+        return $this->revokedAt;
+    }
+
+    public function getSenderResponsibilityAcceptedAt(): \DateTimeImmutable
+    {
+        return $this->senderResponsibilityAcceptedAt;
+    }
+
+    public function isExpired(?\DateTimeImmutable $now = null): bool
+    {
+        return $this->expiresAt <= ($now ?? new \DateTimeImmutable());
+    }
+
+    /**
+     * Every reason a code may be redeemed, in one place.
+     *
+     * A code with no comics left on it is spent as surely as one with no uses
+     * left: every comic it offered has since been deleted, and redeeming it
+     * would create nothing.
+     */
+    public function isRedeemable(?\DateTimeImmutable $now = null): bool
+    {
+        return $this->revokedAt === null
+            && $this->usesRemaining > 0
+            && !$this->comics->isEmpty()
+            && !$this->isExpired($now);
+    }
+
+    /** Spend one use. Callers check {@see isRedeemable()} first. */
+    public function spendUse(): self
+    {
+        $this->usesRemaining = max(0, $this->usesRemaining - 1);
+
+        return $this;
+    }
+
+    public function revoke(): self
+    {
+        $this->revokedAt ??= new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    /**
+     * What the owner is shown about a code they can no longer read.
+     *
+     * Never the code itself — that is gone the moment the response carrying it
+     * is closed — only enough to recognise which offer this is and to withdraw
+     * it.
+     *
+     * @return array<string, mixed>
+     */
+    public function toOwnerPayload(): array
+    {
+        $titles = [];
+        foreach ($this->comics as $comic) {
+            $titles[] = $comic->isExplicitContent()
+                ? 'A comic marked as explicit content (18+)'
+                : (string) $comic->getTitle();
+        }
+
+        return [
+            'id' => $this->id,
+            'comicTitles' => $titles,
+            'comicCount' => count($titles),
+            'maxUses' => $this->maxUses,
+            'usesRemaining' => $this->usesRemaining,
+            'createdAt' => $this->createdAt->format('c'),
+            'expiresAt' => $this->expiresAt->format('c'),
+            'isExpired' => $this->isExpired(),
+            'isRedeemable' => $this->isRedeemable(),
+        ];
+    }
+
+    /** The grouped form of a plaintext code, for the one response that shows it. */
+    public static function forDisplay(string $plaintext): string
+    {
+        return SharingCodeFormat::forDisplay($plaintext);
+    }
+}

--- a/backend/src/Entity/ShareClaimCodeRedemption.php
+++ b/backend/src/Entity/ShareClaimCodeRedemption.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ShareClaimCodeRedemptionRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * One account's claim on one code.
+ *
+ * A counter alone cannot say what "ten uses" means. Decrementing on every
+ * request lets one recipient submit the same code ten times and exhaust an
+ * offer advertised to ten people — and leaves the owner's "claimed 10 of 10"
+ * counting requests rather than people. This row is the difference: a use is
+ * spent by an account that did not have one, and never twice by the same one.
+ *
+ * The unique index is what makes that hold under concurrency. Two simultaneous
+ * redemptions by the same account cannot both insert, so the second is turned
+ * into the idempotent answer rather than a second decrement.
+ *
+ * Deliberately not exposed to the owner. They are told how many people took the
+ * offer up, which is what they asked; who those people are is between them and
+ * the recipients, and the recipient never agreed to be listed.
+ */
+#[ORM\Entity(repositoryClass: ShareClaimCodeRedemptionRepository::class)]
+#[ORM\Table(name: 'share_claim_code_redemption')]
+#[ORM\UniqueConstraint(name: 'uniq_claim_code_recipient', columns: ['claim_code_id', 'recipient_id'])]
+class ShareClaimCodeRedemption
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: ShareClaimCode::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?ShareClaimCode $claimCode = null;
+
+    /**
+     * Cascades with the account. A deleted user takes their redemption record
+     * with them, and the use it spent is not handed back — the offer was made
+     * and taken, and re-opening it later would surprise the owner.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $recipient = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $redeemedAt;
+
+    public function __construct(ShareClaimCode $claimCode, User $recipient)
+    {
+        $this->claimCode = $claimCode;
+        $this->recipient = $recipient;
+        $this->redeemedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getClaimCode(): ?ShareClaimCode
+    {
+        return $this->claimCode;
+    }
+
+    public function getRecipient(): ?User
+    {
+        return $this->recipient;
+    }
+
+    public function getRedeemedAt(): \DateTimeImmutable
+    {
+        return $this->redeemedAt;
+    }
+}

--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -41,6 +41,29 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $name = null;
 
     /**
+     * The permanent address other people share with this account by.
+     *
+     * Not a credential and not a secret: it authenticates nobody, exposes
+     * nothing about the account beyond the display name somebody who already
+     * holds it is shown, and grants no access on its own. That is why it is
+     * stored in the clear where an invitation token is stored hashed — its
+     * owner has to be able to read it back and hand it out again.
+     *
+     * It never changes, and nothing in the application offers to change it. An
+     * address book entry that rotates is an address book entry that stops
+     * working in every conversation it was ever pasted into. What it costs is
+     * that a leaked code cannot be retired, so it is deliberately incapable of
+     * doing anything worse than letting a stranger offer you a comic you can
+     * decline.
+     *
+     * Nullable only so accounts that predate the column can be filled in on
+     * first use rather than in a migration that would have to invent one for
+     * every row at once.
+     */
+    #[ORM\Column(length: 16, unique: true, nullable: true)]
+    private ?string $sharingCode = null;
+
+    /**
      * @var list<string> The user roles
      */
     #[ORM\Column]
@@ -197,6 +220,27 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->name;
     }
     
+    public function getSharingCode(): ?string
+    {
+        return $this->sharingCode;
+    }
+
+    /**
+     * Set once, by {@see \App\Service\SharingCodeService}, and never again.
+     *
+     * There is no path that rewrites an existing code — not an admin screen,
+     * not a profile edit — because everybody who was ever given it is holding
+     * the old one.
+     */
+    public function assignSharingCode(string $sharingCode): static
+    {
+        if ($this->sharingCode === null) {
+            $this->sharingCode = $sharingCode;
+        }
+
+        return $this;
+    }
+
     public function setName(?string $name): static
     {
         $this->name = $name;

--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -41,7 +41,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $name = null;
 
     /**
-     * The permanent address other people share with this account by.
+     * The address other people share with this account by.
      *
      * Not a credential and not a secret: it authenticates nobody, exposes
      * nothing about the account beyond the display name somebody who already
@@ -49,12 +49,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * stored in the clear where an invitation token is stored hashed — its
      * owner has to be able to read it back and hand it out again.
      *
-     * It never changes, and nothing in the application offers to change it. An
-     * address book entry that rotates is an address book entry that stops
-     * working in every conversation it was ever pasted into. What it costs is
-     * that a leaked code cannot be retired, so it is deliberately incapable of
-     * doing anything worse than letting a stranger offer you a comic you can
-     * decline.
+     * Stable, but not permanent. It is meant to be pasted into chats, forums
+     * and group threads, which is exactly the kind of place a thing escapes
+     * from — and an identifier its owner cannot retire after that is one they
+     * are stuck with. Rotation is theirs to trigger, and an administrator's on
+     * their behalf; nothing rotates it on its own, because everybody who was
+     * given the old one has to be told the new one.
      *
      * Nullable only so accounts that predate the column can be filled in on
      * first use rather than in a migration that would have to invent one for
@@ -226,17 +226,35 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * Set once, by {@see \App\Service\SharingCodeService}, and never again.
+     * Give this account its first code, if it has none.
      *
-     * There is no path that rewrites an existing code — not an admin screen,
-     * not a profile edit — because everybody who was ever given it is holding
-     * the old one.
+     * Deliberately refuses to overwrite: issuing and rotating are different
+     * acts, and only one of them is allowed to retire an identifier other
+     * people are holding.
      */
     public function assignSharingCode(string $sharingCode): static
     {
         if ($this->sharingCode === null) {
             $this->sharingCode = $sharingCode;
         }
+
+        return $this;
+    }
+
+    /**
+     * Retire the current code and take a new one.
+     *
+     * The only path that replaces an existing code, and it exists so a code
+     * that has escaped further than its owner intended can be taken out of
+     * circulation. Nothing else about the account changes — least of all the
+     * shares already made through the old code, which are relationships and
+     * not addresses.
+     *
+     * @see \App\Service\SharingCodeService::rotateCode()
+     */
+    public function replaceSharingCode(string $sharingCode): static
+    {
+        $this->sharingCode = $sharingCode;
 
         return $this;
     }

--- a/backend/src/Repository/ShareClaimCodeRedemptionRepository.php
+++ b/backend/src/Repository/ShareClaimCodeRedemptionRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ShareClaimCode;
+use App\Entity\ShareClaimCodeRedemption;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ShareClaimCodeRedemption>
+ */
+class ShareClaimCodeRedemptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ShareClaimCodeRedemption::class);
+    }
+
+    public function findFor(ShareClaimCode $claimCode, User $recipient): ?ShareClaimCodeRedemption
+    {
+        return $this->findOneBy(['claimCode' => $claimCode, 'recipient' => $recipient]);
+    }
+
+    /**
+     * How many distinct accounts have taken this offer up.
+     *
+     * The honest answer to the question the owner is asking, as opposed to the
+     * counter, which only knows how many uses have been spent.
+     */
+    public function countFor(ShareClaimCode $claimCode): int
+    {
+        return (int) $this->createQueryBuilder('r')
+            ->select('COUNT(r.id)')
+            ->andWhere('r.claimCode = :code')
+            ->setParameter('code', $claimCode)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/backend/src/Repository/ShareClaimCodeRepository.php
+++ b/backend/src/Repository/ShareClaimCodeRepository.php
@@ -38,20 +38,44 @@ class ShareClaimCodeRepository extends ServiceEntityRepository
     }
 
     /**
-     * The codes an owner still has out, newest first.
+     * The codes an owner has handed out, newest first.
      *
-     * Expired and spent ones are included: the owner asked what they handed
-     * out, and a code that has run out is part of that answer.
+     * Expired, spent and withdrawn ones are all included, right up until the
+     * cleanup deletes them. The owner is asking what they gave away and how
+     * many people took it up, and a code that has stopped working is part of
+     * that answer — which is the whole reason dead codes are kept for a month
+     * rather than dropped the moment they die.
      *
      * @return list<ShareClaimCode>
      */
-    public function findLiveForOwner(User $owner, int $limit = 20): array
+    public function findForOwner(User $owner, int $limit = 30): array
     {
         return $this->createQueryBuilder('c')
             ->andWhere('c.owner = :owner')
-            ->andWhere('c.revokedAt IS NULL')
             ->setParameter('owner', $owner)
             ->orderBy('c.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Codes whose retention window has passed, oldest first.
+     *
+     * Batched, so a cron job that has not run for a long time cannot hydrate
+     * every dead code and its join rows into one unit of work.
+     *
+     * @return list<ShareClaimCode>
+     */
+    public function findDeletable(\DateTimeImmutable $now, int $limit): array
+    {
+        return $this->createQueryBuilder('c')
+            // The window is measured from expiry for every dead code, withdrawn
+            // or not: a code withdrawn on its first day still has an expiry, and
+            // dating the sweep from one column keeps the rule easy to state.
+            ->andWhere('c.expiresAt < :cutoff')
+            ->setParameter('cutoff', $now->modify('-' . ltrim(ShareClaimCode::RETENTION_AFTER_EXPIRY, '+')))
+            ->orderBy('c.expiresAt', 'ASC')
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();

--- a/backend/src/Repository/ShareClaimCodeRepository.php
+++ b/backend/src/Repository/ShareClaimCodeRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ShareClaimCode;
+use App\Entity\User;
+use App\Service\SharingCodeFormat;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ShareClaimCode>
+ */
+class ShareClaimCodeRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ShareClaimCode::class);
+    }
+
+    /**
+     * Find a code by what somebody typed.
+     *
+     * By hash, so the plaintext is never compared against anything stored and a
+     * database leak yields nothing redeemable. Returns whatever the hash finds,
+     * live or not — deciding whether it may still be used belongs to the
+     * service, which has to answer identically for a spent code and a code that
+     * never existed.
+     */
+    public function findByPlaintext(string $plaintext): ?ShareClaimCode
+    {
+        $normalised = SharingCodeFormat::normalise($plaintext);
+        if ($normalised === '') {
+            return null;
+        }
+
+        return $this->findOneBy(['codeHash' => SharingCodeFormat::hash($normalised)]);
+    }
+
+    /**
+     * The codes an owner still has out, newest first.
+     *
+     * Expired and spent ones are included: the owner asked what they handed
+     * out, and a code that has run out is part of that answer.
+     *
+     * @return list<ShareClaimCode>
+     */
+    public function findLiveForOwner(User $owner, int $limit = 20): array
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.owner = :owner')
+            ->andWhere('c.revokedAt IS NULL')
+            ->setParameter('owner', $owner)
+            ->orderBy('c.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/backend/src/Repository/ShareClaimCodeRepository.php
+++ b/backend/src/Repository/ShareClaimCodeRepository.php
@@ -4,6 +4,8 @@ namespace App\Repository;
 
 use App\Entity\ShareClaimCode;
 use App\Entity\User;
+use App\Service\Pagination\PaginatedResult;
+use App\Service\Pagination\PaginationRequest;
 use App\Service\SharingCodeFormat;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -13,6 +15,14 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class ShareClaimCodeRepository extends ServiceEntityRepository
 {
+    /** Query alias => DQL expression, for the admin table's sort control. */
+    public const ADMIN_SORT_FIELDS = [
+        'createdAt' => 'c.createdAt',
+        'expiresAt' => 'c.expiresAt',
+        'maxUses' => 'c.maxUses',
+        'usesRemaining' => 'c.usesRemaining',
+    ];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ShareClaimCode::class);
@@ -57,6 +67,91 @@ class ShareClaimCodeRepository extends ServiceEntityRepository
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * One page of issued codes for an administrator, newest first by default.
+     *
+     * Every filter is optional and every one of them narrows: an operator
+     * arriving at this table after an abuse report is looking for one code
+     * among everything the instance has issued, and the table grows
+     * continuously between retention sweeps.
+     *
+     * The status filters are expressed here rather than read from a stored
+     * column, because "expired" and "used up" are facts about a row and a clock
+     * rather than states anything writes. A second column saying so would be
+     * one more thing to keep in step.
+     *
+     * @param array{status?: string|null, ownerId?: int|null, createdFrom?: \DateTimeImmutable|null,
+     *              createdTo?: \DateTimeImmutable|null, expiresFrom?: \DateTimeImmutable|null,
+     *              expiresTo?: \DateTimeImmutable|null} $filters
+     *
+     * @return PaginatedResult<ShareClaimCode>
+     */
+    public function findAdminPage(PaginationRequest $request, array $filters = []): PaginatedResult
+    {
+        $qb = $this->createQueryBuilder('c')->leftJoin('c.owner', 'o');
+        $now = new \DateTimeImmutable();
+
+        if (($filters['ownerId'] ?? null) !== null) {
+            $qb->andWhere('c.owner = :ownerId')->setParameter('ownerId', $filters['ownerId']);
+        }
+
+        // The owner is the only thing worth searching by. The code itself is
+        // stored as a hash and cannot be searched for even by somebody holding
+        // it, which is the point of hashing it.
+        if ($pattern = $request->searchPattern()) {
+            $qb->andWhere($qb->expr()->orX(
+                'LOWER(o.name) LIKE :search',
+                'LOWER(o.email) LIKE :search',
+            ))->setParameter('search', $pattern);
+        }
+
+        switch ($filters['status'] ?? null) {
+            case 'active':
+                $qb->andWhere('c.revokedAt IS NULL')
+                    ->andWhere('c.usesRemaining > 0')
+                    ->andWhere('c.expiresAt > :now')
+                    ->setParameter('now', $now);
+                break;
+            case 'withdrawn':
+                $qb->andWhere('c.revokedAt IS NOT NULL');
+                break;
+            case 'expired':
+                // Only codes that ran out of time, so an operator filtering for
+                // "expired" is not shown everything that died some other way.
+                $qb->andWhere('c.revokedAt IS NULL')
+                    ->andWhere('c.usesRemaining > 0')
+                    ->andWhere('c.expiresAt <= :now')
+                    ->setParameter('now', $now);
+                break;
+            case 'exhausted':
+                $qb->andWhere('c.revokedAt IS NULL')->andWhere('c.usesRemaining <= 0');
+                break;
+        }
+
+        foreach ([
+            'createdFrom' => ['c.createdAt >= :createdFrom', 'createdFrom'],
+            'createdTo' => ['c.createdAt <= :createdTo', 'createdTo'],
+            'expiresFrom' => ['c.expiresAt >= :expiresFrom', 'expiresFrom'],
+            'expiresTo' => ['c.expiresAt <= :expiresTo', 'expiresTo'],
+        ] as $key => [$expression, $parameter]) {
+            if (($filters[$key] ?? null) !== null) {
+                $qb->andWhere($expression)->setParameter($parameter, $filters[$key]);
+            }
+        }
+
+        $total = (int) (clone $qb)->select('COUNT(c.id)')->getQuery()->getSingleScalarResult();
+
+        $codes = $qb
+            ->orderBy(self::ADMIN_SORT_FIELDS[$request->sortField], $request->direction)
+            ->addOrderBy('c.id', 'DESC')
+            ->setFirstResult($request->offset())
+            ->setMaxResults($request->limit)
+            ->getQuery()
+            ->getResult();
+
+        return PaginatedResult::fromRequest($codes, $total, $request);
     }
 
     /**

--- a/backend/src/Service/ComicShareSerializer.php
+++ b/backend/src/Service/ComicShareSerializer.php
@@ -46,9 +46,26 @@ class ComicShareSerializer
         // Never redacted. The owner classified the comic, and owns the file; an
         // age gate protects a recipient from content they have not agreed to
         // see, not a person from their own library.
+        // The one thing an owner is not always shown. When the sender reached
+        // this person through their receiver code, the whole point was that the
+        // address never crossed over — so handing it back on the page that
+        // lists what they shared would undo the feature entirely. They get the
+        // name and the code instead, which is exactly what they were given.
+        $hidden = $share->isRecipientAddressHiddenFromOwner();
+
         return $this->common($share, false) + [
-            'recipientEmail' => $share->getRecipientEmailNormalized(),
-            'recipientName' => $share->getRecipientUser()?->getName(),
+            'recipientEmail' => $hidden ? null : $share->getRecipientEmailNormalized(),
+            // Grouped, because that is the only form a code is ever shown in
+            // and the sender will be pasting it back into the share dialog.
+            'recipientSharingCode' => $share->getRecipientSharingCode() === null
+                ? null
+                : SharingCodeFormat::forDisplay($share->getRecipientSharingCode()),
+            'recipientLabel' => $hidden
+                ? ($share->getRecipientAliasName() ?: 'Shared by code')
+                : $share->getRecipientEmailNormalized(),
+            'recipientName' => $hidden
+                ? $share->getRecipientAliasName()
+                : $share->getRecipientUser()?->getName(),
             // Resending only makes sense while the recipient still has a choice
             // to make and there is still a comic behind the invitation.
             'canResend' => !$share->isTombstoned()

--- a/backend/src/Service/ComicShareSerializer.php
+++ b/backend/src/Service/ComicShareSerializer.php
@@ -52,20 +52,28 @@ class ComicShareSerializer
         // lists what they shared would undo the feature entirely. They get the
         // name and the code instead, which is exactly what they were given.
         $hidden = $share->isRecipientAddressHiddenFromOwner();
+        // The recipient's handle as it is now, never the one stored on the
+        // share. That one records how the relationship began and goes stale the
+        // moment they rotate; showing it would offer the owner a retired code
+        // and quietly undo the rotation. A recipient whose account has gone
+        // keeps their name and loses the code, rather than falling back to the
+        // address the code existed to withhold.
+        $currentCode = $hidden ? $share->getRecipientUser()?->getSharingCode() : null;
+        $currentName = $hidden
+            ? ($share->getRecipientUser()?->getName() ?: $share->getRecipientAliasName())
+            : $share->getRecipientUser()?->getName();
 
         return $this->common($share, false) + [
             'recipientEmail' => $hidden ? null : $share->getRecipientEmailNormalized(),
             // Grouped, because that is the only form a code is ever shown in
             // and the sender will be pasting it back into the share dialog.
-            'recipientSharingCode' => $share->getRecipientSharingCode() === null
+            'recipientSharingCode' => $currentCode === null
                 ? null
-                : SharingCodeFormat::forDisplay($share->getRecipientSharingCode()),
+                : SharingCodeFormat::forDisplay($currentCode),
             'recipientLabel' => $hidden
-                ? ($share->getRecipientAliasName() ?: 'Shared by code')
+                ? ($currentName ?: 'Shared by code')
                 : $share->getRecipientEmailNormalized(),
-            'recipientName' => $hidden
-                ? $share->getRecipientAliasName()
-                : $share->getRecipientUser()?->getName(),
+            'recipientName' => $currentName,
             // Resending only makes sense while the recipient still has a choice
             // to make and there is still a comic behind the invitation.
             'canResend' => !$share->isTombstoned()

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -142,7 +142,8 @@ class ComicShareService
         array $comics,
         User $owner,
         string $recipientEmail,
-        bool $senderResponsibilityAccepted
+        bool $senderResponsibilityAccepted,
+        ?SharingCodeRecipient $viaSharingCode = null
     ): array {
         $this->assertSenderResponsibility($senderResponsibilityAccepted);
         $email = $this->assertInvitableRecipient($owner, $recipientEmail);
@@ -172,6 +173,17 @@ class ComicShareService
         $prepared = [];
         foreach ($invitable as $comicId => [$comic, $reusable]) {
             $prepared[$comicId] = $this->openInvitation($reusable, $comic, $owner, $email);
+
+            // The sender reached this person through their receiver code and
+            // never saw the address, so the record carries what the sender may
+            // be shown in its place — and the owner-facing serializer reads
+            // that instead of the address from here on.
+            if ($viaSharingCode !== null) {
+                $prepared[$comicId]->share->hideRecipientBehindSharingCode(
+                    $viaSharingCode->sharingCode,
+                    $viaSharingCode->name
+                );
+            }
         }
 
         try {

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -123,9 +123,10 @@ class ComicShareService
      *   put in somebody's inbox — is exactly what it protected before bulk
      *   sharing existed.
      *
-     * All or nothing on the send: the grouped email is the only notice the
-     * recipient gets, so a failed send must not leave behind invitations nobody
-     * will ever hear about.
+     * A failed send leaves nothing behind: the grouped email is the only notice
+     * the recipient gets, so invitations nobody will ever hear about are worse
+     * than no invitations. See {@see deliver()} for what that guarantee does
+     * and does not cover.
      *
      * The caller is responsible for having checked {@see ComicVoter::SHARE} on
      * every comic it passes in.
@@ -185,14 +186,27 @@ class ComicShareService
             // told it — going on hiding it would withhold something they
             // already hold.
             if ($viaSharingCode !== null) {
-                $prepared[$comicId]->share->hideRecipientBehindSharingCode(
-                    $viaSharingCode->sharingCode,
-                    $viaSharingCode->name
-                );
+                $prepared[$comicId]->share
+                    ->hideRecipientBehindSharingCode(
+                        $viaSharingCode->sharingCode,
+                        $viaSharingCode->name
+                    )
+                    // A code is an account, so this relationship knows who it is
+                    // for before they answer — and that link, not the stored
+                    // code, is what still points at them after a rotation.
+                    ->linkRecipientUser($viaSharingCode->user);
             } else {
                 $prepared[$comicId]->share->revealRecipientAddressToOwner();
             }
         }
+
+        // Whether this call is the one that would roll the batch back. Reporting
+        // a failed send as a per-comic result is only truthful when the rows
+        // actually went away; inside a transaction somebody else owns, they did
+        // not, and that caller's commit would then persist relationships this
+        // method had already reported as failed. So the exception is left to
+        // travel up to whoever can undo it.
+        $ownsTransaction = !$this->entityManager->getConnection()->isTransactionActive();
 
         try {
             $this->deliver(
@@ -200,7 +214,11 @@ class ComicShareService
                 fn () => $this->sendGroupedInvitationEmail(array_values($prepared), $owner)
             );
         } catch (ShareException $exception) {
-            // The rollback already undid every relationship in the batch, so the
+            if (!$ownsTransaction) {
+                throw $exception;
+            }
+
+            // The rollback did undo every relationship in the batch, so the
             // whole group reports the same failure rather than the request
             // looking partly successful.
             foreach (array_keys($prepared) as $comicId) {
@@ -220,6 +238,102 @@ class ComicShareService
         }
 
         return $outcomes;
+    }
+
+    /**
+     * Open one relationship because the recipient redeemed a claim code.
+     *
+     * The third way a {@see ComicShare} comes into existence, and it lives here
+     * with the other two so there is one place that owns what a share is and
+     * how it changes. A transport that grew its own copy of these transitions
+     * would drift from them — the acknowledgement timestamp being recreated at
+     * redemption time is exactly the kind of bug that follows.
+     *
+     * It differs from an emailed invitation in three ways, all deliberate:
+     *
+     * - no token and no email. The recipient is right here; there is nothing to
+     *   send them a link to
+     * - **redeeming counts as accepting.** Typing a code somebody gave you is
+     *   an affirmative act, so an ordinary comic lands in the collection rather
+     *   than waiting to be accepted a second time
+     * - the acknowledgement is inherited, not made. The owner acknowledged
+     *   responsibility when they created the code
+     *
+     * Everything else is the ordinary model. The age gate in particular is not
+     * negotiable: an explicit comic is left pending, decided *before* the share
+     * is accepted so there is no instant in which an unconfirmed recipient
+     * holds an accepted share.
+     *
+     * Does not flush. The caller owns the transaction, because spending a use
+     * of the code and creating the shares it paid for have to land together.
+     *
+     * @param \DateTimeImmutable $acknowledgedAt when the owner accepted
+     *                                          responsibility, from the code
+     *
+     * @return array{status: string, message?: string} the outcome for this comic
+     */
+    public function claimFromCode(
+        Comic $comic,
+        User $owner,
+        User $recipient,
+        \DateTimeImmutable $acknowledgedAt
+    ): array {
+        $email = ComicShare::normaliseEmail((string) $recipient->getEmail());
+        $share = $this->shareRepository->findForComicAndRecipient($comic, $email);
+
+        // Already theirs, or already offered and still open. Redeeming does not
+        // restart either.
+        if ($share !== null && ($share->getStatus() === ComicShare::STATUS_ACCEPTED || $share->isPending())) {
+            return ['status' => 'already_yours', 'message' => 'You already have this comic.'];
+        }
+
+        if ($share === null) {
+            $share = new ComicShare($comic, $owner, $email);
+            $this->entityManager->persist($share);
+        } else {
+            // Declined, revoked or lapsed. Reused rather than duplicated, and
+            // the old age declaration does not carry over — this is a fresh
+            // offer of the comic as it is now.
+            $share->setOwner($owner)->refreshSnapshots()->resetAdultConfirmation();
+        }
+
+        $share
+            ->markPending(new \DateTimeImmutable(self::INVITATION_TTL))
+            ->refreshSnapshots()
+            ->linkRecipientUser($recipient)
+            ->inheritSenderResponsibility($acknowledgedAt);
+
+        $this->auditLogger->audit(SecurityAuditLogger::SHARE_CREATED, [
+            'actor_user_id' => $owner->getId(),
+            'target_type' => 'share',
+            'target_id' => $share->getId(),
+            'comic_id' => $comic->getId(),
+            'recipient_user_id' => $recipient->getId(),
+            'explicit_content' => $comic->isExplicitContent(),
+            'via' => 'claim_code',
+        ]);
+
+        if ($share->requiresAdultConfirmation()) {
+            return [
+                'status' => 'awaiting_age_confirmation',
+                'message' => 'Confirm your age on the Sharing page to open this one.',
+            ];
+        }
+
+        $share->markAccepted($recipient)->refreshSnapshots();
+        $this->revokeOutstandingTokens($share);
+
+        $this->auditLogger->audit(SecurityAuditLogger::SHARE_ACCEPTED, [
+            'actor_user_id' => $recipient->getId(),
+            'target_type' => 'share',
+            'target_id' => $share->getId(),
+            'comic_id' => $comic->getId(),
+            'owner_user_id' => $owner->getId(),
+            'explicit_content' => $comic->isExplicitContent(),
+            'via' => 'claim_code',
+        ]);
+
+        return ['status' => 'claimed'];
     }
 
     /**
@@ -752,6 +866,20 @@ class ComicShareService
      * The send is inside the transaction on purpose: a send that fails rolls the
      * invitations back, so nobody is shown a recipient who was never actually
      * contacted.
+     *
+     * That is the guarantee, and it is worth being exact about its limit,
+     * because an SMTP call is not a participant in a database transaction and
+     * no arrangement of this code can make it one. What holds is one direction:
+     * **a failed send leaves no invitation behind.** The reverse does not — if
+     * the send succeeds and the commit then fails, the recipient is holding
+     * links to relationships that no longer exist, and they will find the
+     * invitation is not valid. Ordering it the other way round trades that for
+     * invitations nobody was told about, which is recoverable by resending but
+     * happens on every transport hiccup rather than on the rarer commit
+     * failure. Making both impossible needs a transactional outbox: the shares
+     * and a pending-notification row committed together, and a worker sending
+     * after the commit. That is a change to how this application delivers
+     * everything, not to this method.
      *
      * @param list<PreparedInvitation> $prepared for the failure log only
      * @param callable(): void         $send

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -79,94 +79,127 @@ class ComicShareService
         string $recipientEmail,
         bool $senderResponsibilityAccepted
     ): IssuedInvitation {
-        // Checked before anything else is decided, so a share cannot come into
-        // existence without the acknowledgement that goes on the record with it.
-        // The tick box in the UI is a prompt, not the rule.
-        if (!$senderResponsibilityAccepted) {
-            throw new ShareException(
-                'You must acknowledge responsibility for the content you share.',
-                400,
-                ShareException::CODE_RESPONSIBILITY_REQUIRED
-            );
-        }
+        $this->assertSenderResponsibility($senderResponsibilityAccepted);
+        $email = $this->assertInvitableRecipient($owner, $recipientEmail);
+        $reusable = $this->assertNoLiveInvitation($comic, $email);
 
-        $email = ComicShare::normaliseEmail($recipientEmail);
+        // The last thing checked before anything is created, so only invitations
+        // that actually go out count against the allowance — a request rejected
+        // as a duplicate, by permissions or by validation spends nothing — and
+        // nothing half-built is left in the unit of work when it is refused.
+        $this->reserveInvitationAllowance($owner);
 
-        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            throw new ShareException('A valid recipient email address is required.', 400);
-        }
+        $prepared = $this->openInvitation($reusable, $comic, $owner, $email);
 
-        if ($email === ComicShare::normaliseEmail((string) $owner->getEmail())) {
-            throw new ShareException('You already own this comic.', 400);
-        }
-
-        // Keyed on the comic, so this only ever finds a live relationship: a
-        // tombstone holds a null comic and is invisible here by construction.
-        // That is deliberate. A tombstone belongs to the recipient, as the
-        // record of a comic that went away; re-pointing it at a different comic
-        // would rewrite their history and delete the explanation they were left
-        // with. Re-inviting somebody after a deletion starts a fresh
-        // relationship, and the null comic keeps it clear of the unique index.
-        $share = $this->shareRepository->findForComicAndRecipient($comic, $email);
-
-        if ($share !== null && $share->getStatus() === ComicShare::STATUS_ACCEPTED) {
-            throw new ShareException('This comic is already shared with that person.', 409);
-        }
-
-        if ($share !== null && $share->isPending()) {
-            throw new ShareException(
-                'An invitation is already pending for that person. Resend it instead.',
-                409
-            );
-        }
-
-        if ($share === null) {
-            $share = new ComicShare($comic, $owner, $email);
-            $this->entityManager->persist($share);
-        } else {
-            // Declined, revoked, or a pending invitation that lapsed. The row is
-            // reused rather than duplicated, which is what the unique index on
-            // (comic, recipient) is there to guarantee.
-            //
-            // Reusing the row does not carry the old age declaration forward:
-            // this is a fresh offer of the comic as it is now, and the previous
-            // relationship ended without the recipient reading anything.
-            $share->setOwner($owner)->refreshSnapshots()->resetAdultConfirmation();
-        }
-
-        $share->markPending($this->invitationExpiry());
-        // A new share, so a new acknowledgement. Resending does not come through
-        // here and keeps the timestamp it already has.
-        $share->acceptSenderResponsibility();
-
-        $invitation = $this->issueInvitation($share, $comic, $owner);
+        $this->deliver(
+            [$prepared],
+            fn () => $this->sendInvitationEmail($prepared->share, $comic, $owner, $prepared->plaintextToken)
+        );
 
         // After the send, so nothing is recorded as shared that was rolled back
         // when the email failed.
-        $this->auditLogger->audit(SecurityAuditLogger::SHARE_CREATED, [
-            'actor_user_id' => $owner->getId(),
-            'target_type' => 'share',
-            'target_id' => $share->getId(),
-            'comic_id' => $comic->getId(),
-            'recipient_user_id' => $share->getRecipientUser()?->getId(),
-            'explicit_content' => $comic->isExplicitContent(),
-        ]);
+        $this->auditInvitation($prepared, $owner);
 
-        // Its own record rather than a field on the one above, because this is
-        // the acknowledgement's audit trail and somebody looking for it should
-        // not have to know that shares are created with one attached. Ids only:
-        // the canonical evidence is ComicShare::senderResponsibilityAcceptedAt,
-        // and the title of an explicit comic is the thing the gate withholds.
-        $this->auditLogger->audit(SecurityAuditLogger::SHARE_SENDER_RESPONSIBILITY_ACCEPTED, [
-            'actor_user_id' => $owner->getId(),
-            'target_type' => 'share',
-            'target_id' => $share->getId(),
-            'comic_id' => $comic->getId(),
-            'recipient_user_id' => $share->getRecipientUser()?->getId(),
-            'accepted_at' => $share->getSenderResponsibilityAcceptedAt()?->format(DATE_ATOM),
-        ]);
+        return new IssuedInvitation($prepared->share, $this->invitationUrl($prepared->plaintextToken));
+    }
 
-        return $invitation;
+    /**
+     * Share several comics with one recipient as a single act.
+     *
+     * A convenience layer and nothing more: every comic still gets its own
+     * {@see ComicShare}, its own token, its own status and its own revocation,
+     * and every one of them goes through the same checks a single invitation
+     * does. Nothing here can grant access that {@see invite()} would refuse.
+     *
+     * Two things are deliberately shared across the batch rather than repeated
+     * per comic:
+     *
+     * - **One email.** Twenty comics must not mean twenty messages in somebody's
+     *   inbox. The recipient gets one notice listing what they were offered,
+     *   with a separate link per comic, because each invitation is still
+     *   answered on its own.
+     * - **One allowance.** One send is one claim on the `share_invitation`
+     *   limiter, so what the limiter protects — how much mail one account can
+     *   put in somebody's inbox — is exactly what it protected before bulk
+     *   sharing existed.
+     *
+     * All or nothing on the send: the grouped email is the only notice the
+     * recipient gets, so a failed send must not leave behind invitations nobody
+     * will ever hear about.
+     *
+     * The caller is responsible for having checked {@see ComicVoter::SHARE} on
+     * every comic it passes in.
+     *
+     * @param list<Comic> $comics
+     *
+     * @return array<int, array{status: string, message?: string, code?: string, shareId?: int|null}>
+     *                                                                                                 keyed by comic id
+     *
+     * @throws ShareException when the whole batch is refused — a bad recipient,
+     *                        a missing acknowledgement or an exhausted allowance
+     */
+    public function inviteMany(
+        array $comics,
+        User $owner,
+        string $recipientEmail,
+        bool $senderResponsibilityAccepted
+    ): array {
+        $this->assertSenderResponsibility($senderResponsibilityAccepted);
+        $email = $this->assertInvitableRecipient($owner, $recipientEmail);
+
+        $outcomes = [];
+        $invitable = [];
+
+        // Read-only pass first. Every comic is judged before any of them is
+        // created, so the allowance is claimed once and only for a send that is
+        // known to have something to announce.
+        foreach ($comics as $comic) {
+            $comicId = (int) $comic->getId();
+
+            try {
+                $invitable[$comicId] = [$comic, $this->assertNoLiveInvitation($comic, $email)];
+            } catch (ShareException $exception) {
+                $outcomes[$comicId] = $this->describeFailure($exception);
+            }
+        }
+
+        if ($invitable === []) {
+            return $outcomes;
+        }
+
+        $this->reserveInvitationAllowance($owner);
+
+        $prepared = [];
+        foreach ($invitable as $comicId => [$comic, $reusable]) {
+            $prepared[$comicId] = $this->openInvitation($reusable, $comic, $owner, $email);
+        }
+
+        try {
+            $this->deliver(
+                array_values($prepared),
+                fn () => $this->sendGroupedInvitationEmail(array_values($prepared), $owner)
+            );
+        } catch (ShareException $exception) {
+            // The rollback already undid every relationship in the batch, so the
+            // whole group reports the same failure rather than the request
+            // looking partly successful.
+            foreach (array_keys($prepared) as $comicId) {
+                $outcomes[$comicId] = $this->describeFailure($exception);
+            }
+
+            return $outcomes;
+        }
+
+        foreach ($prepared as $comicId => $invitation) {
+            $this->auditInvitation($invitation, $owner);
+
+            $outcomes[$comicId] = [
+                'status' => 'created',
+                'shareId' => $invitation->share->getId(),
+            ];
+        }
+
+        return $outcomes;
     }
 
     /**
@@ -188,9 +221,23 @@ class ComicShareService
             throw new ShareException('That invitation has already been accepted.', 409);
         }
 
-        $share->markPending($this->invitationExpiry())->refreshSnapshots();
+        // Claimed before the row is touched, so a resend that is turned away
+        // leaves the invitation exactly as it was.
+        $this->reserveInvitationAllowance($owner);
 
-        return $this->issueInvitation($share, $comic, $owner);
+        $share->markPending($this->invitationExpiry())->refreshSnapshots();
+        $this->revokeOutstandingTokens($share);
+
+        [$plaintext, $hash] = ShareInvitationToken::generate();
+        $this->entityManager->persist(new ShareInvitationToken($share, $hash, $this->invitationExpiry()));
+        $prepared = new PreparedInvitation($share, $comic, $plaintext);
+
+        $this->deliver(
+            [$prepared],
+            fn () => $this->sendInvitationEmail($share, $comic, $owner, $plaintext)
+        );
+
+        return new IssuedInvitation($share, $this->invitationUrl($plaintext));
     }
 
     /**
@@ -571,21 +618,128 @@ class ComicShareService
     }
 
     /**
-     * Mint a token, persist the relationship and email the link.
+     * The acknowledgement that goes on the record with the share.
+     *
+     * Checked before anything else is decided, so a share cannot come into
+     * existence without it. The tick box in the UI is a prompt, not the rule.
      *
      * @throws ShareException
      */
-    private function issueInvitation(ComicShare $share, Comic $comic, User $owner): IssuedInvitation
+    private function assertSenderResponsibility(bool $accepted): void
     {
-        // The last thing checked before anything is created or sent, so only
-        // invitations that actually go out count against the allowance.
-        $this->reserveInvitationAllowance($owner);
+        if (!$accepted) {
+            throw new ShareException(
+                'You must acknowledge responsibility for the content you share.',
+                400,
+                ShareException::CODE_RESPONSIBILITY_REQUIRED
+            );
+        }
+    }
+
+    /**
+     * @return string the normalised address every later step uses
+     *
+     * @throws ShareException
+     */
+    private function assertInvitableRecipient(User $owner, string $recipientEmail): string
+    {
+        $email = ComicShare::normaliseEmail($recipientEmail);
+
+        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new ShareException('A valid recipient email address is required.', 400);
+        }
+
+        if ($email === ComicShare::normaliseEmail((string) $owner->getEmail())) {
+            throw new ShareException('You already own this comic.', 400);
+        }
+
+        return $email;
+    }
+
+    /**
+     * Refuse a comic this recipient can already reach, and hand back the dead
+     * relationship to reuse when there is one.
+     *
+     * Reads only. Bulk sharing judges every comic in a batch before it creates
+     * any of them, so nothing here may write.
+     *
+     * @return ComicShare|null a declined, revoked or lapsed row to reopen
+     *
+     * @throws ShareException
+     */
+    private function assertNoLiveInvitation(Comic $comic, string $email): ?ComicShare
+    {
+        // Keyed on the comic, so this only ever finds a live relationship: a
+        // tombstone holds a null comic and is invisible here by construction.
+        // That is deliberate. A tombstone belongs to the recipient, as the
+        // record of a comic that went away; re-pointing it at a different comic
+        // would rewrite their history and delete the explanation they were left
+        // with. Re-inviting somebody after a deletion starts a fresh
+        // relationship, and the null comic keeps it clear of the unique index.
+        $share = $this->shareRepository->findForComicAndRecipient($comic, $email);
+
+        if ($share !== null && $share->getStatus() === ComicShare::STATUS_ACCEPTED) {
+            throw new ShareException('This comic is already shared with that person.', 409);
+        }
+
+        if ($share !== null && $share->isPending()) {
+            throw new ShareException(
+                'An invitation is already pending for that person. Resend it instead.',
+                409
+            );
+        }
+
+        return $share;
+    }
+
+    /**
+     * Open the relationship and mint the link, without flushing or sending.
+     *
+     * @param ComicShare|null $share the row {@see assertNoLiveInvitation} found
+     */
+    private function openInvitation(?ComicShare $share, Comic $comic, User $owner, string $email): PreparedInvitation
+    {
+        if ($share === null) {
+            $share = new ComicShare($comic, $owner, $email);
+            $this->entityManager->persist($share);
+        } else {
+            // Declined, revoked, or a pending invitation that lapsed. The row is
+            // reused rather than duplicated, which is what the unique index on
+            // (comic, recipient) is there to guarantee.
+            //
+            // Reusing the row does not carry the old age declaration forward:
+            // this is a fresh offer of the comic as it is now, and the previous
+            // relationship ended without the recipient reading anything.
+            $share->setOwner($owner)->refreshSnapshots()->resetAdultConfirmation();
+        }
+
+        $share->markPending($this->invitationExpiry());
+        // A new share, so a new acknowledgement. Resending does not come through
+        // here and keeps the timestamp it already has.
+        $share->acceptSenderResponsibility();
+
         $this->revokeOutstandingTokens($share);
 
         [$plaintext, $hash] = ShareInvitationToken::generate();
-        $token = new ShareInvitationToken($share, $hash, $this->invitationExpiry());
-        $this->entityManager->persist($token);
+        $this->entityManager->persist(new ShareInvitationToken($share, $hash, $this->invitationExpiry()));
 
+        return new PreparedInvitation($share, $comic, $plaintext);
+    }
+
+    /**
+     * Commit the prepared relationships and announce them, as one unit of work.
+     *
+     * The send is inside the transaction on purpose: a send that fails rolls the
+     * invitations back, so nobody is shown a recipient who was never actually
+     * contacted.
+     *
+     * @param list<PreparedInvitation> $prepared for the failure log only
+     * @param callable(): void         $send
+     *
+     * @throws ShareException
+     */
+    private function deliver(array $prepared, callable $send): void
+    {
         // Avoid nesting commits when a caller already owns the transaction, the
         // same way account deletion does — a nested commit would escape the
         // test suite's rollback wrapper.
@@ -598,7 +752,7 @@ class ComicShareService
             }
 
             $this->entityManager->flush();
-            $this->sendInvitationEmail($share, $comic, $owner, $plaintext);
+            $send();
 
             if ($ownsTransaction) {
                 $this->entityManager->commit();
@@ -613,7 +767,10 @@ class ComicShareService
             }
 
             $this->logger->error('Failed to send a comic share invitation.', [
-                'comic_id' => $comic->getId(),
+                'comic_ids' => array_map(
+                    static fn (PreparedInvitation $invitation): ?int => $invitation->comic->getId(),
+                    $prepared
+                ),
                 'exception' => $exception,
             ]);
 
@@ -622,8 +779,59 @@ class ComicShareService
                 502
             );
         }
+    }
 
-        return new IssuedInvitation($share, $this->invitationUrl($plaintext));
+    /** The two records every new sharing relationship leaves behind. */
+    private function auditInvitation(PreparedInvitation $invitation, User $owner): void
+    {
+        $share = $invitation->share;
+        $comic = $invitation->comic;
+
+        $this->auditLogger->audit(SecurityAuditLogger::SHARE_CREATED, [
+            'actor_user_id' => $owner->getId(),
+            'target_type' => 'share',
+            'target_id' => $share->getId(),
+            'comic_id' => $comic->getId(),
+            'recipient_user_id' => $share->getRecipientUser()?->getId(),
+            'explicit_content' => $comic->isExplicitContent(),
+        ]);
+
+        // Its own record rather than a field on the one above, because this is
+        // the acknowledgement's audit trail and somebody looking for it should
+        // not have to know that shares are created with one attached. Ids only:
+        // the canonical evidence is ComicShare::senderResponsibilityAcceptedAt,
+        // and the title of an explicit comic is the thing the gate withholds.
+        $this->auditLogger->audit(SecurityAuditLogger::SHARE_SENDER_RESPONSIBILITY_ACCEPTED, [
+            'actor_user_id' => $owner->getId(),
+            'target_type' => 'share',
+            'target_id' => $share->getId(),
+            'comic_id' => $comic->getId(),
+            'recipient_user_id' => $share->getRecipientUser()?->getId(),
+            'accepted_at' => $share->getSenderResponsibilityAcceptedAt()?->format(DATE_ATOM),
+        ]);
+    }
+
+    /**
+     * One comic's failure, in the shape a bulk result reports it.
+     *
+     * @return array{status: string, message: string, code?: string}
+     */
+    private function describeFailure(ShareException $exception): array
+    {
+        $outcome = [
+            'status' => match ($exception->getStatusCode()) {
+                409 => 'skipped',
+                429 => 'rate_limited',
+                default => 'failed',
+            },
+            'message' => $exception->getMessage(),
+        ];
+
+        if ($exception->getErrorCode() !== null) {
+            $outcome['code'] = $exception->getErrorCode();
+        }
+
+        return $outcome;
     }
 
     private function sendInvitationEmail(ComicShare $share, Comic $comic, User $owner, string $plaintextToken): void
@@ -649,6 +857,68 @@ class ComicShareService
             ->replyTo((string) $owner->getEmail())
             ->to($share->getRecipientEmailNormalized())
             ->subject($ownerName . ' shared a comic with you!')
+            ->html($body);
+
+        $this->mailer->send($email);
+    }
+
+    /**
+     * One message for a whole bulk share.
+     *
+     * Each comic still carries its own link, because each invitation is still
+     * answered, expired and revoked on its own — grouping is about the notice,
+     * not about the access. The 18+ gate is applied per comic exactly as the
+     * single-comic template applies it, so one explicit comic in a batch is
+     * announced without a title while the rest are named normally.
+     *
+     * @param list<PreparedInvitation> $prepared
+     */
+    private function sendGroupedInvitationEmail(array $prepared, User $owner): void
+    {
+        // One comic is not a group. Falling back keeps the ordinary case on the
+        // template that has always described it.
+        if (count($prepared) === 1) {
+            $only = $prepared[0];
+            $this->sendInvitationEmail($only->share, $only->comic, $owner, $only->plaintextToken);
+
+            return;
+        }
+
+        $ownerName = $owner->getName() ?: $owner->getEmail();
+        $recipient = $prepared[0]->share->getRecipientEmailNormalized();
+        $expiresAt = $prepared[0]->share->getExpiresAt();
+
+        $invitations = array_map(
+            function (PreparedInvitation $invitation): array {
+                $explicit = $invitation->comic->isExplicitContent();
+
+                return [
+                    // Withheld rather than rendered and hidden: an email is
+                    // previewed on lock screens and read by scanners, so an
+                    // explicit comic must not be named in one at all.
+                    'title' => $explicit ? null : $invitation->comic->getTitle(),
+                    'author' => $explicit ? null : $invitation->comic->getAuthor(),
+                    'explicitContent' => $explicit,
+                    'shareLink' => $this->invitationUrl($invitation->plaintextToken),
+                ];
+            },
+            $prepared
+        );
+
+        $body = $this->twig->render('emails/share_comics.html.twig', [
+            'invitations' => $invitations,
+            'comicCount' => count($invitations),
+            'explicitCount' => count(array_filter($invitations, static fn (array $i): bool => $i['explicitContent'])),
+            'userName' => $ownerName,
+            'privacyUrl' => $this->publicUrl->to('/privacy'),
+            'expiresAt' => $expiresAt,
+        ]);
+
+        $email = (new Email())
+            ->from(new Address($this->mailerFromAddress, $this->mailerFromName))
+            ->replyTo((string) $owner->getEmail())
+            ->to($recipient)
+            ->subject(sprintf('%s shared %d comics with you!', $ownerName, count($invitations)))
             ->html($body);
 
         $this->mailer->send($email);

--- a/backend/src/Service/ComicShareService.php
+++ b/backend/src/Service/ComicShareService.php
@@ -178,11 +178,19 @@ class ComicShareService
             // never saw the address, so the record carries what the sender may
             // be shown in its place — and the owner-facing serializer reads
             // that instead of the address from here on.
+            //
+            // Cleared in the other direction for the same reason. openInvitation
+            // reuses a declined, revoked or lapsed row, so an owner who reaches
+            // the same person again by typing their address has plainly been
+            // told it — going on hiding it would withhold something they
+            // already hold.
             if ($viaSharingCode !== null) {
                 $prepared[$comicId]->share->hideRecipientBehindSharingCode(
                     $viaSharingCode->sharingCode,
                     $viaSharingCode->name
                 );
+            } else {
+                $prepared[$comicId]->share->revealRecipientAddressToOwner();
             }
         }
 

--- a/backend/src/Service/ExpiredShareCleanupService.php
+++ b/backend/src/Service/ExpiredShareCleanupService.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\ShareClaimCode;
+use App\Entity\User;
+use App\Repository\ComicShareRepository;
+use App\Repository\ShareClaimCodeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * The retention sweep for sharing records, owned in one place.
+ *
+ * Two callers run this: the scheduled `app:cleanup-expired-shares` command,
+ * which is the normal path, and an administrator pressing a button, which is
+ * the fallback for an installation whose cron is not running. They share the
+ * code rather than the intent — a deletion rule that exists twice is a deletion
+ * rule that will eventually disagree with itself, and this one decides what to
+ * remove from somebody's account.
+ *
+ * What it will never do, however it is called:
+ *
+ * - touch a live invitation or a live code. Only records past their own
+ *   deadline are in scope, and pressing the button early deletes nothing
+ * - touch a {@see \App\Entity\ComicShare} created by redeeming a code. Those
+ *   are ordinary relationships and outlive the code entirely; a code is a way
+ *   in, never the access itself
+ */
+final class ExpiredShareCleanupService
+{
+    /**
+     * Records removed per flush. A sweep that has not run for a long time would
+     * otherwise hydrate every expired record and its cascaded rows into one
+     * unit of work — and run out of memory before deleting anything at all.
+     */
+    public const BATCH_SIZE = 200;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ComicShareRepository $shareRepository,
+        private readonly ShareClaimCodeRepository $claimCodeRepository,
+        private readonly SecurityAuditLogger $auditLogger,
+    ) {
+    }
+
+    /**
+     * Both sweeps, with one clock.
+     *
+     * `$now` is resolved by the caller and passed down so a long backlog cannot
+     * pick up records that expire while it is still working through the first
+     * ones.
+     *
+     * @return array{invitations: int, claimCodes: int}
+     */
+    public function run(?\DateTimeImmutable $now = null): array
+    {
+        $now ??= new \DateTimeImmutable();
+
+        return [
+            'invitations' => $this->cleanupExpiredInvitations($now),
+            'claimCodes' => $this->cleanupExpiredClaimCodes($now),
+        ];
+    }
+
+    /**
+     * Delete invitations nobody answered before they expired.
+     *
+     * Only pending relationships are in scope. An accepted share has no expiry,
+     * and a declined or revoked one is history somebody may still be looking
+     * at. An expired invitation is deleted rather than kept because it holds
+     * the email address of somebody who may never have had an account here and
+     * who did not act on it.
+     */
+    public function cleanupExpiredInvitations(?\DateTimeImmutable $now = null): int
+    {
+        $now ??= new \DateTimeImmutable();
+        $count = 0;
+
+        while (($expired = $this->shareRepository->findExpiredPendingShares($now, self::BATCH_SIZE)) !== []) {
+            foreach ($expired as $share) {
+                // The invitation tokens go with it: they are mapped with
+                // orphanRemoval and a cascading foreign key.
+                $this->entityManager->remove($share);
+            }
+
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+            $count += count($expired);
+        }
+
+        return $count;
+    }
+
+    /**
+     * Delete codes that died long enough ago to have answered every question
+     * their owner had about them.
+     *
+     * Withdrawn codes go the same way and on the same clock. Withdrawing one
+     * stops it working immediately; it does not make the record of what was
+     * offered any less interesting to the person who offered it.
+     *
+     * Only the code rows go, with their comic links and redemption history.
+     * The shares a code produced are ordinary relationships and are not in
+     * scope here at all.
+     */
+    public function cleanupExpiredClaimCodes(?\DateTimeImmutable $now = null): int
+    {
+        $now ??= new \DateTimeImmutable();
+        $count = 0;
+
+        while (($dead = $this->claimCodeRepository->findDeletable($now, self::BATCH_SIZE)) !== []) {
+            foreach ($dead as $code) {
+                $this->entityManager->remove($code);
+            }
+
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+            $count += count($dead);
+        }
+
+        return $count;
+    }
+
+    /**
+     * The same sweep, run by hand, with a record of who ran it.
+     *
+     * The scheduled command is deliberately quiet — a cron job reporting "0
+     * removed" every hour is noise, and its work is already visible in what is
+     * no longer there. Somebody pressing a button is not: an administrator
+     * deleting records from other people's accounts is exactly the kind of
+     * thing that should be answerable afterwards, and the count is what makes
+     * it answerable.
+     *
+     * @return array{invitations: int, claimCodes: int}
+     */
+    public function runForAdministrator(User $admin): array
+    {
+        $removed = $this->run();
+
+        $this->auditLogger->audit(SecurityAuditLogger::RETENTION_CLEANUP, [
+            'actor_user_id' => $admin->getId(),
+            'target_type' => 'share',
+            'scope' => 'manual_admin_sweep',
+            'invitations_removed' => $removed['invitations'],
+            'claim_codes_removed' => $removed['claimCodes'],
+            'retention_after_expiry' => ShareClaimCode::RETENTION_AFTER_EXPIRY,
+        ]);
+
+        return $removed;
+    }
+}

--- a/backend/src/Service/PreparedInvitation.php
+++ b/backend/src/Service/PreparedInvitation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Comic;
+use App\Entity\ComicShare;
+
+/**
+ * One invitation that has been built but not yet committed or announced.
+ *
+ * Bulk sharing needs the relationships to exist before the single email that
+ * describes all of them can be rendered, and it needs every one of them to be
+ * undone together if that send fails. This carries the three things the send and
+ * the rollback both need, so the preparation step can hand them over without the
+ * caller reaching back into the unit of work.
+ */
+// Individually readonly properties rather than a readonly class: composer
+// declares "php": ">=8.1" and a readonly *class* is 8.2 syntax that would fatal
+// at parse time on 8.1. Same reasoning as {@see IssuedInvitation}.
+final class PreparedInvitation
+{
+    public function __construct(
+        public readonly ComicShare $share,
+        public readonly Comic $comic,
+        /** Exists only until the email is rendered; only its hash is stored. */
+        public readonly string $plaintextToken,
+    ) {
+    }
+}

--- a/backend/src/Service/SecurityAuditLogger.php
+++ b/backend/src/Service/SecurityAuditLogger.php
@@ -45,6 +45,11 @@ class SecurityAuditLogger
     public const INTEGRATION_TOKEN_REJECTED = 'security.integration.token.rejected';
     public const ADULT_GATE_BYPASS_ATTEMPT = 'security.share.adult_gate_bypass_attempt';
     public const SHARE_WRONG_RECIPIENT = 'security.share.wrong_recipient';
+    // Sharing codes are the only surface that turns an identifier somebody
+    // typed into a person, so they are the only place worth watching for
+    // somebody working through the keyspace rather than pasting a code.
+    public const SHARING_CODE_ENUMERATION_ATTEMPT = 'security.share.sharing_code_enumeration_attempt';
+    public const SHARE_CLAIM_CODE_REJECTED = 'security.share.claim_code_rejected';
     public const DATA_INTEGRITY_FAILURE = 'security.data_integrity.failure';
     // The alarm raised by a sweep large enough to look like a compromised
     // account. Its own name rather than the audit event below reused: the two
@@ -77,6 +82,9 @@ class SecurityAuditLogger
     // that commit — where the deletion events above already carry the count of
     // recipients who lost access.
     public const SHARES_CLEARED = 'audit.share.dead_records_cleared';
+    public const SHARE_CLAIM_CODE_CREATED = 'audit.share.claim_code_created';
+    public const SHARE_CLAIM_CODE_REDEEMED = 'audit.share.claim_code_redeemed';
+    public const SHARE_CLAIM_CODE_REVOKED = 'audit.share.claim_code_revoked';
     public const INTEGRATION_DISCONNECTED = 'audit.integration.disconnected';
     public const STORAGE_ORPHAN_QUARANTINE = 'audit.storage.orphan_quarantine';
     public const RETENTION_CLEANUP = 'audit.retention.cleanup';

--- a/backend/src/Service/SecurityAuditLogger.php
+++ b/backend/src/Service/SecurityAuditLogger.php
@@ -82,6 +82,7 @@ class SecurityAuditLogger
     // that commit — where the deletion events above already carry the count of
     // recipients who lost access.
     public const SHARES_CLEARED = 'audit.share.dead_records_cleared';
+    public const SHARING_CODE_ROTATED = 'audit.share.sharing_code_rotated';
     public const SHARE_CLAIM_CODE_CREATED = 'audit.share.claim_code_created';
     public const SHARE_CLAIM_CODE_REDEEMED = 'audit.share.claim_code_redeemed';
     public const SHARE_CLAIM_CODE_REVOKED = 'audit.share.claim_code_revoked';

--- a/backend/src/Service/ShareClaimCodeService.php
+++ b/backend/src/Service/ShareClaimCodeService.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Comic;
+use App\Entity\ComicShare;
+use App\Entity\ShareClaimCode;
+use App\Entity\User;
+use App\Repository\ComicShareRepository;
+use App\Repository\ShareClaimCodeRepository;
+use App\Security\Voter\ComicVoter;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * Codes an owner hands out so somebody can come and get the comics behind them.
+ *
+ * The other half of the sharing-code story. A receiver code says "this is me";
+ * this says "these are mine, take them" — for the case where the owner does not
+ * know, and should not have to ask for, the other person's address.
+ *
+ * The code is a capability, so the guard rails are on the code and not on the
+ * access it produces:
+ *
+ * - it is stored as a hash, so a database leak yields nothing redeemable
+ * - it dies in a day, because a code pasted into a group chat is out of its
+ *   owner's hands the moment it is sent
+ * - it is spent as it is used, between one and ten times, so the owner decides
+ *   up front how far it may travel, and
+ * - it grants nothing on its own. Redeeming requires being signed in, and
+ *   produces the same ordinary {@see ComicShare} an emailed invitation would
+ *
+ * That last point is the important one. Nothing downstream of redemption knows
+ * or cares that a code was involved: the 18+ gate, revocation, tombstones and
+ * the recipient's own housekeeping all behave exactly as they always have.
+ */
+final class ShareClaimCodeService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ShareClaimCodeRepository $claimCodeRepository,
+        private readonly ComicShareRepository $shareRepository,
+        private readonly ComicShareService $shareService,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly SecurityAuditLogger $auditLogger,
+        private readonly SharingCodeService $sharingCodes,
+        private readonly RateLimiterFactory $shareClaimCodeLimiter,
+    ) {
+    }
+
+    /**
+     * Mint a code for comics this owner may share.
+     *
+     * @param list<int> $comicIds
+     *
+     * @return array{code: ShareClaimCode, plaintext: string}
+     *
+     * @throws ShareException
+     */
+    public function issue(
+        array $comicIds,
+        User $owner,
+        int $maxUses,
+        bool $senderResponsibilityAccepted
+    ): array {
+        if (!$senderResponsibilityAccepted) {
+            throw new ShareException(
+                'You must acknowledge responsibility for the content you share.',
+                400,
+                ShareException::CODE_RESPONSIBILITY_REQUIRED
+            );
+        }
+
+        if (!ShareClaimCode::isUsableCount($maxUses)) {
+            throw new ShareException(
+                sprintf(
+                    'A code can be used between %d and %d times.',
+                    ShareClaimCode::MIN_USES,
+                    ShareClaimCode::MAX_USES
+                ),
+                400
+            );
+        }
+
+        $comics = [];
+        foreach (array_unique($comicIds) as $comicId) {
+            $comic = $this->entityManager->getRepository(Comic::class)->find($comicId);
+
+            // Same silence as the bulk invitation endpoint: a comic that is
+            // missing and a comic belonging to somebody else are one answer, so
+            // this cannot be used to find out which ids exist.
+            if (!$comic instanceof Comic || !$this->authorizationChecker->isGranted(ComicVoter::SHARE, $comic)) {
+                throw new ShareException('One or more of those comics is not available to share.', 403);
+            }
+
+            $comics[] = $comic;
+        }
+
+        if ($comics === []) {
+            throw new ShareException('Select at least one comic to share.', 400);
+        }
+
+        if (count($comics) > SharingWorkflowService::MAX_BULK_COMICS) {
+            throw new ShareException(
+                sprintf('A code can carry at most %d comics.', SharingWorkflowService::MAX_BULK_COMICS),
+                400
+            );
+        }
+
+        // Claimed before the code exists, so a refused request leaves nothing
+        // behind. Creating a code sends no mail, which is why this is its own
+        // allowance rather than the invitation limiter's.
+        $this->reserveIssueAllowance($owner);
+
+        $plaintext = SharingCodeFormat::generate();
+        $code = new ShareClaimCode(
+            $owner,
+            SharingCodeFormat::hash($plaintext),
+            $comics,
+            $maxUses,
+            ShareClaimCode::expiry()
+        );
+
+        $this->entityManager->persist($code);
+        $this->entityManager->flush();
+
+        $this->auditLogger->audit(SecurityAuditLogger::SHARE_CLAIM_CODE_CREATED, [
+            'actor_user_id' => $owner->getId(),
+            'target_type' => 'share_claim_code',
+            'target_id' => $code->getId(),
+            // Ids and counts only. The plaintext is never written anywhere, and
+            // the title of an explicit comic is the thing the gate withholds.
+            'comic_ids' => array_map(static fn (Comic $comic): ?int => $comic->getId(), $comics),
+            'max_uses' => $maxUses,
+            'expires_at' => $code->getExpiresAt()->format(DATE_ATOM),
+        ]);
+
+        return ['code' => $code, 'plaintext' => $plaintext];
+    }
+
+    /**
+     * Turn a code somebody was given into invitations addressed to them.
+     *
+     * A use is spent whether or not every comic on the code was still available
+     * to this person: they consumed the offer, and a code that could be probed
+     * for free would tell somebody which comics they already have.
+     *
+     * @return array{results: list<array<string, mixed>>, claimed: int, ownerName: string}
+     *
+     * @throws ShareException
+     */
+    public function redeem(string $plaintext, User $redeemer): array
+    {
+        $code = $this->claimCodeRepository->findByPlaintext($plaintext);
+
+        // One answer for a code that never existed, one that has been revoked,
+        // one that ran out and one that expired. Telling them apart would say
+        // whether a guess had ever been a real code.
+        if ($code === null || !$code->isRedeemable()) {
+            $this->rejectRedemption($redeemer, $code?->getId());
+        }
+
+        $owner = $code->getOwner();
+
+        if ($owner === null || $owner->getId() === $redeemer->getId()) {
+            // Redeeming your own code is not an attack, and saying so plainly
+            // reveals nothing the holder does not already know.
+            throw new ShareException('This is your own sharing code.', 409);
+        }
+
+        $results = [];
+        $claimed = 0;
+
+        foreach ($code->getComics() as $comic) {
+            $comicId = (int) $comic->getId();
+
+            $existing = $this->shareRepository->findForComicAndRecipient(
+                $comic,
+                ComicShare::normaliseEmail((string) $redeemer->getEmail())
+            );
+
+            if ($existing !== null && ($existing->getStatus() === ComicShare::STATUS_ACCEPTED || $existing->isPending())) {
+                $results[] = [
+                    'comicId' => $comicId,
+                    'status' => 'already_yours',
+                    'message' => 'You already have this comic.',
+                ];
+                continue;
+            }
+
+            $share = $existing ?? new ComicShare($comic, $owner, (string) $redeemer->getEmail());
+            if ($existing === null) {
+                $this->entityManager->persist($share);
+            } else {
+                $share->setOwner($owner)->refreshSnapshots()->resetAdultConfirmation();
+            }
+
+            // The *code* expires in a day; the relationship it produces does
+            // not inherit that. An explicit comic left pending behind the age
+            // gate gets the same two months any other invitation would, because
+            // the recipient answering it is a separate act from the redemption.
+            $share->markPending(new \DateTimeImmutable(ComicShareService::INVITATION_TTL))->refreshSnapshots();
+            // The owner's acknowledgement travels with the code rather than
+            // being asked for again: they made it when they created the offer,
+            // and the person redeeming is not the sender.
+            $share->acceptSenderResponsibility();
+
+            // Redeeming is the recipient's own deliberate act, so it stands in
+            // for accepting an invitation — with one exception this cannot wave
+            // through. An explicit comic is left pending so it is answered
+            // behind the age gate on the Sharing page, exactly as an emailed
+            // invitation would be. Decided before the share is accepted rather
+            // than undone afterwards, so there is no moment where an
+            // unconfirmed recipient holds an accepted share.
+            if ($share->requiresAdultConfirmation()) {
+                $results[] = [
+                    'comicId' => $comicId,
+                    'status' => 'awaiting_age_confirmation',
+                    'message' => 'Confirm your age on the Sharing page to open this one.',
+                ];
+            } else {
+                $share->markAccepted($redeemer);
+                $results[] = ['comicId' => $comicId, 'status' => 'claimed'];
+            }
+
+            ++$claimed;
+        }
+
+        $code->spendUse();
+        $this->entityManager->flush();
+
+        $this->auditLogger->audit(SecurityAuditLogger::SHARE_CLAIM_CODE_REDEEMED, [
+            'actor_user_id' => $redeemer->getId(),
+            'target_type' => 'share_claim_code',
+            'target_id' => $code->getId(),
+            'owner_user_id' => $owner->getId(),
+            'claimed' => $claimed,
+            'uses_remaining' => $code->getUsesRemaining(),
+        ]);
+
+        return [
+            'results' => $results,
+            'claimed' => $claimed,
+            'ownerName' => $owner->getName() ?: 'A Panel Page Flip reader',
+        ];
+    }
+
+    /** @return list<ShareClaimCode> */
+    public function liveCodesFor(User $owner): array
+    {
+        return $this->claimCodeRepository->findLiveForOwner($owner);
+    }
+
+    /**
+     * Withdraw a code. The shares it already produced are untouched — they are
+     * ordinary relationships now, revoked from the Sharing page like any other.
+     *
+     * @throws ShareException
+     */
+    public function revoke(int $codeId, User $owner): void
+    {
+        $code = $this->claimCodeRepository->find($codeId);
+
+        // Reported as missing rather than forbidden, so somebody cannot learn
+        // that an id belongs to somebody else's code.
+        if ($code === null || $code->getOwner()?->getId() !== $owner->getId()) {
+            throw new ShareException('That sharing code was not found.', 404);
+        }
+
+        $code->revoke();
+        $this->entityManager->flush();
+
+        $this->auditLogger->audit(SecurityAuditLogger::SHARE_CLAIM_CODE_REVOKED, [
+            'actor_user_id' => $owner->getId(),
+            'target_type' => 'share_claim_code',
+            'target_id' => $code->getId(),
+        ]);
+    }
+
+    /**
+     * @throws ShareException
+     */
+    private function reserveIssueAllowance(User $owner): void
+    {
+        $limit = $this->shareClaimCodeLimiter->create((string) $owner->getId())->consume();
+
+        if ($limit->isAccepted()) {
+            return;
+        }
+
+        $retryAfter = max(1, $limit->getRetryAfter()->getTimestamp() - time());
+
+        throw new ShareException(
+            sprintf(
+                'You have created too many sharing codes recently. Please try again in %d minute(s).',
+                (int) ceil($retryAfter / 60)
+            ),
+            429
+        );
+    }
+
+    /**
+     * @throws ShareException always
+     */
+    private function rejectRedemption(User $redeemer, ?int $codeId): never
+    {
+        // Charged against the same allowance a mistyped receiver code is, so
+        // redemption cannot be used to work through the keyspace either. The
+        // throw it raises when the allowance runs out is a 429, which is a
+        // truthful answer and still says nothing about the code that was tried.
+        $this->sharingCodes->resolve('', $redeemer);
+
+        $this->auditLogger->suspicious(
+            SecurityAuditLogger::SHARE_CLAIM_CODE_REJECTED,
+            'user:' . $redeemer->getId(),
+            [
+                'actor_user_id' => $redeemer->getId(),
+                'target_type' => 'share_claim_code',
+                'target_id' => $codeId,
+            ],
+            10
+        );
+
+        throw new ShareException('That sharing code is not valid, or has already been used up.', 404);
+    }
+}

--- a/backend/src/Service/ShareClaimCodeService.php
+++ b/backend/src/Service/ShareClaimCodeService.php
@@ -314,13 +314,54 @@ final class ShareClaimCodeService
             throw new ShareException('That sharing code was not found.', 404);
         }
 
+        $this->withdraw($code, $owner);
+    }
+
+    /**
+     * Withdraw somebody else's code, as an administrator.
+     *
+     * The reasons are operational rather than the owner changing their mind: an
+     * abuse report, a code posted publicly, a compromised account. It stops the
+     * code and nothing else — the shares already made through it stay exactly
+     * as they are, which is the same rule that applies when the owner withdraws
+     * it themselves. Taking those away would be moderation of the comics, which
+     * is a different decision with a different surface.
+     *
+     * @throws ShareException
+     */
+    public function revokeAsAdministrator(int $codeId, User $admin): ShareClaimCode
+    {
+        $code = $this->claimCodeRepository->find($codeId);
+
+        if ($code === null) {
+            throw new ShareException('That sharing code was not found.', 404);
+        }
+
+        $this->withdraw($code, $admin);
+
+        return $code;
+    }
+
+    /**
+     * The lifecycle rule itself, wherever the request came from.
+     *
+     * Both callers land here so an administrative path cannot grow its own idea
+     * of what withdrawing means.
+     */
+    private function withdraw(ShareClaimCode $code, User $actor): void
+    {
+        $ownerId = $code->getOwner()?->getId();
+        $byAdmin = $ownerId !== $actor->getId();
+
         $code->revoke();
         $this->entityManager->flush();
 
         $this->auditLogger->audit(SecurityAuditLogger::SHARE_CLAIM_CODE_REVOKED, [
-            'actor_user_id' => $owner->getId(),
+            'actor_user_id' => $actor->getId(),
             'target_type' => 'share_claim_code',
             'target_id' => $code->getId(),
+            'owner_user_id' => $ownerId,
+            'by_admin' => $byAdmin,
         ]);
     }
 

--- a/backend/src/Service/ShareClaimCodeService.php
+++ b/backend/src/Service/ShareClaimCodeService.php
@@ -3,12 +3,11 @@
 namespace App\Service;
 
 use App\Entity\Comic;
-use App\Entity\ComicShare;
 use App\Entity\ShareClaimCode;
+use App\Entity\ShareClaimCodeRedemption;
 use App\Entity\User;
-use App\Repository\ComicShareRepository;
+use App\Repository\ShareClaimCodeRedemptionRepository;
 use App\Repository\ShareClaimCodeRepository;
-use App\Repository\UserRepository;
 use App\Security\Voter\ComicVoter;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\LockMode;
@@ -43,8 +42,7 @@ final class ShareClaimCodeService
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly ShareClaimCodeRepository $claimCodeRepository,
-        private readonly ComicShareRepository $shareRepository,
-        private readonly UserRepository $userRepository,
+        private readonly ShareClaimCodeRedemptionRepository $redemptionRepository,
         private readonly ComicShareService $shareService,
         private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly SecurityAuditLogger $auditLogger,
@@ -121,7 +119,9 @@ final class ShareClaimCodeService
         // allowance rather than the invitation limiter's.
         $this->reserveIssueAllowance($owner);
 
-        $plaintext = $this->mintUniqueCode();
+        // Both kinds of code come out of the same allocator, so one visible
+        // code always means one thing.
+        $plaintext = $this->sharingCodes->allocateUniqueCode();
         $code = new ShareClaimCode(
             $owner,
             SharingCodeFormat::hash($plaintext),
@@ -234,65 +234,44 @@ final class ShareClaimCodeService
             throw new ShareException('This is your own sharing code.', 409);
         }
 
+        // One account, at most one use. Without this a recipient could submit
+        // the same code ten times and exhaust an offer advertised to ten
+        // people — and the owner's "claimed 10 of 10" would be counting
+        // requests rather than the audience it says it counts.
+        $alreadyRedeemed = $this->redemptionRepository->findFor($code, $redeemer) !== null;
+
         $results = [];
         $claimed = 0;
 
         foreach ($code->getComics() as $comic) {
-            $comicId = (int) $comic->getId();
-
-            $existing = $this->shareRepository->findForComicAndRecipient(
+            // The share lifecycle belongs to ComicShareService, wherever a
+            // share comes from. A transport that grew its own copy of these
+            // transitions would drift from the canonical rules.
+            $outcome = $this->shareService->claimFromCode(
                 $comic,
-                ComicShare::normaliseEmail((string) $redeemer->getEmail())
+                $owner,
+                $redeemer,
+                // The owner acknowledged responsibility when they created the
+                // code, not now — and the field this lands in is the canonical
+                // evidence of when they did.
+                $code->getSenderResponsibilityAcceptedAt()
             );
 
-            if ($existing !== null && ($existing->getStatus() === ComicShare::STATUS_ACCEPTED || $existing->isPending())) {
-                $results[] = [
-                    'comicId' => $comicId,
-                    'status' => 'already_yours',
-                    'message' => 'You already have this comic.',
-                ];
-                continue;
+            $results[] = ['comicId' => (int) $comic->getId()] + $outcome;
+
+            if ($outcome['status'] !== 'already_yours') {
+                ++$claimed;
             }
-
-            $share = $existing ?? new ComicShare($comic, $owner, (string) $redeemer->getEmail());
-            if ($existing === null) {
-                $this->entityManager->persist($share);
-            } else {
-                $share->setOwner($owner)->refreshSnapshots()->resetAdultConfirmation();
-            }
-
-            // The *code* expires in a day; the relationship it produces does
-            // not inherit that. An explicit comic left pending behind the age
-            // gate gets the same two months any other invitation would, because
-            // the recipient answering it is a separate act from the redemption.
-            $share->markPending(new \DateTimeImmutable(ComicShareService::INVITATION_TTL))->refreshSnapshots();
-            // The owner's acknowledgement travels with the code rather than
-            // being asked for again: they made it when they created the offer,
-            // and the person redeeming is not the sender.
-            $share->acceptSenderResponsibility();
-
-            // Redeeming is the recipient's own deliberate act, so it stands in
-            // for accepting an invitation — with one exception this cannot wave
-            // through. An explicit comic is left pending so it is answered
-            // behind the age gate on the Sharing page, exactly as an emailed
-            // invitation would be. Decided before the share is accepted rather
-            // than undone afterwards, so there is no moment where an
-            // unconfirmed recipient holds an accepted share.
-            if ($share->requiresAdultConfirmation()) {
-                $results[] = [
-                    'comicId' => $comicId,
-                    'status' => 'awaiting_age_confirmation',
-                    'message' => 'Confirm your age on the Sharing page to open this one.',
-                ];
-            } else {
-                $share->markAccepted($redeemer);
-                $results[] = ['comicId' => $comicId, 'status' => 'claimed'];
-            }
-
-            ++$claimed;
         }
 
-        $code->spendUse();
+        // Spent only for an account that did not already hold a use. Repeating
+        // the same redemption is idempotent: it re-reports what they have and
+        // takes nothing from anybody else.
+        if (!$alreadyRedeemed) {
+            $this->entityManager->persist(new ShareClaimCodeRedemption($code, $redeemer));
+            $code->spendUse();
+        }
+
         $this->entityManager->flush();
 
         $this->auditLogger->audit(SecurityAuditLogger::SHARE_CLAIM_CODE_REDEEMED, [
@@ -301,43 +280,16 @@ final class ShareClaimCodeService
             'target_id' => $code->getId(),
             'owner_user_id' => $owner->getId(),
             'claimed' => $claimed,
+            'repeat' => $alreadyRedeemed,
             'uses_remaining' => $code->getUsesRemaining(),
         ]);
 
         return [
             'results' => $results,
             'claimed' => $claimed,
+            'alreadyRedeemed' => $alreadyRedeemed,
             'ownerName' => $owner->getName() ?: 'A Panel Page Flip reader',
         ];
-    }
-
-    /**
-     * A code no other code is using, of either kind.
-     *
-     * The unique index on `code_hash` already makes two claim codes impossible;
-     * this makes the guarantee whole. A claim code and a receiver code are
-     * pasted into different fields and could not actually be confused, but
-     * "your code is yours" is a rule that is much easier to trust when it has
-     * no exceptions, and one extra indexed lookup is a cheap way to have none.
-     *
-     * @throws ShareException when no free code turns up, which should not happen
-     */
-    private function mintUniqueCode(): string
-    {
-        for ($attempt = 0; $attempt < 5; ++$attempt) {
-            $candidate = SharingCodeFormat::generate();
-
-            $takenByClaimCode = $this->claimCodeRepository
-                ->findOneBy(['codeHash' => SharingCodeFormat::hash($candidate)]) !== null;
-            $takenByReceiver = $this->userRepository
-                ->findOneBy(['sharingCode' => $candidate]) !== null;
-
-            if (!$takenByClaimCode && !$takenByReceiver) {
-                return $candidate;
-            }
-        }
-
-        throw new ShareException('A sharing code could not be created. Please try again.', 500);
     }
 
     /** @return list<ShareClaimCode> */

--- a/backend/src/Service/ShareClaimCodeService.php
+++ b/backend/src/Service/ShareClaimCodeService.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Repository\ComicShareRepository;
 use App\Repository\ShareClaimCodeRepository;
 use App\Security\Voter\ComicVoter;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -83,8 +84,19 @@ final class ShareClaimCodeService
             );
         }
 
+        $ids = array_unique($comicIds);
+
+        // Before the lookups, not after, so an oversized request does not do
+        // hundreds of queries on its way to being refused.
+        if (count($ids) > SharingWorkflowService::MAX_BULK_COMICS) {
+            throw new ShareException(
+                sprintf('A code can carry at most %d comics.', SharingWorkflowService::MAX_BULK_COMICS),
+                400
+            );
+        }
+
         $comics = [];
-        foreach (array_unique($comicIds) as $comicId) {
+        foreach ($ids as $comicId) {
             $comic = $this->entityManager->getRepository(Comic::class)->find($comicId);
 
             // Same silence as the bulk invitation endpoint: a comic that is
@@ -99,13 +111,6 @@ final class ShareClaimCodeService
 
         if ($comics === []) {
             throw new ShareException('Select at least one comic to share.', 400);
-        }
-
-        if (count($comics) > SharingWorkflowService::MAX_BULK_COMICS) {
-            throw new ShareException(
-                sprintf('A code can carry at most %d comics.', SharingWorkflowService::MAX_BULK_COMICS),
-                400
-            );
         }
 
         // Claimed before the code exists, so a refused request leaves nothing
@@ -154,11 +159,59 @@ final class ShareClaimCodeService
     {
         $code = $this->claimCodeRepository->findByPlaintext($plaintext);
 
+        if ($code === null) {
+            $this->rejectRedemption($redeemer, null);
+        }
+
+        // Everything from here is one unit of work, and the row is locked
+        // before its remaining uses are read. "Check the count, then decrement
+        // it" is a read followed by a write: two redemptions arriving together
+        // both see the last use, both create shares, and both write zero — so a
+        // one-use code would let two people in, which is the single guarantee
+        // the count exists to make.
+        $connection = $this->entityManager->getConnection();
+        $ownsTransaction = !$connection->isTransactionActive();
+
+        try {
+            if ($ownsTransaction) {
+                $this->entityManager->beginTransaction();
+            }
+
+            $result = $this->redeemLocked($code, $redeemer);
+
+            if ($ownsTransaction) {
+                $this->entityManager->commit();
+            }
+
+            return $result;
+        } catch (\Throwable $exception) {
+            if ($ownsTransaction && $connection->isTransactionActive()) {
+                $this->entityManager->rollback();
+            }
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * The redemption itself, with the caller holding the transaction.
+     *
+     * @return array{results: list<array<string, mixed>>, claimed: int, ownerName: string}
+     *
+     * @throws ShareException
+     */
+    private function redeemLocked(ShareClaimCode $code, User $redeemer): array
+    {
+        $this->entityManager->lock($code, LockMode::PESSIMISTIC_WRITE);
+        // Re-read behind the lock, so the count this decision is made on is the
+        // committed one rather than whatever was loaded before the wait.
+        $this->entityManager->refresh($code);
+
         // One answer for a code that never existed, one that has been revoked,
         // one that ran out and one that expired. Telling them apart would say
         // whether a guess had ever been a real code.
-        if ($code === null || !$code->isRedeemable()) {
-            $this->rejectRedemption($redeemer, $code?->getId());
+        if (!$code->isRedeemable()) {
+            $this->rejectRedemption($redeemer, $code->getId());
         }
 
         $owner = $code->getOwner();

--- a/backend/src/Service/ShareClaimCodeService.php
+++ b/backend/src/Service/ShareClaimCodeService.php
@@ -8,7 +8,9 @@ use App\Entity\ShareClaimCode;
 use App\Entity\User;
 use App\Repository\ComicShareRepository;
 use App\Repository\ShareClaimCodeRepository;
+use App\Repository\UserRepository;
 use App\Security\Voter\ComicVoter;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
@@ -42,6 +44,7 @@ final class ShareClaimCodeService
         private readonly EntityManagerInterface $entityManager,
         private readonly ShareClaimCodeRepository $claimCodeRepository,
         private readonly ComicShareRepository $shareRepository,
+        private readonly UserRepository $userRepository,
         private readonly ComicShareService $shareService,
         private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly SecurityAuditLogger $auditLogger,
@@ -118,7 +121,7 @@ final class ShareClaimCodeService
         // allowance rather than the invitation limiter's.
         $this->reserveIssueAllowance($owner);
 
-        $plaintext = SharingCodeFormat::generate();
+        $plaintext = $this->mintUniqueCode();
         $code = new ShareClaimCode(
             $owner,
             SharingCodeFormat::hash($plaintext),
@@ -128,7 +131,16 @@ final class ShareClaimCodeService
         );
 
         $this->entityManager->persist($code);
-        $this->entityManager->flush();
+
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException) {
+            // The index is the authority, and it has just refused a code that
+            // was free when it was checked. At sixty bits that is not worth a
+            // recovery path — and there is no manager left to retry through,
+            // because Doctrine closes it when a flush raises this.
+            throw new ShareException('A sharing code could not be created. Please try again.', 500);
+        }
 
         $this->auditLogger->audit(SecurityAuditLogger::SHARE_CLAIM_CODE_CREATED, [
             'actor_user_id' => $owner->getId(),
@@ -299,10 +311,39 @@ final class ShareClaimCodeService
         ];
     }
 
-    /** @return list<ShareClaimCode> */
-    public function liveCodesFor(User $owner): array
+    /**
+     * A code no other code is using, of either kind.
+     *
+     * The unique index on `code_hash` already makes two claim codes impossible;
+     * this makes the guarantee whole. A claim code and a receiver code are
+     * pasted into different fields and could not actually be confused, but
+     * "your code is yours" is a rule that is much easier to trust when it has
+     * no exceptions, and one extra indexed lookup is a cheap way to have none.
+     *
+     * @throws ShareException when no free code turns up, which should not happen
+     */
+    private function mintUniqueCode(): string
     {
-        return $this->claimCodeRepository->findLiveForOwner($owner);
+        for ($attempt = 0; $attempt < 5; ++$attempt) {
+            $candidate = SharingCodeFormat::generate();
+
+            $takenByClaimCode = $this->claimCodeRepository
+                ->findOneBy(['codeHash' => SharingCodeFormat::hash($candidate)]) !== null;
+            $takenByReceiver = $this->userRepository
+                ->findOneBy(['sharingCode' => $candidate]) !== null;
+
+            if (!$takenByClaimCode && !$takenByReceiver) {
+                return $candidate;
+            }
+        }
+
+        throw new ShareException('A sharing code could not be created. Please try again.', 500);
+    }
+
+    /** @return list<ShareClaimCode> */
+    public function codesFor(User $owner): array
+    {
+        return $this->claimCodeRepository->findForOwner($owner);
     }
 
     /**

--- a/backend/src/Service/SharingCodeFormat.php
+++ b/backend/src/Service/SharingCodeFormat.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * The shape of every sharing code, and the only place that decides it.
+ *
+ * Two different things are written in this format — the permanent receiver code
+ * that identifies somebody as a recipient, and the disposable claim code that
+ * hands out a comic — because a person copying one out of a chat window should
+ * not have to know which kind they were given. What they mean is decided by the
+ * field they are pasted into; this only decides what they look like.
+ *
+ * Crockford's alphabet, so a code read off a screen and typed into a phone
+ * survives the trip: no I, L, O or U, and the pairs people confuse anyway are
+ * folded back on the way in. Twelve characters is a little over 60 bits, which
+ * is far past guessable and still short enough to read aloud.
+ */
+final class SharingCodeFormat
+{
+    /** Crockford base32: no I, L, O or U, so nothing reads as something else. */
+    public const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+    /** Characters in a code, excluding the grouping dashes. */
+    public const LENGTH = 12;
+
+    private const GROUP = 4;
+
+    /** A new random code, already normalised. */
+    public static function generate(): string
+    {
+        $alphabet = self::ALPHABET;
+        $max = strlen($alphabet) - 1;
+        $code = '';
+
+        for ($i = 0; $i < self::LENGTH; ++$i) {
+            $code .= $alphabet[random_int(0, $max)];
+        }
+
+        return $code;
+    }
+
+    /**
+     * What somebody typed, reduced to the one form everything else compares.
+     *
+     * Lowercase, spaces, missing dashes and the characters the alphabet leaves
+     * out are all somebody transcribing a code by hand rather than somebody
+     * holding the wrong one, so they are corrected instead of rejected.
+     *
+     * @return string the normalised code, or '' when it cannot be one
+     */
+    public static function normalise(string $input): string
+    {
+        $candidate = strtoupper(preg_replace('/[^A-Za-z0-9]/', '', $input) ?? '');
+        $candidate = strtr($candidate, ['I' => '1', 'L' => '1', 'O' => '0', 'U' => 'V']);
+
+        if (strlen($candidate) !== self::LENGTH) {
+            return '';
+        }
+
+        return strspn($candidate, self::ALPHABET) === self::LENGTH ? $candidate : '';
+    }
+
+    public static function isValid(string $input): bool
+    {
+        return self::normalise($input) !== '';
+    }
+
+    /** The grouped form, which is the only form a person is ever shown. */
+    public static function forDisplay(string $normalised): string
+    {
+        return implode('-', str_split($normalised, self::GROUP));
+    }
+
+    /**
+     * The stored form of a claim code.
+     *
+     * Claim codes are hashed because they carry a capability, exactly like an
+     * invitation token: the plaintext exists once, in the message the owner
+     * sends, and nothing here can reproduce it afterwards. Receiver codes are
+     * stored in the clear instead — they are an address, they grant nothing,
+     * and their owner has to be able to look them up again.
+     *
+     * A raw 60-bit code needs no work factor: there is no dictionary to slow an
+     * attacker down through, and redemption is rate limited besides.
+     */
+    public static function hash(string $normalised): string
+    {
+        return hash('sha256', $normalised);
+    }
+}

--- a/backend/src/Service/SharingCodeRecipient.php
+++ b/backend/src/Service/SharingCodeRecipient.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * A recipient the sender reached by code rather than by address.
+ *
+ * Carries only what the recipient published when they handed their code out:
+ * the code itself and the name shown beside it. The address the invitation is
+ * actually addressed to travels separately and never reaches the sender.
+ */
+// Individually readonly rather than a readonly class, for the 8.1 floor
+// composer declares. Same reasoning as {@see IssuedInvitation}.
+final class SharingCodeRecipient
+{
+    public function __construct(
+        public readonly string $sharingCode,
+        public readonly ?string $name,
+    ) {
+    }
+}

--- a/backend/src/Service/SharingCodeRecipient.php
+++ b/backend/src/Service/SharingCodeRecipient.php
@@ -2,18 +2,26 @@
 
 namespace App\Service;
 
+use App\Entity\User;
+
 /**
  * A recipient the sender reached by code rather than by address.
  *
- * Carries only what the recipient published when they handed their code out:
- * the code itself and the name shown beside it. The address the invitation is
- * actually addressed to travels separately and never reaches the sender.
+ * Carries the account itself, so the share can record *who* it is for and not
+ * only what they were called at the time. That matters because a receiver code
+ * can be rotated: the code stored on a share is a note about how the
+ * relationship began, and anything that needs the recipient's current handle
+ * has to go through the account to find it.
+ *
+ * The address the invitation is actually addressed to travels separately and
+ * never reaches the sender.
  */
 // Individually readonly rather than a readonly class, for the 8.1 floor
 // composer declares. Same reasoning as {@see IssuedInvitation}.
 final class SharingCodeRecipient
 {
     public function __construct(
+        public readonly User $user,
         public readonly string $sharingCode,
         public readonly ?string $name,
     ) {

--- a/backend/src/Service/SharingCodeService.php
+++ b/backend/src/Service/SharingCodeService.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+/**
+ * The permanent code somebody hands out so that others can share with them.
+ *
+ * This is the one place that turns a code back into a person, and it is
+ * deliberately narrow about what that means. Resolving a code answers exactly
+ * one question — "who should this invitation be addressed to?" — and hands back
+ * only the display name that person publishes along with the code itself. It is
+ * not a login, not a lookup by email, and not a way to ask whether an address
+ * has an account behind it.
+ *
+ * It is also the only enumeration surface the sharing feature has, so it is
+ * built to be a bad one: sixty bits of entropy, a single generic answer for
+ * every code that does not resolve, and an hourly ceiling on how many a caller
+ * may try.
+ */
+final class SharingCodeService
+{
+    /**
+     * How many failed lookups an account may make in the limiter's window.
+     *
+     * Sized for somebody mistyping a code a few times, not for somebody working
+     * through the keyspace. At sixty bits, an attacker allowed this many
+     * guesses an hour is still not finishing before the heat death of anything.
+     */
+    public const LOOKUP_ATTEMPTS = 20;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
+        private readonly SecurityAuditLogger $auditLogger,
+        private readonly RateLimiterFactory $sharingCodeLookupLimiter,
+    ) {
+    }
+
+    /**
+     * This account's code, issuing one the first time it is asked for.
+     *
+     * Lazy rather than backfilled by the migration: filling in every existing
+     * account at once means generating a unique value per row inside a
+     * migration that runs against a live installation, and there is no need —
+     * a code that nobody has asked for is a code nobody is holding.
+     *
+     * Whatever it returns is permanent from that moment. Nothing here, and
+     * nothing anywhere else, replaces an existing one.
+     */
+    public function codeFor(User $user): string
+    {
+        $existing = $user->getSharingCode();
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        // Retried rather than trusted: the unique index is the authority on
+        // collisions, and at sixty bits a second attempt is already
+        // vanishingly unlikely to be needed.
+        for ($attempt = 0; $attempt < 5; ++$attempt) {
+            $candidate = SharingCodeFormat::generate();
+
+            if ($this->userRepository->findOneBy(['sharingCode' => $candidate]) !== null) {
+                continue;
+            }
+
+            $user->assignSharingCode($candidate);
+
+            try {
+                $this->entityManager->flush();
+
+                return $candidate;
+            } catch (UniqueConstraintViolationException) {
+                // Somebody else took it between the check and the write. The
+                // in-memory value has to go back to null before the next try,
+                // and assignSharingCode deliberately refuses to overwrite.
+                $this->entityManager->refresh($user);
+            }
+        }
+
+        throw new ShareException('A sharing code could not be issued. Please try again.', 500);
+    }
+
+    /**
+     * Who a code belongs to, or null.
+     *
+     * The caller is charged for a lookup that finds nothing and not for one that
+     * succeeds, so ordinary use never runs into the limit and grinding through
+     * candidates does.
+     *
+     * @throws ShareException when the caller has spent their allowance
+     */
+    public function resolve(string $input, User $caller): ?User
+    {
+        $normalised = SharingCodeFormat::normalise($input);
+
+        $recipient = $normalised === ''
+            ? null
+            : $this->userRepository->findOneBy(['sharingCode' => $normalised]);
+
+        if ($recipient !== null) {
+            return $recipient;
+        }
+
+        $this->chargeFailedLookup($caller);
+
+        return null;
+    }
+
+    /**
+     * What a sender is shown once a code resolves.
+     *
+     * The display name and the code they already typed, and nothing else — not
+     * the address, not the id, not whether the account is verified, active or
+     * an administrator. Somebody holding a code is entitled to know they have
+     * reached the right person, which is what a name answers; everything past
+     * that is the account's business.
+     *
+     * @return array{name: string, sharingCode: string}
+     */
+    public function describe(User $recipient): array
+    {
+        return [
+            'name' => $recipient->getName() ?: 'A Panel Page Flip reader',
+            'sharingCode' => SharingCodeFormat::forDisplay((string) $recipient->getSharingCode()),
+        ];
+    }
+
+    /**
+     * @throws ShareException
+     */
+    private function chargeFailedLookup(User $caller): void
+    {
+        $limit = $this->sharingCodeLookupLimiter->create((string) $caller->getId())->consume();
+
+        if ($limit->isAccepted()) {
+            return;
+        }
+
+        // Ordinary use does not reach this: a code is copied and pasted, and
+        // the few that are mistyped are corrected on the next try. An account
+        // that exhausts the allowance is working through candidates, which is
+        // the one thing this surface exists to be bad at.
+        $this->auditLogger->suspicious(
+            SecurityAuditLogger::SHARING_CODE_ENUMERATION_ATTEMPT,
+            'user:' . $caller->getId(),
+            [
+                'actor_user_id' => $caller->getId(),
+                'target_type' => 'sharing_code',
+            ],
+            1
+        );
+
+        $retryAfter = max(1, $limit->getRetryAfter()->getTimestamp() - time());
+
+        throw new ShareException(
+            sprintf(
+                'Too many sharing codes have been tried. Please try again in %d minute(s).',
+                (int) ceil($retryAfter / 60)
+            ),
+            429
+        );
+    }
+}

--- a/backend/src/Service/SharingCodeService.php
+++ b/backend/src/Service/SharingCodeService.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\User;
+use App\Repository\ShareClaimCodeRepository;
 use App\Repository\UserRepository;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
@@ -37,8 +38,10 @@ final class SharingCodeService
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly UserRepository $userRepository,
+        private readonly ShareClaimCodeRepository $claimCodeRepository,
         private readonly SecurityAuditLogger $auditLogger,
         private readonly RateLimiterFactory $sharingCodeLookupLimiter,
+        private readonly RateLimiterFactory $sharingCodeRotationLimiter,
     ) {
     }
 
@@ -60,30 +63,102 @@ final class SharingCodeService
             return $existing;
         }
 
-        // Candidates are checked against the index before one is kept, and the
-        // search for a free one is where the retrying belongs. The write itself
-        // is attempted once: Doctrine closes the EntityManager when a flush
-        // raises a constraint violation, so there is no manager left to retry
-        // with — refreshing or re-reading through it would only fail again with
-        // a less useful error. At sixty bits, losing the race between the check
-        // and the write is not something worth building a recovery path for;
-        // the caller retries by asking again on the next request.
-        $candidate = null;
-        for ($attempt = 0; $attempt < 5; ++$attempt) {
-            $generated = SharingCodeFormat::generate();
+        $candidate = $this->allocateUniqueCode();
+        $user->assignSharingCode($candidate);
 
-            if ($this->userRepository->findOneBy(['sharingCode' => $generated]) === null) {
-                $candidate = $generated;
-                break;
+        return $this->persistCode($user, $candidate);
+    }
+
+    /**
+     * Retire this account's code and issue a new one.
+     *
+     * The reason receiver codes are safe to hand out at all is that they grant
+     * nothing — but a code lives in chats, forums and group threads, which is
+     * exactly where things escape from, and an identifier its owner cannot
+     * retire is one they are stuck with. This is that escape hatch.
+     *
+     * Only the identifier changes. Every share already made through the old
+     * code is a relationship, not an address, and is left exactly as it was:
+     * pending invitations stay pending, accepted ones stay accepted, and nobody
+     * loses a comic because the way they were first reached has been replaced.
+     *
+     * @param User|null $actor the administrator acting on somebody's behalf, or
+     *                         null when the owner rotates their own
+     *
+     * @throws ShareException
+     */
+    public function rotateCode(User $user, ?User $actor = null): string
+    {
+        $this->reserveRotationAllowance($actor ?? $user);
+
+        $hadCode = $user->getSharingCode() !== null;
+        $candidate = $this->allocateUniqueCode();
+        $user->replaceSharingCode($candidate);
+
+        $code = $this->persistCode($user, $candidate);
+
+        // Ids and facts only. Neither the old code nor the new one goes in the
+        // record: the log would then be the one place both live in plaintext,
+        // and an identifier somebody rotated *because* it leaked is the last
+        // thing to write down.
+        $this->auditLogger->audit(SecurityAuditLogger::SHARING_CODE_ROTATED, [
+            'actor_user_id' => ($actor ?? $user)->getId(),
+            'target_type' => 'user',
+            'target_id' => $user->getId(),
+            'by_admin' => $actor !== null && $actor->getId() !== $user->getId(),
+            'replaced_existing' => $hadCode,
+        ]);
+
+        return $code;
+    }
+
+    /**
+     * A code no other code of either kind is using.
+     *
+     * The single place either kind of sharing code is generated. Two unique
+     * indexes cannot enforce uniqueness *across* two tables, so the invariant
+     * the feature promises — one visible code means one thing — is upheld here,
+     * by checking both stores before a candidate is kept. Centralised rather
+     * than repeated because rotation makes generation something that happens
+     * often rather than once per account.
+     *
+     * At sixty bits a first candidate is essentially always free; the loop is
+     * for the case that cannot be reasoned away rather than one worth planning
+     * around.
+     *
+     * @throws ShareException when no free code turns up
+     */
+    public function allocateUniqueCode(): string
+    {
+        for ($attempt = 0; $attempt < 5; ++$attempt) {
+            $candidate = SharingCodeFormat::generate();
+
+            $taken = $this->userRepository->findOneBy(['sharingCode' => $candidate]) !== null
+                || $this->claimCodeRepository->findOneBy([
+                    'codeHash' => SharingCodeFormat::hash($candidate),
+                ]) !== null;
+
+            if (!$taken) {
+                return $candidate;
             }
         }
 
-        if ($candidate === null) {
-            throw new ShareException('A sharing code could not be issued. Please try again.', 500);
-        }
+        throw new ShareException('A sharing code could not be issued. Please try again.', 500);
+    }
 
-        $user->assignSharingCode($candidate);
-
+    /**
+     * Write the candidate, once.
+     *
+     * Doctrine closes the EntityManager when a flush raises a constraint
+     * violation, so there is no manager left to retry through — refreshing or
+     * re-reading would only fail again with a less useful error. Losing the
+     * race between the check above and this write is not worth a recovery path
+     * at sixty bits; the caller retries by asking again on the next request.
+     *
+     * @throws ShareException
+     */
+    private function persistCode(User $user, string $candidate): string
+    {
         try {
             $this->entityManager->flush();
         } catch (UniqueConstraintViolationException) {
@@ -136,6 +211,34 @@ final class SharingCodeService
             'name' => $recipient->getName() ?: 'A Panel Page Flip reader',
             'sharingCode' => SharingCodeFormat::forDisplay((string) $recipient->getSharingCode()),
         ];
+    }
+
+    /**
+     * Bound how often a code can be replaced.
+     *
+     * Rotating is cheap for the account doing it and expensive for everybody
+     * holding the old code, so this is not about load — it is about a script or
+     * a stuck retry quietly making somebody uncontactable.
+     *
+     * @throws ShareException
+     */
+    private function reserveRotationAllowance(User $actor): void
+    {
+        $limit = $this->sharingCodeRotationLimiter->create((string) $actor->getId())->consume();
+
+        if ($limit->isAccepted()) {
+            return;
+        }
+
+        $retryAfter = max(1, $limit->getRetryAfter()->getTimestamp() - time());
+
+        throw new ShareException(
+            sprintf(
+                'You have changed your sharing code too many times recently. Please try again in %d minute(s).',
+                (int) ceil($retryAfter / 60)
+            ),
+            429
+        );
     }
 
     /**

--- a/backend/src/Service/SharingCodeService.php
+++ b/backend/src/Service/SharingCodeService.php
@@ -60,31 +60,37 @@ final class SharingCodeService
             return $existing;
         }
 
-        // Retried rather than trusted: the unique index is the authority on
-        // collisions, and at sixty bits a second attempt is already
-        // vanishingly unlikely to be needed.
+        // Candidates are checked against the index before one is kept, and the
+        // search for a free one is where the retrying belongs. The write itself
+        // is attempted once: Doctrine closes the EntityManager when a flush
+        // raises a constraint violation, so there is no manager left to retry
+        // with — refreshing or re-reading through it would only fail again with
+        // a less useful error. At sixty bits, losing the race between the check
+        // and the write is not something worth building a recovery path for;
+        // the caller retries by asking again on the next request.
+        $candidate = null;
         for ($attempt = 0; $attempt < 5; ++$attempt) {
-            $candidate = SharingCodeFormat::generate();
+            $generated = SharingCodeFormat::generate();
 
-            if ($this->userRepository->findOneBy(['sharingCode' => $candidate]) !== null) {
-                continue;
-            }
-
-            $user->assignSharingCode($candidate);
-
-            try {
-                $this->entityManager->flush();
-
-                return $candidate;
-            } catch (UniqueConstraintViolationException) {
-                // Somebody else took it between the check and the write. The
-                // in-memory value has to go back to null before the next try,
-                // and assignSharingCode deliberately refuses to overwrite.
-                $this->entityManager->refresh($user);
+            if ($this->userRepository->findOneBy(['sharingCode' => $generated]) === null) {
+                $candidate = $generated;
+                break;
             }
         }
 
-        throw new ShareException('A sharing code could not be issued. Please try again.', 500);
+        if ($candidate === null) {
+            throw new ShareException('A sharing code could not be issued. Please try again.', 500);
+        }
+
+        $user->assignSharingCode($candidate);
+
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException) {
+            throw new ShareException('A sharing code could not be issued. Please try again.', 500);
+        }
+
+        return $candidate;
     }
 
     /**

--- a/backend/src/Service/SharingWorkflowService.php
+++ b/backend/src/Service/SharingWorkflowService.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Comic;
+use App\Entity\ComicShare;
+use App\Entity\User;
+use App\Security\Voter\ComicVoter;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * Convenience workflows built on top of the existing one-comic sharing model.
+ *
+ * This service deliberately does not search User. Reusable recipients come only
+ * from addresses this owner previously supplied themselves, and bulk sharing is
+ * only a coordinator around ComicShareService::invite().
+ */
+final class SharingWorkflowService
+{
+    public const MAX_BULK_COMICS = 20;
+    public const RECENT_RECIPIENT_LIMIT = 20;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ComicShareService $shareService,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+    ) {
+    }
+
+    /**
+     * Addresses this owner has already shared with, newest relationship first.
+     *
+     * No User join is allowed here: the caller learns only information they
+     * previously entered, never whether an address belongs to a registered
+     * account or anything about that account.
+     *
+     * @return list<array{email: string}>
+     */
+    public function recentRecipients(User $owner, int $limit = self::RECENT_RECIPIENT_LIMIT): array
+    {
+        $safeLimit = max(1, min($limit, self::RECENT_RECIPIENT_LIMIT));
+
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('s.recipientEmailNormalized AS email')
+            ->addSelect('MAX(s.id) AS HIDDEN lastShareId')
+            ->from(ComicShare::class, 's')
+            ->andWhere('s.owner = :owner')
+            ->andWhere('s.recipientEmailNormalized <> :empty')
+            ->setParameter('owner', $owner)
+            ->setParameter('empty', '')
+            ->groupBy('s.recipientEmailNormalized')
+            ->orderBy('lastShareId', 'DESC')
+            ->setMaxResults($safeLimit)
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_map(
+            static fn (array $row): array => ['email' => (string) $row['email']],
+            $rows
+        );
+    }
+
+    /**
+     * Share several owned comics with one exact email address.
+     *
+     * Every item goes through the normal invitation service. That intentionally
+     * means the existing rate limiter is consumed once per relationship and a
+     * bulk request cannot become an invitation-spam bypass.
+     *
+     * The first version also keeps the existing one-email-per-comic delivery.
+     * Grouped mail can be added later without changing the durable ComicShare
+     * model or weakening the explicit-content email redaction.
+     *
+     * @param list<int> $comicIds
+     * @return array{created: int, total: int, results: list<array<string, mixed>>}
+     */
+    public function inviteMany(
+        array $comicIds,
+        User $owner,
+        string $recipientEmail,
+        bool $senderResponsibilityAccepted
+    ): array {
+        $ids = array_values(array_unique($comicIds));
+        $results = [];
+        $created = 0;
+
+        foreach ($ids as $comicId) {
+            $comic = $this->entityManager->getRepository(Comic::class)->find($comicId);
+
+            // Do not distinguish a missing comic from somebody else's comic.
+            // The picker only sends owned ids, but a hand-written request must
+            // not turn this endpoint into a comic-id discovery oracle.
+            if (!$comic instanceof Comic || !$this->authorizationChecker->isGranted(ComicVoter::SHARE, $comic)) {
+                $results[] = [
+                    'comicId' => $comicId,
+                    'status' => 'not_available',
+                    'message' => 'This comic is not available to share.',
+                ];
+                continue;
+            }
+
+            try {
+                $invitation = $this->shareService->invite(
+                    $comic,
+                    $owner,
+                    $recipientEmail,
+                    $senderResponsibilityAccepted
+                );
+
+                ++$created;
+                $results[] = [
+                    'comicId' => $comicId,
+                    'status' => 'created',
+                    'shareId' => $invitation->share->getId(),
+                ];
+            } catch (ShareException $exception) {
+                $status = match ($exception->getStatusCode()) {
+                    409 => 'skipped',
+                    429 => 'rate_limited',
+                    default => 'failed',
+                };
+
+                $results[] = [
+                    'comicId' => $comicId,
+                    'status' => $status,
+                    'message' => $exception->getMessage(),
+                    'code' => $exception->getCodeName(),
+                ];
+            }
+        }
+
+        return [
+            'created' => $created,
+            'total' => count($ids),
+            'results' => $results,
+        ];
+    }
+}

--- a/backend/src/Service/SharingWorkflowService.php
+++ b/backend/src/Service/SharingWorkflowService.php
@@ -54,45 +54,72 @@ final class SharingWorkflowService
 
         $rows = $this->entityManager->createQueryBuilder()
             ->select('s.recipientEmailNormalized AS email')
-            ->addSelect('s.recipientSharingCode AS sharingCode')
-            ->addSelect('s.recipientAliasName AS name')
+            // Whether this relationship was made by code, not which code. The
+            // stored one is a note about how it began and goes stale the moment
+            // the recipient rotates; offering it back would put a retired code
+            // straight into the picker and defeat the rotation.
+            ->addSelect('s.recipientSharingCode AS historicalCode')
+            // The recipient's handle as it is now. Joining User is forbidden
+            // everywhere else in this service, and allowed here for one reason:
+            // the rows are already restricted to people this owner has an
+            // existing sharing relationship with, so nothing is learned that
+            // sharing with them did not already establish. It is a lookup of a
+            // known correspondent, not a search of the directory.
+            ->addSelect('ru.sharingCode AS currentCode')
+            ->addSelect('ru.name AS currentName')
             ->addSelect('MAX(s.id) AS HIDDEN lastShareId')
             ->from(ComicShare::class, 's')
+            ->leftJoin('s.recipientUser', 'ru')
             ->andWhere('s.owner = :owner')
             ->andWhere('s.recipientEmailNormalized <> :empty')
             ->setParameter('owner', $owner)
             ->setParameter('empty', '')
-            // Grouped by all three so a person the owner has reached both ways
-            // appears once per way of reaching them, rather than one entry
-            // silently carrying the other's label.
+            // Grouped so a person the owner has reached both ways appears once
+            // per way of reaching them, rather than one entry silently carrying
+            // the other's label.
             ->groupBy('s.recipientEmailNormalized')
             ->addGroupBy('s.recipientSharingCode')
-            ->addGroupBy('s.recipientAliasName')
+            ->addGroupBy('ru.sharingCode')
+            ->addGroupBy('ru.name')
             ->orderBy('lastShareId', 'DESC')
             ->setMaxResults($safeLimit)
             ->getQuery()
             ->getArrayResult();
 
-        return array_map(
-            static function (array $row): array {
-                $sharingCode = $row['sharingCode'] === null ? null : (string) $row['sharingCode'];
-                $name = $row['name'] === null ? null : (string) $row['name'];
+        $recipients = [];
+        foreach ($rows as $row) {
+            $byCode = $row['historicalCode'] !== null;
+            $currentCode = $row['currentCode'] === null ? null : (string) $row['currentCode'];
+            $name = $row['currentName'] === null ? null : (string) $row['currentName'];
 
-                return [
-                    // Withheld for a code recipient, so the picker cannot put
-                    // back on screen the address the sender never learned.
-                    'email' => $sharingCode === null ? (string) $row['email'] : null,
-                    'sharingCode' => $sharingCode === null
-                        ? null
-                        : SharingCodeFormat::forDisplay($sharingCode),
-                    'name' => $name,
-                    'label' => $sharingCode === null
-                        ? (string) $row['email']
-                        : ($name ?: SharingCodeFormat::forDisplay($sharingCode)),
+            if (!$byCode) {
+                $recipients[] = [
+                    'email' => (string) $row['email'],
+                    'sharingCode' => null,
+                    'name' => null,
+                    'label' => (string) $row['email'],
                 ];
-            },
-            $rows
-        );
+                continue;
+            }
+
+            // A code recipient whose account can no longer be resolved, or who
+            // has no code right now, is simply not offered. The alternative —
+            // falling back to the address — would hand over the one thing the
+            // code existed to withhold.
+            if ($currentCode === null) {
+                continue;
+            }
+
+            $display = SharingCodeFormat::forDisplay($currentCode);
+            $recipients[] = [
+                'email' => null,
+                'sharingCode' => $display,
+                'name' => $name,
+                'label' => $name ?: $display,
+            ];
+        }
+
+        return $recipients;
     }
 
     /**

--- a/backend/src/Service/SharingWorkflowService.php
+++ b/backend/src/Service/SharingWorkflowService.php
@@ -121,12 +121,15 @@ final class SharingWorkflowService
                     default => 'failed',
                 };
 
-                $results[] = [
+                $result = [
                     'comicId' => $comicId,
                     'status' => $status,
                     'message' => $exception->getMessage(),
-                    'code' => $exception->getCodeName(),
                 ];
+                if ($exception->getErrorCode() !== null) {
+                    $result['code'] = $exception->getErrorCode();
+                }
+                $results[] = $result;
             }
         }
 

--- a/backend/src/Service/SharingWorkflowService.php
+++ b/backend/src/Service/SharingWorkflowService.php
@@ -14,11 +14,19 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
  *
  * This service deliberately does not search User. Reusable recipients come only
  * from addresses this owner previously supplied themselves, and bulk sharing is
- * only a coordinator around ComicShareService::invite().
+ * only the permission gate in front of ComicShareService::inviteMany().
  */
 final class SharingWorkflowService
 {
+    /**
+     * How many comics one bulk share may carry.
+     *
+     * A ceiling on the size of one invitation email rather than on how much
+     * mail can be sent — that is the `share_invitation` limiter's job, and a
+     * bulk share claims one allowance from it however many comics it carries.
+     */
     public const MAX_BULK_COMICS = 20;
+
     public const RECENT_RECIPIENT_LIMIT = 20;
 
     public function __construct(
@@ -64,16 +72,17 @@ final class SharingWorkflowService
     /**
      * Share several owned comics with one exact email address.
      *
-     * Every item goes through the normal invitation service. That intentionally
-     * means the existing rate limiter is consumed once per relationship and a
-     * bulk request cannot become an invitation-spam bypass.
-     *
-     * The first version also keeps the existing one-email-per-comic delivery.
-     * Grouped mail can be added later without changing the durable ComicShare
-     * model or weakening the explicit-content email redaction.
+     * This layer decides only what the caller is allowed to touch. Everything
+     * that follows — the duplicate rules, the acknowledgement, the tokens, the
+     * grouped email, the rate limiting and the audit records — belongs to
+     * {@see ComicShareService::inviteMany()}, so a bulk share cannot drift away
+     * from what a single invitation does.
      *
      * @param list<int> $comicIds
+     *
      * @return array{created: int, total: int, results: list<array<string, mixed>>}
+     *
+     * @throws ShareException when the whole request is refused
      */
     public function inviteMany(
         array $comicIds,
@@ -81,9 +90,9 @@ final class SharingWorkflowService
         string $recipientEmail,
         bool $senderResponsibilityAccepted
     ): array {
-        $ids = array_values(array_unique($comicIds));
+        $ids = array_values(array_unique(array_map('intval', $comicIds)));
+        $shareable = [];
         $results = [];
-        $created = 0;
 
         foreach ($ids as $comicId) {
             $comic = $this->entityManager->getRepository(Comic::class)->find($comicId);
@@ -92,51 +101,46 @@ final class SharingWorkflowService
             // The picker only sends owned ids, but a hand-written request must
             // not turn this endpoint into a comic-id discovery oracle.
             if (!$comic instanceof Comic || !$this->authorizationChecker->isGranted(ComicVoter::SHARE, $comic)) {
-                $results[] = [
-                    'comicId' => $comicId,
+                $results[$comicId] = [
                     'status' => 'not_available',
                     'message' => 'This comic is not available to share.',
                 ];
                 continue;
             }
 
-            try {
-                $invitation = $this->shareService->invite(
-                    $comic,
-                    $owner,
-                    $recipientEmail,
-                    $senderResponsibilityAccepted
-                );
+            $shareable[$comicId] = $comic;
+        }
 
+        if ($shareable !== []) {
+            $results += $this->shareService->inviteMany(
+                array_values($shareable),
+                $owner,
+                $recipientEmail,
+                $senderResponsibilityAccepted
+            );
+        }
+
+        // Reported in the order the caller asked, so the response lines up with
+        // the selection the sender is looking at.
+        $ordered = [];
+        $created = 0;
+        foreach ($ids as $comicId) {
+            $result = $results[$comicId] ?? [
+                'status' => 'failed',
+                'message' => 'This comic could not be shared.',
+            ];
+
+            if ($result['status'] === 'created') {
                 ++$created;
-                $results[] = [
-                    'comicId' => $comicId,
-                    'status' => 'created',
-                    'shareId' => $invitation->share->getId(),
-                ];
-            } catch (ShareException $exception) {
-                $status = match ($exception->getStatusCode()) {
-                    409 => 'skipped',
-                    429 => 'rate_limited',
-                    default => 'failed',
-                };
-
-                $result = [
-                    'comicId' => $comicId,
-                    'status' => $status,
-                    'message' => $exception->getMessage(),
-                ];
-                if ($exception->getErrorCode() !== null) {
-                    $result['code'] = $exception->getErrorCode();
-                }
-                $results[] = $result;
             }
+
+            $ordered[] = ['comicId' => $comicId] + $result;
         }
 
         return [
             'created' => $created,
             'total' => count($ids),
-            'results' => $results,
+            'results' => $ordered,
         ];
     }
 }

--- a/backend/src/Service/SharingWorkflowService.php
+++ b/backend/src/Service/SharingWorkflowService.php
@@ -43,7 +43,10 @@ final class SharingWorkflowService
      * previously entered, never whether an address belongs to a registered
      * account or anything about that account.
      *
-     * @return list<array{email: string}>
+     * Recipients reached by receiver code are listed too, but by their code and
+     * name — never by the address the sender was deliberately not given.
+     *
+     * @return list<array{email: string|null, sharingCode: string|null, name: string|null, label: string}>
      */
     public function recentRecipients(User $owner, int $limit = self::RECENT_RECIPIENT_LIMIT): array
     {
@@ -51,20 +54,43 @@ final class SharingWorkflowService
 
         $rows = $this->entityManager->createQueryBuilder()
             ->select('s.recipientEmailNormalized AS email')
+            ->addSelect('s.recipientSharingCode AS sharingCode')
+            ->addSelect('s.recipientAliasName AS name')
             ->addSelect('MAX(s.id) AS HIDDEN lastShareId')
             ->from(ComicShare::class, 's')
             ->andWhere('s.owner = :owner')
             ->andWhere('s.recipientEmailNormalized <> :empty')
             ->setParameter('owner', $owner)
             ->setParameter('empty', '')
+            // Grouped by all three so a person the owner has reached both ways
+            // appears once per way of reaching them, rather than one entry
+            // silently carrying the other's label.
             ->groupBy('s.recipientEmailNormalized')
+            ->addGroupBy('s.recipientSharingCode')
+            ->addGroupBy('s.recipientAliasName')
             ->orderBy('lastShareId', 'DESC')
             ->setMaxResults($safeLimit)
             ->getQuery()
             ->getArrayResult();
 
         return array_map(
-            static fn (array $row): array => ['email' => (string) $row['email']],
+            static function (array $row): array {
+                $sharingCode = $row['sharingCode'] === null ? null : (string) $row['sharingCode'];
+                $name = $row['name'] === null ? null : (string) $row['name'];
+
+                return [
+                    // Withheld for a code recipient, so the picker cannot put
+                    // back on screen the address the sender never learned.
+                    'email' => $sharingCode === null ? (string) $row['email'] : null,
+                    'sharingCode' => $sharingCode === null
+                        ? null
+                        : SharingCodeFormat::forDisplay($sharingCode),
+                    'name' => $name,
+                    'label' => $sharingCode === null
+                        ? (string) $row['email']
+                        : ($name ?: SharingCodeFormat::forDisplay($sharingCode)),
+                ];
+            },
             $rows
         );
     }
@@ -88,7 +114,8 @@ final class SharingWorkflowService
         array $comicIds,
         User $owner,
         string $recipientEmail,
-        bool $senderResponsibilityAccepted
+        bool $senderResponsibilityAccepted,
+        ?SharingCodeRecipient $viaSharingCode = null
     ): array {
         $ids = array_values(array_unique(array_map('intval', $comicIds)));
         $shareable = [];
@@ -116,7 +143,8 @@ final class SharingWorkflowService
                 array_values($shareable),
                 $owner,
                 $recipientEmail,
-                $senderResponsibilityAccepted
+                $senderResponsibilityAccepted,
+                $viaSharingCode
             );
         }
 

--- a/backend/templates/emails/share_comics.html.twig
+++ b/backend/templates/emails/share_comics.html.twig
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Comic Sharing Invitations</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+            color: #333333;
+        }
+        .container {
+            width: 100%;
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        .header {
+            text-align: center;
+            padding-bottom: 20px;
+        }
+        .header h1 {
+            margin: 0;
+            font-size: 24px;
+            color: #333333;
+        }
+        .content p {
+            line-height: 1.6;
+            margin: 10px 0;
+        }
+        .invitation {
+            border: 1px solid #e2e2e2;
+            border-radius: 6px;
+            padding: 12px 16px;
+            margin: 12px 0;
+        }
+        .invitation-title {
+            font-weight: bold;
+            font-size: 16px;
+            margin: 0 0 4px 0;
+        }
+        .invitation-author {
+            color: #777777;
+            font-size: 13px;
+            margin: 0 0 10px 0;
+        }
+        .invitation-link {
+            display: inline-block;
+            padding: 8px 16px;
+            background-color: #007bff;
+            color: #ffffff;
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+        .footer {
+            text-align: center;
+            font-size: 12px;
+            color: #777777;
+            margin-top: 20px;
+        }
+        .highlight {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>You've Been Invited to Read {{ comicCount }} Comics!</h1>
+        </div>
+        <div class="content">
+            <p>Hi there,</p>
+            <p>
+                <span class="highlight">{{ userName|e }}</span> would like to share
+                <span class="highlight">{{ comicCount }} comics</span> with you.
+            </p>
+            {% if explicitCount > 0 %}
+                <p class="highlight">
+                    {{ explicitCount }} of them {{ explicitCount == 1 ? 'has' : 'have' }} been marked as
+                    containing explicit adult content (18+). You will be asked to confirm that you are
+                    18 or older before any details of {{ explicitCount == 1 ? 'that comic' : 'those comics' }}
+                    are shown to you.
+                </p>
+            {% endif %}
+            {# Each comic keeps its own link because each invitation is still
+               answered on its own: accepting one says nothing about the rest,
+               and the sender can withdraw any of them separately. The links only
+               ever open a preview — mail scanners and link-preview services
+               follow links without a person behind them, so nothing here may
+               accept or decline on the recipient's behalf. #}
+            <p>Each link below shows you what is being shared. Nothing is added to your account until you choose to accept it.</p>
+
+            {% for invitation in invitations %}
+                <div class="invitation">
+                    {# An explicit comic is not named here. The email is the one
+                       place the recipient cannot choose to open: it is previewed
+                       on lock screens and read by scanners, so the title stays
+                       behind the age gate along with everything else that
+                       identifies the comic. #}
+                    {% if invitation.explicitContent %}
+                        <p class="invitation-title">A comic marked as explicit content (18+)</p>
+                        <p class="invitation-author">Details are hidden until you confirm your age.</p>
+                    {% else %}
+                        <p class="invitation-title">{{ invitation.title|e }}</p>
+                        {% if invitation.author %}
+                            <p class="invitation-author">{{ invitation.author|e }}</p>
+                        {% endif %}
+                    {% endif %}
+                    <a href="{{ invitation.shareLink|e('html_attr') }}" class="invitation-link" style="color: #ffffff;">Review invitation</a>
+                </div>
+            {% endfor %}
+
+            <p>
+                To accept, you'll need to log in or create an account on
+                <span class="highlight">Comic Share Platform</span>.
+            </p>
+            <p>
+                The comics stay owned by {{ userName|e }}. You will be able to read them
+                for as long as they keep sharing them, and any of them may become
+                unavailable if they stop sharing or remove it.
+            </p>
+            <p>
+                These invitation links will expire on <span class="highlight">{{ expiresAt|date("F j, Y") }}</span>.
+            </p>
+            <p>
+                You received this email because {{ userName|e }} entered your address
+                to share these comics. If you do not know the sender or do not want the
+                invitations, you can ignore this email; no account will be created for you.
+            </p>
+            <p>Happy reading!</p>
+        </div>
+        <div class="footer">
+            <p>&copy; {{ "now"|date("Y") }} Comic Share Platform. All rights reserved.</p>
+            <p><a href="{{ privacyUrl|e('html_attr') }}">Privacy information</a></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/tests/Functional/Controller/AdminShareCodeControllerTest.php
+++ b/backend/tests/Functional/Controller/AdminShareCodeControllerTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\ComicShare;
+use App\Entity\ShareClaimCode;
+use App\Service\ExpiredShareCleanupService;
+use App\Service\SecurityAuditLogger;
+use App\Tests\Factory\ComicFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\Functional\AbstractApiTestCase;
+use App\Tests\Functional\SecurityLogAssertions;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * The operational surface for issued claim codes.
+ *
+ * Claim codes are capabilities that leave the building, so somebody has to be
+ * able to see what is outstanding and stop one. Most of what is asserted here
+ * is what this surface must *not* do: show a code it cannot recover, take back
+ * comics that were already claimed, or delete anything the nightly sweep would
+ * have left alone.
+ */
+final class AdminShareCodeControllerTest extends AbstractApiTestCase
+{
+    use SecurityLogAssertions;
+
+    public function testOrdinaryUsersCannotReachAnyOfIt(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'ordinary@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        $this->getJson('/api/admin/sharing-codes');
+        self::assertResponseStatusCodeSame(403);
+
+        $this->postJson(sprintf('/api/admin/sharing-codes/%d/revoke', $created['claimCode']['id']), []);
+        self::assertResponseStatusCodeSame(403);
+
+        $this->postJson('/api/admin/sharing-codes/cleanup', []);
+        self::assertResponseStatusCodeSame(403);
+
+        // And the code they could not revoke is still live.
+        self::assertTrue($this->getJson('/api/shares/claim-codes')['codes'][0]['isRedeemable']);
+    }
+
+    public function testAnAdministratorSeesIssuedCodesWithoutEverSeeingACode(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'issuer@example.com', 'name' => 'Issuer'])->object();
+        $this->loginAs($owner);
+        $comic = ComicFactory::new()->ownedBy($owner)->create(['title' => 'Handed Out'])->object();
+        $plaintext = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 4,
+            'senderResponsibilityAccepted' => true,
+        ])['code'];
+
+        $this->createAndLoginAdmin(['email' => 'ops@example.com']);
+        $payload = $this->getJson('/api/admin/sharing-codes');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $payload['items']);
+
+        $entry = $payload['items'][0];
+        self::assertSame((int) $owner->getId(), $entry['ownerId']);
+        self::assertSame('issuer@example.com', $entry['ownerEmail']);
+        self::assertSame(4, $entry['maxUses']);
+        self::assertSame(0, $entry['timesUsed']);
+        self::assertSame('Handed Out', $entry['comics'][0]['title']);
+        self::assertNotNull($entry['deletableAfter']);
+        self::assertSame(1, $payload['pagination']['totalItems']);
+
+        // Only the hash is stored, so there is nothing to show and nothing to
+        // recover — not even to an administrator.
+        $body = (string) $this->browser()->getResponse()->getContent();
+        self::assertStringNotContainsString(str_replace('-', '', $plaintext), str_replace('-', '', $body));
+        self::assertArrayNotHasKey('code', $entry);
+        self::assertArrayNotHasKey('codeHash', $entry);
+    }
+
+    public function testTheListPagesAndFiltersByStatus(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'prolific@example.com'])->object();
+        $other = UserFactory::createOne(['email' => 'somebody-else@example.com'])->object();
+        $this->loginAs($owner);
+
+        $ids = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+            $ids[] = $this->postJson('/api/shares/claim-codes', [
+                'comicIds' => [$comic->getId()],
+                'maxUses' => 1,
+                'senderResponsibilityAccepted' => true,
+            ])['claimCode']['id'];
+        }
+
+        $this->loginAs($other);
+        $othersComic = ComicFactory::new()->ownedBy($other)->create()->object();
+        $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$othersComic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        $admin = $this->createAndLoginAdmin(['email' => 'pager@example.com']);
+
+        // Paged, because this table grows continuously between sweeps.
+        $firstPage = $this->getJson('/api/admin/sharing-codes?limit=2');
+        self::assertCount(2, $firstPage['items']);
+        self::assertSame(4, $firstPage['pagination']['totalItems']);
+        self::assertSame(2, $firstPage['pagination']['totalPages']);
+        self::assertCount(2, $this->getJson('/api/admin/sharing-codes?limit=2&page=2')['items']);
+
+        // Narrowed to one owner, which is how an abuse report arrives.
+        $mine = $this->getJson(sprintf('/api/admin/sharing-codes?ownerId=%d', $owner->getId()));
+        self::assertSame(3, $mine['pagination']['totalItems']);
+
+        $searched = $this->getJson('/api/admin/sharing-codes?search=somebody-else');
+        self::assertSame(1, $searched['pagination']['totalItems']);
+
+        // Withdraw one and the status filters separate the two halves.
+        $this->postJson(sprintf('/api/admin/sharing-codes/%d/revoke', $ids[0]), []);
+        self::assertResponseIsSuccessful();
+
+        self::assertSame(3, $this->getJson('/api/admin/sharing-codes?status=active')['pagination']['totalItems']);
+        $withdrawn = $this->getJson('/api/admin/sharing-codes?status=withdrawn');
+        self::assertSame(1, $withdrawn['pagination']['totalItems']);
+        self::assertSame('withdrawn', $withdrawn['items'][0]['deadReason']);
+        self::assertNotNull($withdrawn['items'][0]['revokedAt']);
+        self::assertNotNull($admin->getId());
+    }
+
+    public function testAnAdministratorCanStopACodeWithoutTakingBackWhatItAlreadyGaveOut(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'reported@example.com'])->object();
+        $this->loginAs($owner);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 5,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        $claimer = $this->createAndLoginUser(['email' => 'got-there-first@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $created['code']]);
+        self::assertResponseIsSuccessful();
+
+        $this->createAndLoginAdmin(['email' => 'responder@example.com']);
+        $payload = $this->postJson(sprintf('/api/admin/sharing-codes/%d/revoke', $created['claimCode']['id']), []);
+
+        self::assertResponseIsSuccessful();
+        self::assertTrue($payload['claimCode']['isRevoked']);
+        self::assertFalse($payload['claimCode']['isRedeemable']);
+
+        // Nobody else gets in.
+        $this->createAndLoginUser(['email' => 'too-slow@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $created['code']]);
+        self::assertResponseStatusCodeSame(404);
+
+        // But withdrawing a code stops the way in, never the access already
+        // granted. Taking a comic back is moderation, not code management.
+        $this->loginAs($claimer);
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'];
+        self::assertCount(1, $received);
+        self::assertSame(ComicShare::STATUS_ACCEPTED, $received[0]['status']);
+        self::assertTrue($received[0]['canRead']);
+    }
+
+    public function testAdministrativeRevocationIsAudited(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'audited-owner@example.com'])->object();
+        $this->loginAs($owner);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 2,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        $admin = $this->createAndLoginAdmin(['email' => 'accountable@example.com']);
+        $this->postJson(sprintf('/api/admin/sharing-codes/%d/revoke', $created['claimCode']['id']), []);
+        self::assertResponseIsSuccessful();
+
+        $record = $this->assertLoggedAuditEvent(SecurityAuditLogger::SHARE_CLAIM_CODE_REVOKED);
+        self::assertSame($admin->getId(), $record->context['actor_user_id']);
+        self::assertSame((int) $owner->getId(), $record->context['owner_user_id']);
+        self::assertSame($created['claimCode']['id'], $record->context['target_id']);
+        self::assertTrue($record->context['by_admin']);
+
+        // The code itself is never recoverable and never written down.
+        self::assertStringNotContainsString(
+            str_replace('-', '', $created['code']),
+            str_replace('-', '', json_encode($record->context, JSON_THROW_ON_ERROR))
+        );
+    }
+
+    public function testManualCleanupRemovesOnlyWhatTheScheduledSweepWould(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'housekeeper@example.com'])->object();
+        $this->loginAs($owner);
+
+        $codeIds = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+            $codeIds[] = $this->postJson('/api/shares/claim-codes', [
+                'comicIds' => [$comic->getId()],
+                'maxUses' => 1,
+                'senderResponsibilityAccepted' => true,
+            ])['claimCode']['id'];
+        }
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $expire = static function (int $id, string $modifier) use ($entityManager): void {
+            $entityManager->getConnection()->executeStatement(
+                'UPDATE share_claim_code SET expires_at = :when WHERE id = :id',
+                ['when' => (new \DateTimeImmutable($modifier))->format('Y-m-d H:i:s'), 'id' => $id]
+            );
+        };
+
+        // One live, one dead but inside the retention window, one past it.
+        $expire($codeIds[1], '-2 days');
+        $expire($codeIds[2], '-40 days');
+        $entityManager->clear();
+
+        $this->createAndLoginAdmin(['email' => 'sweeper@example.com']);
+        $payload = $this->postJson('/api/admin/sharing-codes/cleanup', []);
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(1, $payload['claimCodesRemoved']);
+
+        $remaining = array_column($this->getJson('/api/admin/sharing-codes')['items'], 'id');
+        // The live one and the recently expired one both survive: pressing the
+        // button early must not delete what the nightly job would have kept.
+        self::assertEqualsCanonicalizing([$codeIds[0], $codeIds[1]], $remaining);
+    }
+
+    public function testManualCleanupNeverRemovesTheSharesACodeProduced(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'gave-away@example.com'])->object();
+        $this->loginAs($owner);
+        $comic = ComicFactory::new()->ownedBy($owner)->create(['title' => 'Claimed Long Ago'])->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        $claimer = $this->createAndLoginUser(['email' => 'keeps-it@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $created['code']]);
+        self::assertResponseIsSuccessful();
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->getConnection()->executeStatement(
+            'UPDATE share_claim_code SET expires_at = :when WHERE id = :id',
+            [
+                'when' => (new \DateTimeImmutable('-40 days'))->format('Y-m-d H:i:s'),
+                'id' => $created['claimCode']['id'],
+            ]
+        );
+        $entityManager->clear();
+
+        $this->createAndLoginAdmin(['email' => 'tidy@example.com']);
+        $this->postJson('/api/admin/sharing-codes/cleanup', []);
+        self::assertResponseIsSuccessful();
+        self::assertSame([], $this->getJson('/api/admin/sharing-codes')['items']);
+
+        // A code is a way in, never the access itself. Sweeping the code away
+        // leaves the relationship it produced entirely alone.
+        $this->loginAs($claimer);
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'];
+        self::assertCount(1, $received);
+        self::assertSame('Claimed Long Ago', $received[0]['comicTitle']);
+        self::assertTrue($received[0]['canRead']);
+    }
+
+    public function testManualCleanupIsAuditedWithWhoRanItAndWhatWentAway(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'old-codes@example.com'])->object();
+        $this->loginAs($owner);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $codeId = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ])['claimCode']['id'];
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->getConnection()->executeStatement(
+            'UPDATE share_claim_code SET expires_at = :when WHERE id = :id',
+            ['when' => (new \DateTimeImmutable('-40 days'))->format('Y-m-d H:i:s'), 'id' => $codeId]
+        );
+        $entityManager->clear();
+
+        $admin = $this->createAndLoginAdmin(['email' => 'answerable@example.com']);
+        $this->postJson('/api/admin/sharing-codes/cleanup', []);
+
+        // The scheduled command is deliberately quiet; a person deleting
+        // records from other people's accounts is not.
+        $record = $this->assertLoggedAuditEvent(SecurityAuditLogger::RETENTION_CLEANUP);
+        self::assertSame($admin->getId(), $record->context['actor_user_id']);
+        self::assertSame('manual_admin_sweep', $record->context['scope']);
+        self::assertSame(1, $record->context['claim_codes_removed']);
+    }
+
+    /**
+     * The button and the cron job must never disagree about what is rubbish,
+     * which is why they are the same code and not two implementations.
+     */
+    public function testTheAdminSweepAndTheScheduledOneAreTheSameSweep(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'both-ways@example.com'])->object();
+        $this->loginAs($owner);
+
+        $ids = [];
+        for ($i = 0; $i < 2; ++$i) {
+            $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+            $ids[] = $this->postJson('/api/shares/claim-codes', [
+                'comicIds' => [$comic->getId()],
+                'maxUses' => 1,
+                'senderResponsibilityAccepted' => true,
+            ])['claimCode']['id'];
+        }
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->getConnection()->executeStatement(
+            'UPDATE share_claim_code SET expires_at = :when WHERE id = :id',
+            ['when' => (new \DateTimeImmutable('-40 days'))->format('Y-m-d H:i:s'), 'id' => $ids[0]]
+        );
+        $entityManager->clear();
+
+        // The service the command runs, invoked directly: it finds the one row
+        // the admin endpoint would have removed and leaves the other.
+        $cleanup = static::getContainer()->get(ExpiredShareCleanupService::class);
+        self::assertSame(1, $cleanup->cleanupExpiredClaimCodes());
+        self::assertSame(0, $cleanup->cleanupExpiredClaimCodes());
+
+        $this->createAndLoginAdmin(['email' => 'nothing-left@example.com']);
+        // Nothing for the button to do, because the cron job already did it.
+        self::assertSame(0, $this->postJson('/api/admin/sharing-codes/cleanup', [])['claimCodesRemoved']);
+        self::assertSame([$ids[1]], array_column($this->getJson('/api/admin/sharing-codes')['items'], 'id'));
+
+        self::assertNotNull(ShareClaimCode::RETENTION_AFTER_EXPIRY);
+    }
+}

--- a/backend/tests/Functional/Controller/SharingCodeControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingCodeControllerTest.php
@@ -127,6 +127,61 @@ final class SharingCodeControllerTest extends AbstractApiTestCase
         self::assertSame(ComicShare::STATUS_PENDING, $received[0]['status']);
     }
 
+    /**
+     * Re-inviting reuses the row, so a relationship that began with a receiver
+     * code can be reopened by somebody typing the address. Going on hiding it
+     * then would withhold something the owner plainly already has.
+     */
+    public function testTypingTheAddressLaterStopsHidingIt(): void
+    {
+        $recipient = UserFactory::createOne(['email' => 'both-ways@example.com', 'name' => 'Both Ways'])->object();
+        $this->loginAs($recipient);
+        $code = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $owner = $this->createAndLoginUser(['email' => 'switcher@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$comic->getId()],
+            'sharingCode' => $code,
+            'senderResponsibilityAccepted' => true,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $shareId = $this->getJson('/api/shares/shared-by-me')['sharedByMe'][0]['recipients'][0]['id'];
+        $this->postJson(sprintf('/api/shares/%d/revoke', $shareId), []);
+        self::assertResponseIsSuccessful();
+
+        // The same person, reached the other way this time.
+        $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$comic->getId()],
+            'email' => 'both-ways@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $entry = $this->getJson('/api/shares/shared-by-me')['sharedByMe'][0]['recipients'][0];
+        self::assertSame('both-ways@example.com', $entry['recipientEmail']);
+        self::assertNull($entry['recipientSharingCode']);
+        self::assertSame('both-ways@example.com', $entry['recipientLabel']);
+    }
+
+    public function testAClaimCodeCannotCarryMoreComicsThanOneActionMay(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'oversized@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => array_fill(0, 500, (int) $comic->getId()),
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        // Refused on the raw count, before any of those ids is looked up.
+        self::assertResponseStatusCodeSame(400);
+        self::assertSame([], $this->getJson('/api/shares/claim-codes')['codes']);
+    }
+
     public function testRecentRecipientsListACodeRecipientWithoutTheirAddress(): void
     {
         $recipient = UserFactory::createOne(['email' => 'quiet@example.com', 'name' => 'Quiet Reader'])->object();

--- a/backend/tests/Functional/Controller/SharingCodeControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingCodeControllerTest.php
@@ -1,0 +1,420 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\ComicShare;
+use App\Entity\ShareClaimCode;
+use App\Entity\User;
+use App\Service\SharingCodeFormat;
+use App\Tests\Factory\ComicFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\Functional\AbstractApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Sharing codes, in both directions.
+ *
+ * A **receiver code** is permanent, belongs to the person who wants to be
+ * shared with, and grants nothing: it only says who an invitation should be
+ * addressed to, so the sender never has to be told an email address. A **claim
+ * code** goes the other way — an owner hands it out and whoever redeems it gets
+ * the comics behind it — so it is disposable, short-lived and counted down.
+ *
+ * The tests here are mostly about what a code must *not* do: name an address,
+ * survive being used up, outlive a day, or answer differently for a code that
+ * never existed than for one that has run out.
+ */
+final class SharingCodeControllerTest extends AbstractApiTestCase
+{
+    public function testAReceiverCodeIsIssuedOnceAndNeverChanges(): void
+    {
+        $user = $this->createAndLoginUser(['email' => 'stable@example.com', 'name' => 'Stable Reader']);
+
+        $first = $this->getJson('/api/shares/my-code');
+        self::assertResponseIsSuccessful();
+        self::assertSame('Stable Reader', $first['name']);
+        self::assertMatchesRegularExpression('/^[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}$/', $first['sharingCode']);
+
+        // Asked again, and again after the account has been reloaded from the
+        // database: everybody who was ever given this code is holding it.
+        self::assertSame($first['sharingCode'], $this->getJson('/api/shares/my-code')['sharingCode']);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $stored = $entityManager->getRepository(User::class)->find($user->getId());
+        self::assertSame(
+            $first['sharingCode'],
+            SharingCodeFormat::forDisplay((string) $stored->getSharingCode())
+        );
+    }
+
+    public function testResolvingACodeRevealsANameAndNothingElse(): void
+    {
+        $recipient = UserFactory::createOne([
+            'email' => 'private-address@example.com',
+            'name' => 'Jane Reader',
+        ])->object();
+        $this->loginAs($recipient);
+        $code = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $this->createAndLoginUser(['email' => 'sender@example.com']);
+        $payload = $this->postJson('/api/shares/resolve-code', ['sharingCode' => $code]);
+
+        self::assertResponseIsSuccessful();
+        self::assertSame('Jane Reader', $payload['recipient']['name']);
+        // The address is the whole thing a receiver code exists to withhold.
+        self::assertStringNotContainsString(
+            'private-address@example.com',
+            (string) $this->browser()->getResponse()->getContent()
+        );
+        self::assertArrayNotHasKey('email', $payload['recipient']);
+        self::assertArrayNotHasKey('id', $payload['recipient']);
+    }
+
+    /**
+     * A code that does not resolve says so in one way, whether it is malformed,
+     * well formed and unused, or well formed and somebody else's. Telling those
+     * apart would turn this into a way to find out which codes are real.
+     */
+    public function testAnUnknownCodeIsAnswerdTheSameWayHoweverItIsWrong(): void
+    {
+        $this->createAndLoginUser(['email' => 'prober@example.com']);
+
+        $answers = [];
+        foreach (['not-a-code', 'ZZZZ-ZZZZ-ZZZZ', '0000-0000-0000'] as $attempt) {
+            $payload = $this->postJson('/api/shares/resolve-code', ['sharingCode' => $attempt]);
+            $answers[] = [$this->browser()->getResponse()->getStatusCode(), $payload['message']];
+        }
+
+        self::assertCount(1, array_unique($answers, SORT_REGULAR));
+        self::assertSame(404, $answers[0][0]);
+    }
+
+    public function testSharingByReceiverCodeNeverShowsTheSenderTheAddress(): void
+    {
+        $recipient = UserFactory::createOne([
+            'email' => 'hidden@example.com',
+            'name' => 'Hidden Reader',
+        ])->object();
+        $this->loginAs($recipient);
+        $code = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $owner = $this->createAndLoginUser(['email' => 'code-sender@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create(['title' => 'Shared By Code'])->object();
+
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$comic->getId()],
+            'sharingCode' => $code,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame(1, $payload['created']);
+
+        // The sender's own page, which is where an address would leak back.
+        $sharedByMe = $this->getJson('/api/shares/shared-by-me')['sharedByMe'];
+        $body = (string) $this->browser()->getResponse()->getContent();
+        self::assertStringNotContainsString('hidden@example.com', $body);
+
+        $entry = $sharedByMe[0]['recipients'][0];
+        self::assertNull($entry['recipientEmail']);
+        self::assertSame('Hidden Reader', $entry['recipientLabel']);
+        self::assertSame($code, $entry['recipientSharingCode']);
+
+        // And the recipient still gets an ordinary invitation addressed to them.
+        $this->loginAs($recipient);
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'];
+        self::assertCount(1, $received);
+        self::assertSame(ComicShare::STATUS_PENDING, $received[0]['status']);
+    }
+
+    public function testRecentRecipientsListACodeRecipientWithoutTheirAddress(): void
+    {
+        $recipient = UserFactory::createOne(['email' => 'quiet@example.com', 'name' => 'Quiet Reader'])->object();
+        $this->loginAs($recipient);
+        $code = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $owner = $this->createAndLoginUser(['email' => 'reuser@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$comic->getId()],
+            'sharingCode' => $code,
+            'senderResponsibilityAccepted' => true,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $recipients = $this->getJson('/api/shares/recent-recipients')['recipients'];
+        $body = (string) $this->browser()->getResponse()->getContent();
+
+        self::assertStringNotContainsString('quiet@example.com', $body);
+        self::assertCount(1, $recipients);
+        self::assertNull($recipients[0]['email']);
+        self::assertSame($code, $recipients[0]['sharingCode']);
+        self::assertSame('Quiet Reader', $recipients[0]['label']);
+    }
+
+    public function testAClaimCodeIsShownOnceAndCountsDownAsItIsUsed(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'claim-owner@example.com', 'name' => 'Claim Owner']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create(['title' => 'Claimable'])->object();
+
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 2,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        $code = $created['code'];
+        self::assertMatchesRegularExpression('/^[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}$/', $code);
+        self::assertSame(2, $created['claimCode']['usesRemaining']);
+
+        // Listing never gives the code back — only its hash is stored.
+        $listed = $this->getJson('/api/shares/claim-codes')['codes'];
+        self::assertCount(1, $listed);
+        self::assertArrayNotHasKey('code', $listed[0]);
+        self::assertStringNotContainsString(
+            str_replace('-', '', $code),
+            (string) $this->browser()->getResponse()->getContent()
+        );
+
+        $first = $this->createAndLoginUser(['email' => 'first-claimer@example.com']);
+        $claim = $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseIsSuccessful();
+        self::assertSame(1, $claim['claimed']);
+        self::assertSame('Claim Owner', $claim['ownerName']);
+        self::assertSame(['claimed'], array_column($claim['results'], 'status'));
+
+        // Redeeming is the recipient's own act, so an ordinary comic lands in
+        // their collection rather than waiting to be accepted again.
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'];
+        self::assertSame(ComicShare::STATUS_ACCEPTED, $received[0]['status']);
+
+        $this->createAndLoginUser(['email' => 'second-claimer@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseIsSuccessful();
+
+        // Two uses, two claimers, and then it is spent.
+        $this->createAndLoginUser(['email' => 'third-claimer@example.com']);
+        $payload = $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseStatusCodeSame(404);
+        self::assertStringContainsString('not valid', $payload['message']);
+
+        self::assertNotNull($first->getId());
+    }
+
+    public function testAnExhaustedCodeIsIndistinguishableFromOneThatNeverExisted(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'used-up@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $code = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ])['code'];
+
+        $this->createAndLoginUser(['email' => 'claimer@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseIsSuccessful();
+
+        $spent = $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        $spentStatus = $this->browser()->getResponse()->getStatusCode();
+
+        $imaginary = $this->postJson('/api/shares/claim-codes/redeem', ['code' => 'ZZZZ-ZZZZ-ZZZZ']);
+
+        self::assertSame($spentStatus, $this->browser()->getResponse()->getStatusCode());
+        self::assertSame($spent['message'], $imaginary['message']);
+    }
+
+    public function testAnExpiredClaimCodeIsRefused(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'stale-code@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $code = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 5,
+            'senderResponsibilityAccepted' => true,
+        ])['code'];
+
+        // A day is the whole guarantee: a code pasted into a group chat is out
+        // of its owner's hands the moment it is sent.
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $stored = $entityManager->getRepository(ShareClaimCode::class)->findOneBy([]);
+        $entityManager->getConnection()->executeStatement(
+            'UPDATE share_claim_code SET expires_at = :expired WHERE id = :id',
+            [
+                'expired' => (new \DateTimeImmutable('-1 minute'))->format('Y-m-d H:i:s'),
+                'id' => $stored->getId(),
+            ]
+        );
+        $entityManager->clear();
+
+        $this->createAndLoginUser(['email' => 'late@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testRedeemingLeavesAnExplicitComicBehindTheAgeGate(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'explicit-owner@example.com']);
+        $ordinary = ComicFactory::new()->ownedBy($owner)->create(['title' => 'All Ages'])->object();
+        $explicit = ComicFactory::new()->ownedBy($owner)
+            ->create(['title' => 'Adults Only', 'explicitContent' => true])
+            ->object();
+
+        $code = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$ordinary->getId(), $explicit->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ])['code'];
+
+        $this->createAndLoginUser(['email' => 'young@example.com']);
+        $payload = $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+
+        self::assertResponseIsSuccessful();
+        $byStatus = array_column($payload['results'], 'status');
+        self::assertEqualsCanonicalizing(['claimed', 'awaiting_age_confirmation'], $byStatus);
+
+        // Redeeming stands in for accepting, but never for declaring an age.
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'];
+        $gated = null;
+        foreach ($received as $share) {
+            if ($share['requiresAdultConfirmation'] === true) {
+                $gated = $share;
+            }
+        }
+
+        self::assertNotNull($gated, 'The explicit comic should still be gated.');
+        self::assertSame(ComicShare::STATUS_PENDING, $gated['status']);
+        // And it reveals nothing about itself while it is gated.
+        self::assertNull($gated['comicTitle']);
+        self::assertStringNotContainsString(
+            'Adults Only',
+            (string) $this->browser()->getResponse()->getContent()
+        );
+    }
+
+    public function testAnOwnerCannotRedeemTheirOwnClaimCode(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'self-claim@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $code = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ])['code'];
+
+        $payload = $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+
+        self::assertResponseStatusCodeSame(409);
+        self::assertStringContainsString('your own', $payload['message']);
+    }
+
+    public function testAClaimCodeCannotCarrySomebodyElsesComic(): void
+    {
+        $stranger = UserFactory::createOne(['email' => 'stranger@example.com'])->object();
+        $theirs = ComicFactory::new()->ownedBy($stranger)->create()->object();
+
+        $this->createAndLoginUser(['email' => 'grabby@example.com']);
+        $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$theirs->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertSame([], $this->getJson('/api/shares/claim-codes')['codes']);
+    }
+
+    public function testAClaimCodeStillRequiresTheSenderResponsibilityAcknowledgement(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'unacknowledged@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $payload = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => false,
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+        self::assertStringContainsString('acknowledge responsibility', $payload['message']);
+        self::assertSame([], $this->getJson('/api/shares/claim-codes')['codes']);
+    }
+
+    public function testAClaimCodeMustBeUsableBetweenOneAndTenTimes(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'greedy-uses@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        foreach ([0, ShareClaimCode::MAX_USES + 1, -3] as $uses) {
+            $this->postJson('/api/shares/claim-codes', [
+                'comicIds' => [$comic->getId()],
+                'maxUses' => $uses,
+                'senderResponsibilityAccepted' => true,
+            ]);
+            self::assertResponseStatusCodeSame(400, sprintf('%d uses should be refused.', $uses));
+        }
+
+        $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => ShareClaimCode::MAX_USES,
+            'senderResponsibilityAccepted' => true,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+    }
+
+    public function testWithdrawingACodeStopsItWithoutTouchingWhatItAlreadyGaveOut(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'withdrawer@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 5,
+            'senderResponsibilityAccepted' => true,
+        ]);
+        $code = $created['code'];
+
+        $this->createAndLoginUser(['email' => 'early-bird@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseIsSuccessful();
+
+        $this->loginAs($owner);
+        $this->browser()->request(
+            'DELETE',
+            '/api/shares/claim-codes/' . $created['claimCode']['id'],
+            [],
+            [],
+            array_merge(['HTTP_ACCEPT' => 'application/json'], $this->csrfHeader())
+        );
+        self::assertResponseIsSuccessful();
+
+        // The relationship it produced is an ordinary share now, revoked from
+        // the Sharing page like any other rather than by the code going away.
+        $sharedByMe = $this->getJson('/api/shares/shared-by-me')['sharedByMe'];
+        self::assertCount(1, $sharedByMe);
+        self::assertSame(ComicShare::STATUS_ACCEPTED, $sharedByMe[0]['recipients'][0]['status']);
+
+        $this->createAndLoginUser(['email' => 'too-late@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testEveryCodeEndpointRequiresAuthentication(): void
+    {
+        $accept = ['HTTP_ACCEPT' => 'application/json', 'CONTENT_TYPE' => 'application/json'];
+
+        $this->browser()->request('GET', '/api/shares/my-code', [], [], $accept);
+        self::assertResponseStatusCodeSame(401);
+
+        $this->browser()->request('POST', '/api/shares/resolve-code', [], [], $accept, '{"sharingCode":"AAAA-AAAA-AAAA"}');
+        self::assertResponseStatusCodeSame(401);
+
+        $this->browser()->request('GET', '/api/shares/claim-codes', [], [], $accept);
+        self::assertResponseStatusCodeSame(401);
+
+        $this->browser()->request('POST', '/api/shares/claim-codes/redeem', [], [], $accept, '{"code":"AAAA-AAAA-AAAA"}');
+        self::assertResponseStatusCodeSame(401);
+    }
+}

--- a/backend/tests/Functional/Controller/SharingCodeControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingCodeControllerTest.php
@@ -577,6 +577,235 @@ final class SharingCodeControllerTest extends AbstractApiTestCase
         self::assertNotNull($entityManager->getRepository(Comic::class)->find($comic->getId()));
     }
 
+    /* ---------------------------------------------------------------------- */
+    /* Rotation                                                               */
+    /* ---------------------------------------------------------------------- */
+
+    public function testRotatingRetiresTheOldCodeAndIssuesANewOne(): void
+    {
+        $recipient = $this->createAndLoginUser(['email' => 'rotator@example.com', 'name' => 'Rotator']);
+        $original = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $rotated = $this->postJson('/api/shares/my-code/rotate', []);
+        self::assertResponseIsSuccessful();
+        self::assertNotSame($original, $rotated['sharingCode']);
+        self::assertSame('Rotator', $rotated['name']);
+
+        // Read back the same new one, not a third.
+        self::assertSame($rotated['sharingCode'], $this->getJson('/api/shares/my-code')['sharingCode']);
+
+        $this->createAndLoginUser(['email' => 'holder-of-old@example.com']);
+        // The old code is gone for everybody who was given it, which is the
+        // entire point.
+        $this->postJson('/api/shares/resolve-code', ['sharingCode' => $original]);
+        self::assertResponseStatusCodeSame(404);
+
+        $resolved = $this->postJson('/api/shares/resolve-code', ['sharingCode' => $rotated['sharingCode']]);
+        self::assertResponseIsSuccessful();
+        self::assertSame('Rotator', $resolved['recipient']['name']);
+        self::assertNotNull($recipient->getId());
+    }
+
+    public function testRotatingLeavesExistingSharesUntouched(): void
+    {
+        $recipient = UserFactory::createOne(['email' => 'keeps-comics@example.com', 'name' => 'Keeper'])->object();
+        $this->loginAs($recipient);
+        $original = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $owner = $this->createAndLoginUser(['email' => 'gave-comics@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create(['title' => 'Still Mine'])->object();
+        $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$comic->getId()],
+            'sharingCode' => $original,
+            'senderResponsibilityAccepted' => true,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $this->loginAs($recipient);
+        $newCode = $this->postJson('/api/shares/my-code/rotate', [])['sharingCode'];
+
+        // Rotation replaces an address, not a relationship.
+        $received = $this->getJson('/api/shares/shared-with-me')['sharedWithMe'];
+        self::assertCount(1, $received);
+        self::assertSame(ComicShare::STATUS_PENDING, $received[0]['status']);
+
+        // And the sender is offered the new code, never the retired one — a
+        // stale snapshot in the picker would put the withdrawn code straight
+        // back into circulation.
+        $this->loginAs($owner);
+        $entry = $this->getJson('/api/shares/shared-by-me')['sharedByMe'][0]['recipients'][0];
+        self::assertSame($newCode, $entry['recipientSharingCode']);
+        self::assertNull($entry['recipientEmail']);
+
+        $recipients = $this->getJson('/api/shares/recent-recipients')['recipients'];
+        self::assertSame([$newCode], array_column($recipients, 'sharingCode'));
+        self::assertStringNotContainsString(
+            str_replace('-', '', $original),
+            str_replace('-', '', (string) $this->browser()->getResponse()->getContent())
+        );
+    }
+
+    public function testAnAdminCanRotateSomebodyElsesCodeWithoutSeeingIt(): void
+    {
+        $target = UserFactory::createOne(['email' => 'needs-help@example.com'])->object();
+        $this->loginAs($target);
+        $original = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $this->createAndLoginAdmin(['email' => 'support@example.com']);
+        $payload = $this->postJson(sprintf('/api/users/%d/sharing-code/rotate', $target->getId()), []);
+
+        self::assertResponseIsSuccessful();
+        // Support has no reason to hold somebody's contact handle; the user
+        // reads the new one off their own page.
+        self::assertArrayNotHasKey('sharingCode', $payload);
+        self::assertStringNotContainsString(
+            str_replace('-', '', $original),
+            str_replace('-', '', (string) $this->browser()->getResponse()->getContent())
+        );
+
+        $this->loginAs($target);
+        self::assertNotSame($original, $this->getJson('/api/shares/my-code')['sharingCode']);
+    }
+
+    public function testAnOrdinaryUserCannotRotateSomebodyElsesCode(): void
+    {
+        $target = UserFactory::createOne(['email' => 'not-yours@example.com'])->object();
+        $this->loginAs($target);
+        $original = $this->getJson('/api/shares/my-code')['sharingCode'];
+
+        $this->createAndLoginUser(['email' => 'meddling-user@example.com']);
+        $this->postJson(sprintf('/api/users/%d/sharing-code/rotate', $target->getId()), []);
+        self::assertResponseStatusCodeSame(403);
+
+        $this->loginAs($target);
+        self::assertSame($original, $this->getJson('/api/shares/my-code')['sharingCode']);
+    }
+
+    public function testRotationIsRateLimited(): void
+    {
+        $this->createAndLoginUser(['email' => 'spinner@example.com']);
+        $this->getJson('/api/shares/my-code');
+
+        // Rotated until it is refused rather than exactly N times: the limiter
+        // is cache-backed while the database rolls back between tests, so a
+        // user id can arrive at a key an earlier test already spent from. What
+        // matters is that the allowance is finite and says so.
+        $refused = null;
+        for ($attempt = 0; $attempt < 6 && $refused === null; ++$attempt) {
+            $payload = $this->postJson('/api/shares/my-code/rotate', []);
+
+            if ($this->browser()->getResponse()->getStatusCode() === 429) {
+                $refused = $payload;
+            }
+        }
+
+        self::assertNotNull($refused, 'Rotation should run out of allowance.');
+        self::assertStringContainsString('too many times', $refused['message']);
+    }
+
+    /* ---------------------------------------------------------------------- */
+    /* Redemption identity                                                    */
+    /* ---------------------------------------------------------------------- */
+
+    /**
+     * "Ten uses" has to mean ten people. Charging per request lets one
+     * recipient exhaust an offer made to everybody else.
+     */
+    public function testOneAccountSpendsAtMostOneUseHoweverOftenItRedeems(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'ten-uses@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 10,
+            'senderResponsibilityAccepted' => true,
+        ]);
+        $code = $created['code'];
+
+        $this->createAndLoginUser(['email' => 'eager@example.com']);
+        for ($i = 0; $i < 6; ++$i) {
+            $payload = $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+            self::assertResponseIsSuccessful();
+            if ($i > 0) {
+                self::assertTrue($payload['alreadyRedeemed'], 'A repeat redemption should say so.');
+            }
+        }
+
+        $this->loginAs($owner);
+        $listed = $this->getJson('/api/shares/claim-codes')['codes'][0];
+        self::assertSame(1, $listed['timesUsed'], 'One account is one use, however many requests.');
+        self::assertSame(9, $listed['usesRemaining']);
+    }
+
+    public function testDistinctAccountsEachSpendOneUseUntilTheCodeRunsOut(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'party@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $code = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 3,
+            'senderResponsibilityAccepted' => true,
+        ])['code'];
+
+        for ($i = 0; $i < 3; ++$i) {
+            $this->createAndLoginUser(['email' => sprintf('guest%d@example.com', $i)]);
+            $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+            self::assertResponseIsSuccessful(sprintf('Guest %d should be able to claim.', $i));
+        }
+
+        $this->createAndLoginUser(['email' => 'fourth@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseStatusCodeSame(404);
+
+        $this->loginAs($owner);
+        self::assertSame(3, $this->getJson('/api/shares/claim-codes')['codes'][0]['timesUsed']);
+    }
+
+    /**
+     * The canonical evidence of the sender's acknowledgement has to say when
+     * the sender acknowledged, not when somebody else consumed the code.
+     */
+    public function testAClaimedShareInheritsTheOwnersAcknowledgementTimestamp(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'acknowledger@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $code = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ])['code'];
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $claimCode = $entityManager->getRepository(ShareClaimCode::class)->findOneBy([]);
+        $acknowledgedAt = $claimCode->getSenderResponsibilityAcceptedAt();
+
+        // Redeemed later, by somebody the owner was not present for.
+        $entityManager->getConnection()->executeStatement(
+            'UPDATE share_claim_code SET sender_responsibility_accepted_at = :then, created_at = :then WHERE id = :id',
+            [
+                'then' => $acknowledgedAt->modify('-8 hours')->format('Y-m-d H:i:s'),
+                'id' => $claimCode->getId(),
+            ]
+        );
+        $entityManager->clear();
+
+        $expected = $acknowledgedAt->modify('-8 hours')->format('Y-m-d H:i:s');
+
+        $this->createAndLoginUser(['email' => 'much-later@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
+        self::assertResponseIsSuccessful();
+
+        $share = $entityManager->getRepository(ComicShare::class)->findOneBy([
+            'recipientEmailNormalized' => 'much-later@example.com',
+        ]);
+
+        self::assertSame(
+            $expected,
+            $share->getSenderResponsibilityAcceptedAt()?->format('Y-m-d H:i:s'),
+            'The share must record when the owner acknowledged, not when the code was redeemed.'
+        );
+    }
+
     public function testEveryCodeEndpointRequiresAuthentication(): void
     {
         $accept = ['HTTP_ACCEPT' => 'application/json', 'CONTENT_TYPE' => 'application/json'];

--- a/backend/tests/Functional/Controller/SharingCodeControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingCodeControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller;
 
+use App\Entity\Comic;
 use App\Entity\ComicShare;
 use App\Entity\ShareClaimCode;
 use App\Entity\User;
@@ -436,13 +437,7 @@ final class SharingCodeControllerTest extends AbstractApiTestCase
         self::assertResponseIsSuccessful();
 
         $this->loginAs($owner);
-        $this->browser()->request(
-            'DELETE',
-            '/api/shares/claim-codes/' . $created['claimCode']['id'],
-            [],
-            [],
-            array_merge(['HTTP_ACCEPT' => 'application/json'], $this->csrfHeader())
-        );
+        $this->deleteJson('/api/shares/claim-codes/' . $created['claimCode']['id']);
         self::assertResponseIsSuccessful();
 
         // The relationship it produced is an ordinary share now, revoked from
@@ -454,6 +449,132 @@ final class SharingCodeControllerTest extends AbstractApiTestCase
         $this->createAndLoginUser(['email' => 'too-late@example.com']);
         $this->postJson('/api/shares/claim-codes/redeem', ['code' => $code]);
         self::assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * A code the owner has changed their mind about must stop working straight
+     * away, not in whatever is left of its day.
+     */
+    public function testWithdrawingACodeTakesEffectImmediately(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'quick-change@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 10,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertTrue($created['claimCode']['isRedeemable']);
+        self::assertFalse($created['claimCode']['isExpired']);
+
+        $this->deleteJson('/api/shares/claim-codes/' . $created['claimCode']['id']);
+        self::assertResponseIsSuccessful();
+
+        // Still listed — dead codes are kept so the owner can see what happened
+        // to them — but plainly dead, and with no uses spent.
+        $listed = $this->getJson('/api/shares/claim-codes')['codes'];
+        self::assertCount(1, $listed);
+        self::assertTrue($listed[0]['isRevoked']);
+        self::assertFalse($listed[0]['isRedeemable']);
+        self::assertSame('withdrawn', $listed[0]['deadReason']);
+        self::assertSame(0, $listed[0]['timesUsed']);
+
+        $this->createAndLoginUser(['email' => 'shut-out@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $created['code']]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testAnotherOwnerCannotWithdrawSomebodyElsesCode(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'code-owner@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $created = $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 3,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        $this->createAndLoginUser(['email' => 'meddler@example.com']);
+        // Reported as missing rather than forbidden, so an id cannot be probed
+        // for whether it belongs to somebody's code.
+        $this->deleteJson('/api/shares/claim-codes/' . $created['claimCode']['id']);
+        self::assertResponseStatusCodeSame(404);
+
+        $this->createAndLoginUser(['email' => 'still-welcome@example.com']);
+        $this->postJson('/api/shares/claim-codes/redeem', ['code' => $created['code']]);
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testEveryIssuedCodeIsUniqueAcrossBothKinds(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'many-codes@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $seen = [$this->getJson('/api/shares/my-code')['sharingCode']];
+
+        for ($i = 0; $i < 8; ++$i) {
+            $seen[] = $this->postJson('/api/shares/claim-codes', [
+                'comicIds' => [$comic->getId()],
+                'maxUses' => 1,
+                'senderResponsibilityAccepted' => true,
+            ])['code'];
+            self::assertResponseStatusCodeSame(201);
+        }
+
+        self::assertCount(count($seen), array_unique($seen));
+
+        // And the unique index is the authority behind the check, not just the
+        // check itself.
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $hashes = $entityManager->getConnection()
+            ->fetchFirstColumn('SELECT code_hash FROM share_claim_code');
+        self::assertSame(count($hashes), count(array_unique($hashes)));
+    }
+
+    /**
+     * Dead codes are kept for a month so the owner can still see how many
+     * people took them up, then swept.
+     */
+    public function testTheCleanupKeepsADeadCodeForAMonthAndThenRemovesIt(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'housekeeping@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $this->postJson('/api/shares/claim-codes', [
+            'comicIds' => [$comic->getId()],
+            'maxUses' => 1,
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $repository = $entityManager->getRepository(ShareClaimCode::class);
+        $codeId = $repository->findOneBy([])->getId();
+
+        $expireAt = static function (string $modifier) use ($entityManager, $codeId): void {
+            $entityManager->getConnection()->executeStatement(
+                'UPDATE share_claim_code SET expires_at = :when WHERE id = :id',
+                ['when' => (new \DateTimeImmutable($modifier))->format('Y-m-d H:i:s'), 'id' => $codeId]
+            );
+            $entityManager->clear();
+        };
+
+        // Expired yesterday: dead, but still the owner's record of what they
+        // handed out.
+        $expireAt('-1 day');
+        self::assertSame([], $repository->findDeletable(new \DateTimeImmutable(), 100));
+        self::assertCount(1, $this->getJson('/api/shares/claim-codes')['codes']);
+
+        // A month and a day later there is nothing left to look at.
+        $expireAt('-31 days');
+        $deletable = $repository->findDeletable(new \DateTimeImmutable(), 100);
+        self::assertCount(1, $deletable);
+
+        $entityManager->remove($deletable[0]);
+        $entityManager->flush();
+
+        // The comic is untouched by the sweep — a code is a way in, never the
+        // access itself.
+        self::assertSame([], $this->getJson('/api/shares/claim-codes')['codes']);
+        self::assertNotNull($entityManager->getRepository(Comic::class)->find($comic->getId()));
     }
 
     public function testEveryCodeEndpointRequiresAuthentication(): void

--- a/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
@@ -8,11 +8,25 @@ use App\Entity\User;
 use App\Service\ComicShareService;
 use App\Tests\Factory\ComicFactory;
 use App\Tests\Factory\UserFactory;
+use App\Service\SharingWorkflowService;
 use App\Tests\Functional\AbstractApiTestCase;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 
+/**
+ * The two convenience endpoints behind the Sharing page's **Share comics**
+ * flow, and the privacy boundary they are built around.
+ *
+ * The boundary is the point of most of this file: reusable recipients are
+ * addresses the sender previously supplied, never anything read out of the user
+ * directory, and a bulk share is a convenience over the ordinary invitation
+ * model rather than a second way in.
+ */
 final class SharingWorkflowControllerTest extends AbstractApiTestCase
 {
+    use MailerAssertionsTrait;
+
+
     public function testRecentRecipientsOnlyReturnsAddressesThisOwnerPreviouslyUsed(): void
     {
         $owner = UserFactory::createOne(['email' => 'owner@example.com'])->object();
@@ -122,6 +136,238 @@ final class SharingWorkflowControllerTest extends AbstractApiTestCase
         self::assertResponseStatusCodeSame(400);
         self::assertStringContainsString('acknowledge responsibility', $payload['message']);
         self::assertSame([], $this->getJson('/api/shares/shared-by-me')['sharedByMe']);
+    }
+
+    public function testBothEndpointsRequireAuthentication(): void
+    {
+        $this->browser()->request('GET', '/api/shares/recent-recipients', [], [], ['HTTP_ACCEPT' => 'application/json']);
+        self::assertResponseStatusCodeSame(401);
+
+        $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [1],
+            'email' => 'friend@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testRecentRecipientsAreCappedAtTheDocumentedLimit(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'busy-sharer@example.com']);
+
+        for ($i = 0; $i < SharingWorkflowService::RECENT_RECIPIENT_LIMIT + 5; ++$i) {
+            $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+            $this->persistPendingShare($comic, $owner, sprintf('friend%d@example.com', $i));
+        }
+
+        $recipients = $this->getJson('/api/shares/recent-recipients')['recipients'];
+
+        self::assertCount(SharingWorkflowService::RECENT_RECIPIENT_LIMIT, $recipients);
+        // Most recent first, so the cap keeps the addresses a sender is most
+        // likely to want rather than the ones they have finished with.
+        self::assertSame('friend24@example.com', $recipients[0]['email']);
+    }
+
+    /**
+     * Twenty comics must not mean twenty messages in somebody's inbox. Each one
+     * still carries its own link, because each invitation is still answered,
+     * expired and revoked on its own.
+     */
+    public function testBulkShareSendsOneGroupedEmailCarryingEveryInvitation(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'grouped@example.com', 'name' => 'Grouped Owner']);
+        $comics = [
+            ComicFactory::new()->ownedBy($owner)->create(['title' => 'Batman Begins'])->object(),
+            ComicFactory::new()->ownedBy($owner)->create(['title' => 'Superman Returns'])->object(),
+            ComicFactory::new()->ownedBy($owner)->create(['title' => 'Wonder Woman'])->object(),
+        ];
+
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => array_map(static fn (Comic $comic): int => (int) $comic->getId(), $comics),
+            'email' => 'friend@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame(3, $payload['created']);
+
+        self::assertEmailCount(1);
+        $email = self::getMailerMessage();
+        self::assertSame('Grouped Owner shared 3 comics with you!', $email->getSubject());
+        self::assertSame('friend@example.com', $email->getTo()[0]->getAddress());
+
+        $body = $email->getHtmlBody();
+        foreach (['Batman Begins', 'Superman Returns', 'Wonder Woman'] as $title) {
+            self::assertStringContainsString($title, $body);
+        }
+
+        // One link per invitation, and three different ones: a shared link
+        // would make accepting one comic accept all of them. Decoded first
+        // because the template escapes hrefs as HTML attributes.
+        preg_match_all('#/share/invitation/([A-Za-z0-9_-]+)#', html_entity_decode($body), $matches);
+        self::assertCount(3, array_unique($matches[1]));
+    }
+
+    public function testAGroupedInvitationEmailStillNamesNoExplicitComic(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'mixed@example.com']);
+        $ordinary = ComicFactory::new()->ownedBy($owner)->create(['title' => 'All Ages Adventure'])->object();
+        $explicit = ComicFactory::new()->ownedBy($owner)
+            ->create(['title' => 'Very Explicit Title', 'explicitContent' => true])
+            ->object();
+
+        $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$ordinary->getId(), $explicit->getId()],
+            'email' => 'friend@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertEmailCount(1);
+
+        $body = self::getMailerMessage()->getHtmlBody();
+        self::assertStringContainsString('All Ages Adventure', $body);
+        // The inbox is the one surface the recipient cannot choose to open, so
+        // the age gate holds here exactly as it does on the invitation page.
+        self::assertStringNotContainsString('Very Explicit Title', $body);
+        self::assertStringContainsString('explicit content (18+)', $body);
+    }
+
+    /**
+     * One send is one claim on the allowance, so what the limiter protects —
+     * how much mail one account can put in somebody's inbox — is unchanged by
+     * bulk sharing.
+     */
+    public function testABulkShareClaimsOneAllowanceHoweverManyComicsItCarries(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'allowance@example.com']);
+
+        // Five comics in one action. Charged per relationship this would spend
+        // half the hourly allowance on its own.
+        $comicIds = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $comicIds[] = (int) ComicFactory::new()->ownedBy($owner)->create()->object()->getId();
+        }
+
+        $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => $comicIds,
+            'email' => 'first@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        // Nine of the ten remain, so nine more sends are still accepted.
+        for ($i = 0; $i < 9; ++$i) {
+            $this->postJson('/api/shares/invitations/bulk', [
+                'comicIds' => $comicIds,
+                'email' => sprintf('guest%d@example.com', $i),
+                'senderResponsibilityAccepted' => true,
+            ]);
+            self::assertResponseStatusCodeSame(201, sprintf('Bulk share %d should be within the allowance.', $i + 2));
+        }
+
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => $comicIds,
+            'email' => 'one-too-many@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(429);
+        self::assertStringContainsString('too many invitations', $payload['message']);
+
+        // Refused before anything was created, so the eleventh recipient has no
+        // half-made relationship waiting for them.
+        $sharedByMe = $this->getJson('/api/shares/shared-by-me')['sharedByMe'];
+        $recipients = [];
+        foreach ($sharedByMe as $group) {
+            foreach ($group['recipients'] as $recipient) {
+                $recipients[] = $recipient['recipientEmail'];
+            }
+        }
+        self::assertNotContains('one-too-many@example.com', $recipients);
+    }
+
+    public function testBulkShareRejectsMoreComicsThanOneActionMayCarry(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'greedy@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => array_fill(0, SharingWorkflowService::MAX_BULK_COMICS + 1, (int) $comic->getId()),
+            'email' => 'friend@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+        self::assertStringContainsString('at most', $payload['message']);
+        self::assertEmailCount(0);
+    }
+
+    public function testBulkShareDoesNotSilentlyRecreateAPendingInvitation(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'repeat@example.com']);
+        $pending = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $fresh = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $existing = $this->persistPendingShare($pending, $owner, 'friend@example.com');
+        // To the second: the column has no sub-second precision, and what
+        // matters is that the clock was not restarted.
+        $existingExpiry = $existing->getExpiresAt()?->format('Y-m-d H:i:s');
+
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$pending->getId(), $fresh->getId()],
+            'email' => 'friend@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(207);
+        self::assertSame(1, $payload['created']);
+
+        $byId = array_column($payload['results'], null, 'comicId');
+        self::assertSame('skipped', $byId[(int) $pending->getId()]['status']);
+        self::assertSame('created', $byId[(int) $fresh->getId()]['status']);
+
+        // The existing relationship is untouched — its clock was not restarted
+        // and no second row was created beside it.
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $rows = $entityManager->getRepository(ComicShare::class)
+            ->findBy(['comic' => $pending, 'recipientEmailNormalized' => 'friend@example.com']);
+
+        self::assertCount(1, $rows);
+        self::assertSame((int) $existing->getId(), (int) $rows[0]->getId());
+        self::assertSame($existingExpiry, $rows[0]->getExpiresAt()?->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * The invitation endpoint must not become an account-enumeration oracle:
+     * an address that belongs to a registered user and one that does not have
+     * to be indistinguishable in the response.
+     */
+    public function testBulkShareAnswersIdenticallyForRegisteredAndUnknownRecipients(): void
+    {
+        UserFactory::createOne(['email' => 'registered@example.com']);
+        $owner = $this->createAndLoginUser(['email' => 'prober@example.com']);
+        $first = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $second = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $known = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$first->getId()],
+            'email' => 'registered@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+        $knownStatus = $this->browser()->getResponse()->getStatusCode();
+
+        $unknown = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$second->getId()],
+            'email' => 'nobody-here@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertSame($knownStatus, $this->browser()->getResponse()->getStatusCode());
+        self::assertSame(
+            array_column($known['results'], 'status'),
+            array_column($unknown['results'], 'status')
+        );
+        self::assertSame($known['created'], $unknown['created']);
     }
 
     private function persistPendingShare(Comic $comic, User $owner, string $recipientEmail): ComicShare

--- a/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller;
 
+use App\Entity\Comic;
 use App\Entity\ComicShare;
 use App\Entity\User;
 use App\Service\ComicShareService;
@@ -123,7 +124,7 @@ final class SharingWorkflowControllerTest extends AbstractApiTestCase
         self::assertSame([], $this->getJson('/api/shares/shared-by-me')['sharedByMe']);
     }
 
-    private function persistPendingShare(object $comic, User $owner, string $recipientEmail): ComicShare
+    private function persistPendingShare(Comic $comic, User $owner, string $recipientEmail): ComicShare
     {
         $share = new ComicShare($comic, $owner, $recipientEmail);
         $share->markPending(new \DateTimeImmutable(ComicShareService::INVITATION_TTL));

--- a/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\ComicShare;
+use App\Entity\User;
+use App\Service\ComicShareService;
+use App\Tests\Factory\ComicFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\Functional\AbstractApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class SharingWorkflowControllerTest extends AbstractApiTestCase
+{
+    public function testRecentRecipientsOnlyReturnsAddressesThisOwnerPreviouslyUsed(): void
+    {
+        $owner = UserFactory::createOne(['email' => 'owner@example.com'])->object();
+        $other = UserFactory::createOne(['email' => 'other@example.com'])->object();
+
+        $first = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $second = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $third = ComicFactory::new()->ownedBy($owner)->create()->object();
+        $incoming = ComicFactory::new()->ownedBy($other)->create()->object();
+        $otherComic = ComicFactory::new()->ownedBy($other)->create()->object();
+
+        $this->persistPendingShare($first, $owner, 'jane@example.com');
+        $this->persistPendingShare($second, $owner, 'bob@example.com');
+        // Reusing Jane on a newer comic must collapse to one recipient and put
+        // her first without looking her up in User.
+        $this->persistPendingShare($third, $owner, 'jane@example.com');
+
+        // Neither direction of somebody else's relationship belongs in the
+        // owner's reusable address history.
+        $this->persistPendingShare($incoming, $other, 'owner@example.com');
+        $this->persistPendingShare($otherComic, $other, 'private@example.com');
+
+        $this->loginAs($owner);
+        $payload = $this->getJson('/api/shares/recent-recipients');
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(
+            ['jane@example.com', 'bob@example.com'],
+            array_column($payload['recipients'], 'email')
+        );
+    }
+
+    public function testBulkShareCreatesIndependentNormalShareRelationships(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'bulk-owner@example.com']);
+        $first = ComicFactory::new()->ownedBy($owner)->create(['title' => 'First'])->object();
+        $second = ComicFactory::new()->ownedBy($owner)->create(['title' => 'Second'])->object();
+
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$first->getId(), $second->getId()],
+            'email' => 'friend@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame(2, $payload['created']);
+        self::assertSame(2, $payload['total']);
+        self::assertSame(['created', 'created'], array_column($payload['results'], 'status'));
+
+        $sharedByMe = $this->getJson('/api/shares/shared-by-me')['sharedByMe'];
+        self::assertEqualsCanonicalizing(
+            [$first->getId(), $second->getId()],
+            array_column($sharedByMe, 'comicId')
+        );
+        foreach ($sharedByMe as $group) {
+            self::assertSame('friend@example.com', $group['recipients'][0]['recipientEmail']);
+            self::assertSame(ComicShare::STATUS_PENDING, $group['recipients'][0]['status']);
+        }
+    }
+
+    public function testBulkShareCannotReshareAComicReceivedFromSomeoneElse(): void
+    {
+        $originalOwner = UserFactory::createOne(['email' => 'original@example.com'])->object();
+        $recipient = UserFactory::createOne(['email' => 'recipient@example.com'])->object();
+        $receivedComic = ComicFactory::new()->ownedBy($originalOwner)->create()->object();
+        $ownComic = ComicFactory::new()->ownedBy($recipient)->create()->object();
+
+        $share = $this->persistPendingShare($receivedComic, $originalOwner, 'recipient@example.com');
+        $share->markAccepted($recipient);
+        static::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $this->loginAs($recipient);
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$receivedComic->getId(), $ownComic->getId()],
+            'email' => 'third@example.com',
+            'senderResponsibilityAccepted' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(207);
+        self::assertSame(1, $payload['created']);
+        self::assertSame(2, $payload['total']);
+
+        $byId = [];
+        foreach ($payload['results'] as $result) {
+            $byId[(int) $result['comicId']] = $result;
+        }
+
+        self::assertSame('not_available', $byId[(int) $receivedComic->getId()]['status']);
+        self::assertSame('created', $byId[(int) $ownComic->getId()]['status']);
+        self::assertSame(
+            'This comic is not available to share.',
+            $byId[(int) $receivedComic->getId()]['message']
+        );
+    }
+
+    public function testBulkShareStillRequiresTheSenderResponsibilityAcknowledgement(): void
+    {
+        $owner = $this->createAndLoginUser(['email' => 'responsible@example.com']);
+        $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
+
+        $payload = $this->postJson('/api/shares/invitations/bulk', [
+            'comicIds' => [$comic->getId()],
+            'email' => 'friend@example.com',
+            'senderResponsibilityAccepted' => false,
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+        self::assertStringContainsString('acknowledge responsibility', $payload['message']);
+        self::assertSame([], $this->getJson('/api/shares/shared-by-me')['sharedByMe']);
+    }
+
+    private function persistPendingShare(object $comic, User $owner, string $recipientEmail): ComicShare
+    {
+        $share = new ComicShare($comic, $owner, $recipientEmail);
+        $share->markPending(new \DateTimeImmutable(ComicShareService::INVITATION_TTL));
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->persist($share);
+        $entityManager->flush();
+
+        return $share;
+    }
+}

--- a/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
+++ b/backend/tests/Functional/Controller/SharingWorkflowControllerTest.php
@@ -155,7 +155,8 @@ final class SharingWorkflowControllerTest extends AbstractApiTestCase
     {
         $owner = $this->createAndLoginUser(['email' => 'busy-sharer@example.com']);
 
-        for ($i = 0; $i < SharingWorkflowService::RECENT_RECIPIENT_LIMIT + 5; ++$i) {
+        $shared = SharingWorkflowService::RECENT_RECIPIENT_LIMIT + 5;
+        for ($i = 0; $i < $shared; ++$i) {
             $comic = ComicFactory::new()->ownedBy($owner)->create()->object();
             $this->persistPendingShare($comic, $owner, sprintf('friend%d@example.com', $i));
         }
@@ -165,7 +166,7 @@ final class SharingWorkflowControllerTest extends AbstractApiTestCase
         self::assertCount(SharingWorkflowService::RECENT_RECIPIENT_LIMIT, $recipients);
         // Most recent first, so the cap keeps the addresses a sender is most
         // likely to want rather than the ones they have finished with.
-        self::assertSame('friend24@example.com', $recipients[0]['email']);
+        self::assertSame(sprintf('friend%d@example.com', $shared - 1), $recipients[0]['email']);
     }
 
     /**

--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -93,6 +93,8 @@ security and audit records. Decide which mode you are in and write it down;
 | `var/log/security/` | `SECURITY_LOG_RETENTION_DAYS` (default 365) | `app:cleanup-logs` |
 | `var/log/audit/` | `AUDIT_LOG_RETENTION_DAYS` (default 365) | `app:cleanup-logs` |
 | `admin_audit_log` table | 12 months | `app:cleanup-personal-data` |
+| Unanswered `ComicShare` invitations | Until `expiresAt` (2 months) | `app:cleanup-expired-shares` |
+| `share_claim_code` rows | 30 days past expiry | `app:cleanup-expired-shares` |
 | `ComicShare.senderResponsibilityAcceptedAt` / `adultConfirmedAt` | Lifetime of the share record | Nothing — see below |
 
 Deletion is **not** automatic. A `max_files` setting nothing enforces is how an
@@ -103,6 +105,11 @@ keeping everything forever. Schedule the command:
 # daily, deploy user
 15 3 * * * cd /var/www/comics/backend && php bin/console app:cleanup-logs --env=prod >> /var/log/comics-cleanup.log 2>&1
 ```
+
+This is one of three commands a production instance must have scheduled — the
+others apply the personal-data and sharing retention above. The full list, with
+what breaks if each is missing, is in
+[SSH-deploy.md §7](../SSH-deploy.md#7-background-jobs-cron--systemd-timers).
 
 `--dry-run` reports what would go without removing anything. Expired files are
 removed along with the month and year folders they empty; the stream root stays,

--- a/frontend/src/components/AdminSharingCodesList.jsx
+++ b/frontend/src/components/AdminSharingCodesList.jsx
@@ -1,0 +1,318 @@
+import { useMemo, useState } from "react";
+import { Brush, Search } from "lucide-react";
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { AdminPagination } from "@/components/AdminPagination";
+import { useAdminList } from "@/hooks/use-admin-list";
+import { useToast } from "@/hooks/use-toast";
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+import { formatDate } from "@/lib/format";
+
+/** The statuses the backend filters on, in the order an operator wants them. */
+const STATUSES = [
+  ["", "All"],
+  ["active", "Active"],
+  ["expired", "Expired"],
+  ["exhausted", "Used up"],
+  ["withdrawn", "Withdrawn"],
+];
+
+const STATUS_LABELS = {
+  withdrawn: "Withdrawn",
+  expired: "Expired",
+  used_up: "Used up",
+  comics_removed: "Comics removed",
+};
+
+/**
+ * The claim codes an instance has issued, and the two things support can do
+ * about them.
+ *
+ * Deliberately not a place a code can be read. Only the hash is stored, so
+ * there is nothing to show — the table identifies a code by its record id, its
+ * owner and what is behind it, which is what somebody acting on an abuse report
+ * actually has to go on.
+ *
+ * Receiver codes are not here. Their lifecycle is rotation, which lives on the
+ * user page beside the account it identifies.
+ */
+export function AdminSharingCodesList() {
+  const { toast } = useToast();
+  const [status, setStatus] = useState("");
+  const [ownerId, setOwnerId] = useState("");
+  const [createdFrom, setCreatedFrom] = useState("");
+  const [createdTo, setCreatedTo] = useState("");
+  const [codeToRevoke, setCodeToRevoke] = useState(null);
+  const [isCleanupOpen, setIsCleanupOpen] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const filters = useMemo(() => ({
+    ...(status ? { status } : {}),
+    ...(ownerId.trim() ? { ownerId: ownerId.trim() } : {}),
+    ...(createdFrom ? { createdFrom } : {}),
+    ...(createdTo ? { createdTo } : {}),
+  }), [status, ownerId, createdFrom, createdTo]);
+
+  const {
+    items: codes,
+    pagination,
+    payload,
+    isLoading,
+    searchInput,
+    setSearch,
+    setPage,
+    setLimit,
+    reload,
+  } = useAdminList({
+    basePath: "/api/admin/sharing-codes",
+    filters,
+    urlKey: "sharingCodes",
+    itemsKey: "items",
+    errorTitle: "Could not load sharing codes",
+  });
+
+  const revoke = async () => {
+    setIsBusy(true);
+
+    try {
+      await api.post(`/api/admin/sharing-codes/${codeToRevoke.id}/revoke`, {});
+      toast({
+        title: "Sharing code withdrawn",
+        description: "Nobody else can use it. Comics already claimed through it are unaffected.",
+      });
+      await reload();
+    } catch (error) {
+      logger.error("Revoking a sharing code failed:", error);
+      toast({ title: "Could not withdraw the code", description: error.message, variant: "destructive" });
+    } finally {
+      setIsBusy(false);
+      setCodeToRevoke(null);
+    }
+  };
+
+  const runCleanup = async () => {
+    setIsBusy(true);
+
+    try {
+      const data = await api.post("/api/admin/sharing-codes/cleanup", {});
+      toast({ title: "Cleanup complete", description: data.message });
+      await reload();
+    } catch (error) {
+      logger.error("Running the sharing cleanup failed:", error);
+      toast({ title: "Cleanup failed", description: error.message, variant: "destructive" });
+    } finally {
+      setIsBusy(false);
+      setIsCleanupOpen(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Sharing codes</h2>
+          <p className="text-sm text-muted-foreground">
+            Codes users have handed out so others can claim their comics. The codes themselves are
+            stored only as hashes and cannot be shown or recovered.
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => setIsCleanupOpen(true)} disabled={isBusy}>
+          <Brush className="mr-2 h-4 w-4" />
+          Run cleanup
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="relative min-w-[220px] flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchInput}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search by owner name or email…"
+            className="pl-9"
+            aria-label="Search sharing codes by owner"
+          />
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {STATUSES.map(([value, label]) => (
+            <Button
+              key={value || "all"}
+              size="sm"
+              variant={status === value ? "default" : "outline"}
+              aria-pressed={status === value}
+              onClick={() => { setStatus(value); setPage(1); }}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor="admin-codes-owner" className="text-xs">Owner ID</Label>
+          <Input
+            id="admin-codes-owner"
+            value={ownerId}
+            onChange={(event) => { setOwnerId(event.target.value.replace(/[^0-9]/g, "")); setPage(1); }}
+            className="w-28"
+            placeholder="Any"
+          />
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor="admin-codes-from" className="text-xs">Created from</Label>
+          <Input
+            id="admin-codes-from"
+            type="date"
+            value={createdFrom}
+            onChange={(event) => { setCreatedFrom(event.target.value); setPage(1); }}
+            className="w-40"
+          />
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor="admin-codes-to" className="text-xs">Created to</Label>
+          <Input
+            id="admin-codes-to"
+            type="date"
+            value={createdTo}
+            onChange={(event) => { setCreatedTo(event.target.value); setPage(1); }}
+            className="w-40"
+          />
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Owner</TableHead>
+              <TableHead>Comics</TableHead>
+              <TableHead>Uses</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Expires</TableHead>
+              <TableHead>Deleted after</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading && (
+              <TableRow><TableCell colSpan={9}>Loading sharing codes…</TableCell></TableRow>
+            )}
+            {!isLoading && codes.length === 0 && (
+              <TableRow><TableCell colSpan={9}>No sharing codes match these filters.</TableCell></TableRow>
+            )}
+            {!isLoading && codes.map((code) => (
+              <TableRow key={code.id}>
+                <TableCell className="font-mono text-xs">{code.id}</TableCell>
+                <TableCell>
+                  <span className="block text-sm">{code.ownerName || "—"}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {code.ownerEmail} · #{code.ownerId}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <span className="block text-sm">{code.comicCount}</span>
+                  <span className="block max-w-[220px] truncate text-xs text-muted-foreground">
+                    {code.comics.map((comic) => `#${comic.id} ${comic.title}`).join(", ")}
+                  </span>
+                </TableCell>
+                <TableCell className="text-sm">
+                  {code.timesUsed} / {code.maxUses}
+                </TableCell>
+                <TableCell className="text-xs">{formatDate(code.createdAt)}</TableCell>
+                <TableCell className="text-xs">{formatDate(code.expiresAt)}</TableCell>
+                <TableCell className="text-xs">{formatDate(code.deletableAfter)}</TableCell>
+                <TableCell>
+                  <Badge variant={code.isRedeemable ? "default" : "outline"}>
+                    {STATUS_LABELS[code.deadReason] || "Active"}
+                  </Badge>
+                  {code.revokedAt && (
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {formatDate(code.revokedAt)}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  {code.isRedeemable && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={isBusy}
+                      onClick={() => setCodeToRevoke(code)}
+                    >
+                      Withdraw
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <AdminPagination
+        pagination={pagination}
+        itemCount={codes.length}
+        isLoading={isLoading}
+        onPageChange={setPage}
+        onLimitChange={setLimit}
+        label="sharing codes"
+      />
+
+      <AlertDialog open={codeToRevoke !== null} onOpenChange={() => setCodeToRevoke(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Withdraw sharing code #{codeToRevoke?.id}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Nobody will be able to claim anything with it from now on. Comics that have already
+              been claimed through it stay with the people who claimed them — withdrawing a code
+              closes the way in, it does not take access back.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={(event) => { event.preventDefault(); revoke(); }}
+            >
+              Withdraw code
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={isCleanupOpen} onOpenChange={setIsCleanupOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Run the retention cleanup now?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This is the same sweep the scheduled job runs, so it removes only invitations that
+              expired unanswered and codes that died more than {payload?.retentionAfterExpiry || "30 days"} ago.
+              Live codes, recently expired ones, and the comics people claimed through them are all
+              left alone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={(event) => { event.preventDefault(); runCleanup(); }}>
+              Run cleanup
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/frontend/src/components/AdminSharingCodesList.test.jsx
+++ b/frontend/src/components/AdminSharingCodesList.test.jsx
@@ -1,0 +1,147 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AdminSharingCodesList } from "./AdminSharingCodesList";
+import { api } from "@/lib/api";
+
+const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
+
+vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
+
+const liveCode = {
+  id: 12,
+  ownerId: 3,
+  ownerName: "Issuer",
+  ownerEmail: "issuer@example.com",
+  comicCount: 2,
+  comics: [
+    { id: 8, title: "Batman #1", explicitContent: false },
+    { id: 9, title: "Superman #1", explicitContent: false },
+  ],
+  maxUses: 5,
+  usesRemaining: 3,
+  timesUsed: 2,
+  createdAt: "2026-08-09T09:00:00+00:00",
+  expiresAt: "2026-08-10T09:00:00+00:00",
+  deletableAfter: "2026-09-09T09:00:00+00:00",
+  isExpired: false,
+  isRevoked: false,
+  isRedeemable: true,
+  deadReason: null,
+  revokedAt: null,
+};
+
+const withdrawnCode = {
+  ...liveCode,
+  id: 13,
+  isRedeemable: false,
+  isRevoked: true,
+  deadReason: "withdrawn",
+  revokedAt: "2026-08-09T10:00:00+00:00",
+};
+
+const respondWith = (items) => {
+  vi.mocked(api.get).mockResolvedValue({
+    items,
+    pagination: { page: 1, limit: 25, totalItems: items.length, totalPages: 1 },
+    retentionAfterExpiry: "30 days",
+  });
+};
+
+const renderList = () => render(
+  <MemoryRouter><AdminSharingCodesList /></MemoryRouter>
+);
+
+describe("AdminSharingCodesList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    respondWith([liveCode]);
+  });
+
+  it("identifies a code by its record, never by the code itself", async () => {
+    renderList();
+
+    expect(await screen.findByText("issuer@example.com · #3")).toBeInTheDocument();
+    expect(screen.getByText("2 / 5")).toBeInTheDocument();
+    expect(screen.getByText(/#8 Batman #1, #9 Superman #1/)).toBeInTheDocument();
+
+    // Only the hash is stored, so there is nothing to show and no column that
+    // could ever hold one.
+    expect(screen.queryByText(/····|[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}/)).not.toBeInTheDocument();
+  });
+
+  it("warns that withdrawing closes the way in without taking access back", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ message: "Sharing code withdrawn." });
+
+    renderList();
+    await screen.findByText("issuer@example.com · #3");
+
+    await user.click(screen.getByRole("button", { name: "Withdraw" }));
+
+    expect(await screen.findByText(/stay with the people who claimed them/)).toBeInTheDocument();
+    expect(api.post).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Withdraw code" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/admin/sharing-codes/12/revoke",
+      {}
+    ));
+  });
+
+  it("offers no withdraw action on a code that has already stopped working", async () => {
+    respondWith([withdrawnCode]);
+    renderList();
+
+    // Located by its id cell rather than by the status text, which also names
+    // one of the filter buttons above the table.
+    const row = (await screen.findByRole("cell", { name: "13" })).closest("tr");
+    expect(within(row).getByText("Withdrawn")).toBeInTheDocument();
+    expect(within(row).queryByRole("button", { name: "Withdraw" })).not.toBeInTheDocument();
+  });
+
+  it("filters by status through the backend rather than in the table", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("issuer@example.com · #3");
+
+    await user.click(screen.getByRole("button", { name: "Withdrawn" }));
+
+    // The table can grow past one page between cleanups, so narrowing has to
+    // happen in the query and not in what has already been fetched.
+    await waitFor(() => expect(vi.mocked(api.get).mock.calls.at(-1)[0])
+      .toContain("status=withdrawn"));
+  });
+
+  it("says what the cleanup will and will not remove before running it", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      message: "0 expired invitation(s) and 2 dead sharing code(s) removed.",
+      claimCodesRemoved: 2,
+    });
+
+    renderList();
+    await screen.findByText("issuer@example.com · #3");
+
+    await user.click(screen.getByRole("button", { name: /run cleanup/i }));
+
+    expect(await screen.findByText(/same sweep the scheduled job runs/)).toBeInTheDocument();
+    expect(await screen.findByText(/died more than 30 days ago/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Run cleanup" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/admin/sharing-codes/cleanup",
+      {}
+    ));
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Cleanup complete",
+      description: "0 expired invitation(s) and 2 dead sharing code(s) removed.",
+    }));
+  });
+});

--- a/frontend/src/components/ShareComicModal.jsx
+++ b/frontend/src/components/ShareComicModal.jsx
@@ -82,7 +82,22 @@ function ShareComicModalForm({ isOpen, onClose, comicId, comicTitle, onShared })
         title: "Invitation sent",
         description: `${recipientEmail.trim()} has been invited to read “${comicTitle}”.`,
       });
-      onShared?.();
+
+      // In its own try, and awaited rather than left running: the invitation
+      // exists once the POST resolves, so a refresh that fails is a stale list
+      // to warn about — never a reason to tell the sender their share failed,
+      // and never an unhandled rejection nobody sees.
+      try {
+        await onShared?.();
+      } catch (refreshError) {
+        logger.error("Sharing data refresh failed:", refreshError);
+        toast({
+          title: "Invitation sent",
+          description: "The invitation was sent, but the Sharing list could not refresh. "
+            + "Reload the page to see the latest state.",
+          variant: "destructive",
+        });
+      }
     } catch (err) {
       const message = err.message || "The invitation could not be sent.";
       setError(message);

--- a/frontend/src/components/ShareComicModal.test.jsx
+++ b/frontend/src/components/ShareComicModal.test.jsx
@@ -7,8 +7,10 @@ import { ShareComicModal } from "./ShareComicModal";
 import { api } from "@/lib/api";
 import { SHARE_RESPONSIBILITY_NOTICE } from "@/lib/sharing";
 
+const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
+
 vi.mock("@/lib/api", () => ({ api: { post: vi.fn() } }));
-vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
 
 const renderModal = (props = {}) => render(
@@ -28,8 +30,30 @@ const acknowledgement = () => screen.getByRole("checkbox", { name: /i understand
 
 describe("ShareComicModal", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(api.post).mockReset();
     vi.mocked(api.post).mockResolvedValue({ invitationUrl: "https://example.test/share/invitation/abc" });
+  });
+
+  it("keeps a successful invitation distinct from a failed refresh", async () => {
+    const user = userEvent.setup();
+    const onShared = vi.fn().mockRejectedValue(new Error("refresh failed"));
+    renderModal({ onShared });
+
+    await user.type(screen.getByLabelText(/recipient email/i), "jane@example.com");
+    await user.click(acknowledgement());
+    await user.click(sendButton());
+
+    // The invitation exists, so the one-time link is still offered and nothing
+    // tells the sender to try again.
+    expect(await screen.findByDisplayValue("https://example.test/share/invitation/abc"))
+      .toBeInTheDocument();
+    expect(toast).not.toHaveBeenCalledWith(expect.objectContaining({
+      title: "Could not share comic",
+    }));
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      description: expect.stringContaining("could not refresh"),
+    }));
   });
 
   it("states that the sender is responsible for what they share", () => {

--- a/frontend/src/components/ShareComicsDialog.jsx
+++ b/frontend/src/components/ShareComicsDialog.jsx
@@ -564,12 +564,18 @@ export function ShareComicsDialog({
                           key={recipient.sharingCode}
                           type="button"
                           size="sm"
-                          variant={sharingCode === recipient.sharingCode ? "default" : "outline"}
-                          aria-pressed={sharingCode === recipient.sharingCode}
+                          // Compared normalised: the input rewrites what it
+                          // holds through formatSharingCode, so a grouping
+                          // difference must not break the pressed state.
+                          variant={normaliseSharingCode(sharingCode) === normaliseSharingCode(recipient.sharingCode) ? "default" : "outline"}
+                          aria-pressed={normaliseSharingCode(sharingCode) === normaliseSharingCode(recipient.sharingCode)}
                           disabled={isSending}
                           onClick={() => {
-                            setSharingCode(recipient.sharingCode);
-                            setCodeRecipient({ name: recipient.name });
+                            setSharingCode(formatSharingCode(recipient.sharingCode));
+                            // The server sends no name for a recipient who had
+                            // none to snapshot, and falls back to the code in
+                            // the label — so that is what to show them as.
+                            setCodeRecipient({ name: recipient.name || recipient.label });
                           }}
                         >
                           {recipient.label}

--- a/frontend/src/components/ShareComicsDialog.jsx
+++ b/frontend/src/components/ShareComicsDialog.jsx
@@ -210,7 +210,19 @@ export function ShareComicsDialog({
           : `Invitation${created === 1 ? "" : "s"} sent to ${recipientEmail.trim()}.`,
       });
 
-      await onShared?.();
+      try {
+        await onShared?.();
+      } catch (refreshError) {
+        logger.error("Sharing data refresh failed:", refreshError);
+        toast({
+          title: "Invitation sent",
+          description: "The invitation was sent, but the Sharing list could not refresh. Reload the page to see the latest state.",
+          variant: "destructive",
+        });
+      }
+
+      // The invitations already exist at this point. Always close so a refresh
+      // failure cannot encourage the sender to submit the same share again.
       onClose();
     } catch (err) {
       logger.error("Bulk sharing failed:", err);

--- a/frontend/src/components/ShareComicsDialog.jsx
+++ b/frontend/src/components/ShareComicsDialog.jsx
@@ -75,8 +75,6 @@ export function ShareComicsDialog({
     if (!isOpen) return undefined;
 
     let ignore = false;
-    setIsLoading(true);
-    setError(null);
 
     Promise.all([
       api.get("/api/comics?ownership=mine"),
@@ -287,7 +285,7 @@ export function ShareComicsDialog({
                   return (
                     <label
                       key={comic.id}
-                      className="flex cursor-pointer items-center gap-3 p-3 has-[[data-disabled]]:cursor-not-allowed has-[[data-disabled]]:opacity-60"
+                      className={`flex items-center gap-3 p-3 ${disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}
                     >
                       <Checkbox
                         checked={checked}

--- a/frontend/src/components/ShareComicsDialog.jsx
+++ b/frontend/src/components/ShareComicsDialog.jsx
@@ -21,6 +21,7 @@ import {
   SHARE_RESPONSIBILITY_ACK_LABEL,
   SHARE_RESPONSIBILITY_NOTICE,
   SHARE_STATUS,
+  buildInvitationRequest,
   isValidShareEmail,
 } from "@/lib/sharing";
 import { useToast } from "@/hooks/use-toast";
@@ -182,32 +183,39 @@ export function ShareComicsDialog({
       return;
     }
 
+    const recipient = recipientEmail.trim();
+
     setIsSending(true);
     setError(null);
 
     try {
       const data = await api.post("/api/shares/invitations/bulk", {
+        ...buildInvitationRequest({ email: recipient, responsibilityAccepted: true }),
         comicIds: selectedComicIds.map(Number),
-        email: recipientEmail.trim(),
-        senderResponsibilityAccepted: true,
       });
 
-      const created = Number(data.created || 0);
-      const total = Number(data.total || selectedComicIds.length);
-      const skipped = Math.max(0, total - created);
+      const results = Array.isArray(data.results) ? data.results : [];
+      const created = Number(data.created) || results.filter((r) => r.status === "created").length;
+      // Everything the server did not create, with the first reason it gave.
+      // Reporting these as "skipped" would tell somebody whose comic was
+      // refused that their share went through.
+      const refused = results.filter((result) => result.status !== "created");
+      const reason = refused.find((result) => result.message)?.message;
 
       if (created === 0) {
-        const message = data.results?.find((result) => result.message)?.message
-          || "No new invitations were created.";
-        setError(message);
+        setError(reason || "No new invitations were created.");
         return;
       }
 
       toast({
         title: created === 1 ? "Comic shared" : `${created} comics shared`,
-        description: skipped > 0
-          ? `${skipped} ${skipped === 1 ? "comic was" : "comics were"} skipped. Check the Sharing list for current access.`
-          : `Invitation${created === 1 ? "" : "s"} sent to ${recipientEmail.trim()}.`,
+        // One email, however many comics went into it — so this says what the
+        // recipient actually receives rather than implying a message each.
+        description: refused.length > 0
+          ? `One invitation email was sent to ${recipient}. `
+            + `${refused.length} ${refused.length === 1 ? "comic was" : "comics were"} left out`
+            + `${reason ? `: ${reason}` : "."}`
+          : `One invitation email was sent to ${recipient}.`,
       });
 
       try {
@@ -349,6 +357,8 @@ export function ShareComicsDialog({
                       type="button"
                       size="sm"
                       variant={normaliseEmail(recipientEmail) === normaliseEmail(recipient.email) ? "default" : "outline"}
+                      aria-pressed={normaliseEmail(recipientEmail) === normaliseEmail(recipient.email)}
+                      disabled={isSending}
                       onClick={() => setRecipientEmail(recipient.email)}
                     >
                       {recipient.email}
@@ -377,7 +387,8 @@ export function ShareComicsDialog({
                 <p className="text-sm text-muted-foreground">
                   {selectedComics.length === 0
                     ? "Select at least one comic above."
-                    : `${selectedComics.length} ${selectedComics.length === 1 ? "comic" : "comics"} will be offered to ${recipientEmail.trim() || "the recipient"}.`}
+                    : `${selectedComics.length} ${selectedComics.length === 1 ? "comic" : "comics"} will be offered to ${recipientEmail.trim() || "the recipient"} in one invitation email. `
+                      + "They must accept each one before they can read it, and you can withdraw any of them later."}
                 </p>
               </div>
 

--- a/frontend/src/components/ShareComicsDialog.jsx
+++ b/frontend/src/components/ShareComicsDialog.jsx
@@ -1,0 +1,419 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, Search, Share2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+import {
+  EXPLICIT_FLAG_LABEL,
+  SHARE_RESPONSIBILITY_ACK_LABEL,
+  SHARE_RESPONSIBILITY_NOTICE,
+  SHARE_STATUS,
+  isValidShareEmail,
+} from "@/lib/sharing";
+import { useToast } from "@/hooks/use-toast";
+
+// Mirrors SharingWorkflowService::MAX_BULK_COMICS. The backend remains the
+// authority; this only stops the UI inviting somebody to select work that the
+// request will reject.
+const MAX_BULK_COMICS = 20;
+
+const normaliseEmail = (value) => (typeof value === "string" ? value.trim().toLowerCase() : "");
+
+function liveComicIdsForRecipient(sharedByMe, email) {
+  const wanted = normaliseEmail(email);
+  const ids = new Set();
+  if (!wanted) return ids;
+
+  (sharedByMe || []).forEach((group) => {
+    const alreadyLive = (group.recipients || []).some((recipient) => {
+      if (normaliseEmail(recipient.recipientEmail) !== wanted) return false;
+      if (recipient.status === SHARE_STATUS.ACCEPTED) return true;
+      return recipient.status === SHARE_STATUS.PENDING && !recipient.isExpired;
+    });
+
+    if (alreadyLive) ids.add(String(group.comicId));
+  });
+
+  return ids;
+}
+
+export function ShareComicsDialog({
+  isOpen,
+  onClose,
+  sharedByMe = [],
+  initialRecipient = "",
+  initialComicIds = [],
+  onShared,
+}) {
+  const [comics, setComics] = useState([]);
+  const [recentRecipients, setRecentRecipients] = useState([]);
+  const [search, setSearch] = useState("");
+  const [recipientEmail, setRecipientEmail] = useState(initialRecipient);
+  const [selectedIds, setSelectedIds] = useState(
+    () => new Set((initialComicIds || []).map((id) => String(id)))
+  );
+  const [responsibilityAccepted, setResponsibilityAccepted] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    let ignore = false;
+    setIsLoading(true);
+    setError(null);
+
+    Promise.all([
+      api.get("/api/comics?ownership=mine"),
+      api.get("/api/shares/recent-recipients"),
+    ])
+      .then(([library, recipients]) => {
+        if (ignore) return;
+        // ownership=mine is already scoped server-side; canShare is a second UI
+        // guard so a future payload change cannot make a received comic appear
+        // selectable here.
+        setComics((library.comics || []).filter((comic) => comic.canShare === true));
+        setRecentRecipients(recipients.recipients || []);
+      })
+      .catch((err) => {
+        if (ignore) return;
+        logger.error("Failed to load sharing picker:", err);
+        setError(err.message || "Could not load your shareable comics.");
+      })
+      .finally(() => {
+        if (!ignore) setIsLoading(false);
+      });
+
+    return () => { ignore = true; };
+  }, [isOpen]);
+
+  const alreadySharedIds = useMemo(
+    () => liveComicIdsForRecipient(sharedByMe, recipientEmail),
+    [sharedByMe, recipientEmail]
+  );
+
+  const filteredComics = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return comics;
+
+    return comics.filter((comic) =>
+      [comic.title, comic.author]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(query))
+    );
+  }, [comics, search]);
+
+  const selectedComicIds = useMemo(
+    () => [...selectedIds].filter((id) => !alreadySharedIds.has(id)),
+    [selectedIds, alreadySharedIds]
+  );
+
+  const selectedComics = useMemo(() => {
+    const selected = new Set(selectedComicIds);
+    return comics.filter((comic) => selected.has(String(comic.id)));
+  }, [comics, selectedComicIds]);
+
+  const visibleSelectable = filteredComics.filter(
+    (comic) => !alreadySharedIds.has(String(comic.id))
+  );
+  const allVisibleSelected = visibleSelectable.length > 0
+    && visibleSelectable.every((comic) => selectedIds.has(String(comic.id)));
+
+  const toggleComic = (comicId) => {
+    const id = String(comicId);
+    if (alreadySharedIds.has(id)) return;
+
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else if (selectedComicIds.length < MAX_BULK_COMICS) {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleVisible = () => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (allVisibleSelected) {
+        visibleSelectable.forEach((comic) => next.delete(String(comic.id)));
+        return next;
+      }
+
+      let slots = MAX_BULK_COMICS - [...next].filter((id) => !alreadySharedIds.has(id)).length;
+      for (const comic of visibleSelectable) {
+        if (slots <= 0) break;
+        const id = String(comic.id);
+        if (!next.has(id)) {
+          next.add(id);
+          --slots;
+        }
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!isValidShareEmail(recipientEmail)) {
+      setError("Please enter a valid recipient email address.");
+      return;
+    }
+    if (selectedComicIds.length === 0) {
+      setError("Select at least one comic to share.");
+      return;
+    }
+    if (!responsibilityAccepted) {
+      setError("Please confirm that you understand you are responsible for what you share.");
+      return;
+    }
+
+    setIsSending(true);
+    setError(null);
+
+    try {
+      const data = await api.post("/api/shares/invitations/bulk", {
+        comicIds: selectedComicIds.map(Number),
+        email: recipientEmail.trim(),
+        senderResponsibilityAccepted: true,
+      });
+
+      const created = Number(data.created || 0);
+      const total = Number(data.total || selectedComicIds.length);
+      const skipped = Math.max(0, total - created);
+
+      if (created === 0) {
+        const message = data.results?.find((result) => result.message)?.message
+          || "No new invitations were created.";
+        setError(message);
+        return;
+      }
+
+      toast({
+        title: created === 1 ? "Comic shared" : `${created} comics shared`,
+        description: skipped > 0
+          ? `${skipped} ${skipped === 1 ? "comic was" : "comics were"} skipped. Check the Sharing list for current access.`
+          : `Invitation${created === 1 ? "" : "s"} sent to ${recipientEmail.trim()}.`,
+      });
+
+      await onShared?.();
+      onClose();
+    } catch (err) {
+      logger.error("Bulk sharing failed:", err);
+      setError(err.message || "The comics could not be shared.");
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const selectionLimitReached = selectedComicIds.length >= MAX_BULK_COMICS;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isSending) onClose();
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[720px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Share2 className="h-5 w-5" />
+            Share comics
+          </DialogTitle>
+          <DialogDescription>
+            Choose comics you own, then send a private invitation to an exact email address or
+            somebody you have shared with before. Registered users are never searched or listed.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center gap-2 py-12 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            Loading your comics…
+          </div>
+        ) : (
+          <div className="space-y-6 py-2">
+            <section className="space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h3 className="font-semibold">1. Choose comics</h3>
+                  <p className="text-xs text-muted-foreground">
+                    {selectedComicIds.length}/{MAX_BULK_COMICS} selected
+                  </p>
+                </div>
+                {visibleSelectable.length > 0 && (
+                  <Button type="button" variant="outline" size="sm" onClick={toggleVisible}>
+                    {allVisibleSelected ? "Clear shown" : "Select shown"}
+                  </Button>
+                )}
+              </div>
+
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search your library…"
+                  className="pl-9"
+                />
+              </div>
+
+              <div className="max-h-64 divide-y overflow-y-auto rounded-md border">
+                {filteredComics.length === 0 ? (
+                  <p className="p-4 text-sm text-muted-foreground">No owned comics match this search.</p>
+                ) : filteredComics.map((comic) => {
+                  const id = String(comic.id);
+                  const alreadyShared = alreadySharedIds.has(id);
+                  const checked = selectedIds.has(id) && !alreadyShared;
+                  const disabled = alreadyShared || (selectionLimitReached && !checked);
+
+                  return (
+                    <label
+                      key={comic.id}
+                      className="flex cursor-pointer items-center gap-3 p-3 has-[[data-disabled]]:cursor-not-allowed has-[[data-disabled]]:opacity-60"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={disabled}
+                        onCheckedChange={() => toggleComic(comic.id)}
+                        aria-label={`Select ${comic.title}`}
+                      />
+                      {comic.coverImagePath ? (
+                        <img
+                          src={comic.coverImagePath}
+                          alt=""
+                          loading="lazy"
+                          className="h-14 w-10 flex-none rounded object-cover"
+                        />
+                      ) : (
+                        <div className="h-14 w-10 flex-none rounded bg-muted" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">{comic.title}</p>
+                        {comic.author && (
+                          <p className="truncate text-xs text-muted-foreground">{comic.author}</p>
+                        )}
+                        {comic.explicitContent && (
+                          <Badge variant="outline" className="mt-1">{EXPLICIT_FLAG_LABEL}</Badge>
+                        )}
+                      </div>
+                      {alreadyShared && (
+                        <Badge variant="secondary">Already shared</Badge>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <div>
+                <h3 className="font-semibold">2. Share with</h3>
+                <p className="text-xs text-muted-foreground">
+                  Recent recipients are only addresses you previously entered yourself.
+                </p>
+              </div>
+
+              {recentRecipients.length > 0 && (
+                <div className="flex flex-wrap gap-2" aria-label="Recent recipients">
+                  {recentRecipients.map((recipient) => (
+                    <Button
+                      key={recipient.email}
+                      type="button"
+                      size="sm"
+                      variant={normaliseEmail(recipientEmail) === normaliseEmail(recipient.email) ? "default" : "outline"}
+                      onClick={() => setRecipientEmail(recipient.email)}
+                    >
+                      {recipient.email}
+                    </Button>
+                  ))}
+                </div>
+              )}
+
+              <div className="grid gap-2">
+                <Label htmlFor="bulk-share-email">Recipient email</Label>
+                <Input
+                  id="bulk-share-email"
+                  type="email"
+                  autoComplete="off"
+                  value={recipientEmail}
+                  onChange={(event) => setRecipientEmail(event.target.value)}
+                  placeholder="recipient@example.com"
+                  disabled={isSending}
+                />
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <div>
+                <h3 className="font-semibold">3. Review</h3>
+                <p className="text-sm text-muted-foreground">
+                  {selectedComics.length === 0
+                    ? "Select at least one comic above."
+                    : `${selectedComics.length} ${selectedComics.length === 1 ? "comic" : "comics"} will be offered to ${recipientEmail.trim() || "the recipient"}.`}
+                </p>
+              </div>
+
+              {selectedComics.length > 0 && (
+                <ul className="max-h-28 list-disc overflow-y-auto pl-5 text-sm">
+                  {selectedComics.map((comic) => <li key={comic.id}>{comic.title}</li>)}
+                </ul>
+              )}
+
+              <div className="space-y-3 rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">{SHARE_RESPONSIBILITY_NOTICE}</p>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="bulk-share-responsibility"
+                    checked={responsibilityAccepted}
+                    onCheckedChange={(checked) => setResponsibilityAccepted(checked === true)}
+                    disabled={isSending}
+                  />
+                  <Label htmlFor="bulk-share-responsibility" className="cursor-pointer text-sm font-medium">
+                    {SHARE_RESPONSIBILITY_ACK_LABEL}
+                  </Label>
+                </div>
+              </div>
+            </section>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isSending}>Cancel</Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={
+              isLoading
+              || isSending
+              || selectedComicIds.length === 0
+              || !isValidShareEmail(recipientEmail)
+              || !responsibilityAccepted
+            }
+          >
+            {isSending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Send {selectedComicIds.length > 1 ? `${selectedComicIds.length} invitations` : "invitation"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ShareComicsDialog.jsx
+++ b/frontend/src/components/ShareComicsDialog.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Loader2, Search, Share2 } from "lucide-react";
+import { Check, Copy, Loader2, Search, Share2, UserCheck } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -21,8 +21,12 @@ import {
   SHARE_RESPONSIBILITY_ACK_LABEL,
   SHARE_RESPONSIBILITY_NOTICE,
   SHARE_STATUS,
+  SHARING_CODE_COPY,
   buildInvitationRequest,
+  formatSharingCode,
   isValidShareEmail,
+  isValidSharingCode,
+  normaliseSharingCode,
 } from "@/lib/sharing";
 import { useToast } from "@/hooks/use-toast";
 
@@ -51,18 +55,46 @@ function liveComicIdsForRecipient(sharedByMe, email) {
   return ids;
 }
 
+/**
+ * The three ways to name who a share is for.
+ *
+ * They differ only in how the recipient is identified; the comics, the review
+ * step and the responsibility acknowledgement are the same for all three,
+ * because the share they produce is the same share.
+ */
+const MODES = {
+  EMAIL: "email",
+  CODE: "code",
+  CLAIM: "claim",
+};
+
+const MAX_CLAIM_USES = 10;
+
 export function ShareComicsDialog({
   isOpen,
   onClose,
   sharedByMe = [],
   initialRecipient = "",
+  initialSharingCode = "",
   initialComicIds = [],
   onShared,
 }) {
   const [comics, setComics] = useState([]);
   const [recentRecipients, setRecentRecipients] = useState([]);
   const [search, setSearch] = useState("");
+  const [mode, setMode] = useState(initialSharingCode ? MODES.CODE : MODES.EMAIL);
   const [recipientEmail, setRecipientEmail] = useState(initialRecipient);
+  const [sharingCode, setSharingCode] = useState(initialSharingCode);
+  // The name behind a resolved code. Held separately from the code itself so a
+  // typed character invalidates the confirmation rather than leaving a stale
+  // name sitting next to a different code.
+  const [codeRecipient, setCodeRecipient] = useState(null);
+  const [isResolvingCode, setIsResolvingCode] = useState(false);
+  // Held as text, so the field can be emptied and retyped. Clamping every
+  // keystroke turns clearing "1" and typing "4" into 14.
+  const [claimUses, setClaimUses] = useState("1");
+  const [issuedClaimCode, setIssuedClaimCode] = useState(null);
+  const [claimCodeCopied, setClaimCodeCopied] = useState(false);
   const [selectedIds, setSelectedIds] = useState(
     () => new Set((initialComicIds || []).map((id) => String(id)))
   );
@@ -101,9 +133,12 @@ export function ShareComicsDialog({
     return () => { ignore = true; };
   }, [isOpen]);
 
+  // Only meaningful for an email recipient. A code names somebody the sender
+  // cannot match against their own list, and a claim code names nobody at all,
+  // so neither can mark a comic as already shared.
   const alreadySharedIds = useMemo(
-    () => liveComicIdsForRecipient(sharedByMe, recipientEmail),
-    [sharedByMe, recipientEmail]
+    () => liveComicIdsForRecipient(sharedByMe, mode === MODES.EMAIL ? recipientEmail : ""),
+    [sharedByMe, mode, recipientEmail]
   );
 
   const filteredComics = useMemo(() => {
@@ -169,17 +204,55 @@ export function ShareComicsDialog({
     });
   };
 
-  const handleSubmit = async () => {
-    if (!isValidShareEmail(recipientEmail)) {
-      setError("Please enter a valid recipient email address.");
-      return;
+  /** Check a code names somebody, before anything is offered to them. */
+  const resolveSharingCode = async () => {
+    setIsResolvingCode(true);
+    setError(null);
+    setCodeRecipient(null);
+
+    try {
+      const data = await api.post("/api/shares/resolve-code", {
+        sharingCode: normaliseSharingCode(sharingCode),
+      });
+      setCodeRecipient(data.recipient);
+    } catch (err) {
+      logger.error("Resolving a sharing code failed:", err);
+      setError(err.message || "That sharing code is not valid.");
+    } finally {
+      setIsResolvingCode(false);
     }
+  };
+
+  const copyClaimCode = async () => {
+    try {
+      await navigator.clipboard.writeText(issuedClaimCode);
+      setClaimCodeCopied(true);
+      setTimeout(() => setClaimCodeCopied(false), 2000);
+    } catch (err) {
+      logger.error("Could not copy the sharing code:", err);
+      toast({
+        title: "Could not copy the code",
+        description: "Select the code and copy it manually.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleSubmit = async () => {
     if (selectedComicIds.length === 0) {
       setError("Select at least one comic to share.");
       return;
     }
     if (!responsibilityAccepted) {
       setError("Please confirm that you understand you are responsible for what you share.");
+      return;
+    }
+    if (mode === MODES.EMAIL && !isValidShareEmail(recipientEmail)) {
+      setError("Please enter a valid recipient email address.");
+      return;
+    }
+    if (mode === MODES.CODE && !isValidSharingCode(sharingCode)) {
+      setError("Please enter a valid sharing code.");
       return;
     }
 
@@ -189,10 +262,44 @@ export function ShareComicsDialog({
     setError(null);
 
     try {
-      const data = await api.post("/api/shares/invitations/bulk", {
-        ...buildInvitationRequest({ email: recipient, responsibilityAccepted: true }),
-        comicIds: selectedComicIds.map(Number),
-      });
+      if (mode === MODES.CLAIM) {
+        const data = await api.post("/api/shares/claim-codes", {
+          comicIds: selectedComicIds.map(Number),
+          maxUses: claimUsesValue,
+          senderResponsibilityAccepted: true,
+        });
+
+        // Shown rather than auto-closing: this is the only moment the code
+        // exists in a readable form, because the server keeps only its hash.
+        setIssuedClaimCode(data.code);
+        toast({
+          title: "Sharing code created",
+          description: `Anyone you give it to can claim ${selectedComicIds.length === 1 ? "this comic" : "these comics"}, `
+            + `${claimUsesValue === 1 ? "once" : `up to ${claimUsesValue} times`}, within 24 hours.`,
+        });
+
+        try {
+          await onShared?.();
+        } catch (refreshError) {
+          logger.error("Sharing data refresh failed:", refreshError);
+        }
+
+        return;
+      }
+
+      // Exactly one of the two ways to name a recipient goes on the wire. The
+      // server picks the code when it is present, so sending both would make
+      // the typed address silently irrelevant.
+      const data = await api.post("/api/shares/invitations/bulk", mode === MODES.CODE
+        ? {
+          comicIds: selectedComicIds.map(Number),
+          sharingCode: normaliseSharingCode(sharingCode),
+          senderResponsibilityAccepted: true,
+        }
+        : {
+          ...buildInvitationRequest({ email: recipient, responsibilityAccepted: true }),
+          comicIds: selectedComicIds.map(Number),
+        });
 
       const results = Array.isArray(data.results) ? data.results : [];
       const created = Number(data.created) || results.filter((r) => r.status === "created").length;
@@ -207,15 +314,21 @@ export function ShareComicsDialog({
         return;
       }
 
+      // The recipient as the sender knows them. Reached by code, that is a
+      // name — the address is exactly what they were never given.
+      const sentTo = mode === MODES.CODE
+        ? (codeRecipient?.name || "them")
+        : recipient;
+
       toast({
         title: created === 1 ? "Comic shared" : `${created} comics shared`,
         // One email, however many comics went into it — so this says what the
         // recipient actually receives rather than implying a message each.
         description: refused.length > 0
-          ? `One invitation email was sent to ${recipient}. `
+          ? `One invitation email was sent to ${sentTo}. `
             + `${refused.length} ${refused.length === 1 ? "comic was" : "comics were"} left out`
             + `${reason ? `: ${reason}` : "."}`
-          : `One invitation email was sent to ${recipient}.`,
+          : `One invitation email was sent to ${sentTo}.`,
       });
 
       try {
@@ -241,6 +354,38 @@ export function ShareComicsDialog({
   };
 
   const selectionLimitReached = selectedComicIds.length >= MAX_BULK_COMICS;
+
+  /** The typed uses, made legal. The server enforces the same range. */
+  const claimUsesValue = Math.min(MAX_CLAIM_USES, Math.max(1, Number(claimUses) || 1));
+
+  // Who this share is for, in the sender's own terms. A code recipient is a
+  // name once it has been checked, and the code itself before that — never an
+  // address, which is the whole reason a code was used.
+  const recipientDescription = mode === MODES.CLAIM
+    ? "whoever you give the code to"
+    : mode === MODES.CODE
+      ? (codeRecipient?.name || (isValidSharingCode(sharingCode) ? sharingCode : "the recipient"))
+      : (recipientEmail.trim() || "the recipient");
+
+  const comicCountLabel = `${selectedComics.length} ${selectedComics.length === 1 ? "comic" : "comics"}`;
+
+  const reviewSummary = selectedComics.length === 0
+    ? "Select at least one comic above."
+    : mode === MODES.CLAIM
+      ? `${comicCountLabel} will be put behind a code that ${claimUsesValue === 1 ? "one person" : `up to ${claimUsesValue} people`} `
+        + "can claim within 24 hours. You can withdraw the code, or any share it created, at any time."
+      : `${comicCountLabel} will be offered to ${recipientDescription} in one invitation email. `
+        + "They must accept each one before they can read it, and you can withdraw any of them later.";
+
+  const recipientChosen = mode === MODES.CLAIM
+    || (mode === MODES.EMAIL && isValidShareEmail(recipientEmail))
+    || (mode === MODES.CODE && isValidSharingCode(sharingCode));
+
+  const canSubmit = selectedComicIds.length > 0 && responsibilityAccepted && recipientChosen;
+
+  const submitLabel = mode === MODES.CLAIM
+    ? "Create sharing code"
+    : `Send ${selectedComicIds.length > 1 ? `${selectedComicIds.length} invitations` : "invitation"}`;
 
   return (
     <Dialog
@@ -342,54 +487,188 @@ export function ShareComicsDialog({
             </section>
 
             <section className="space-y-3">
-              <div>
-                <h3 className="font-semibold">2. Share with</h3>
-                <p className="text-xs text-muted-foreground">
-                  Recent recipients are only addresses you previously entered yourself.
-                </p>
+              <h3 className="font-semibold">2. Share with</h3>
+
+              {/* One line of explanation per mode, swapped with the mode, so the
+                  dialog says what the chosen option does without stacking three
+                  paragraphs of guidance on top of each other. */}
+              <div className="flex flex-wrap gap-1 rounded-md border p-1" role="tablist">
+                {[
+                  [MODES.EMAIL, "Email address"],
+                  [MODES.CODE, "Sharing code"],
+                  [MODES.CLAIM, "Create a code"],
+                ].map(([value, label]) => (
+                  <Button
+                    key={value}
+                    type="button"
+                    role="tab"
+                    size="sm"
+                    variant={mode === value ? "default" : "ghost"}
+                    aria-selected={mode === value}
+                    disabled={isSending || issuedClaimCode !== null}
+                    onClick={() => { setMode(value); setError(null); }}
+                  >
+                    {label}
+                  </Button>
+                ))}
               </div>
 
-              {recentRecipients.length > 0 && (
-                <div className="flex flex-wrap gap-2" aria-label="Recent recipients">
-                  {recentRecipients.map((recipient) => (
-                    <Button
-                      key={recipient.email}
-                      type="button"
-                      size="sm"
-                      variant={normaliseEmail(recipientEmail) === normaliseEmail(recipient.email) ? "default" : "outline"}
-                      aria-pressed={normaliseEmail(recipientEmail) === normaliseEmail(recipient.email)}
+              {mode === MODES.EMAIL && (
+                <div className="space-y-3">
+                  <p className="text-xs text-muted-foreground">
+                    Recent recipients are only people you have shared with before. Registered users
+                    are never searched or listed.
+                  </p>
+
+                  {recentRecipients.length > 0 && (
+                    <div className="flex flex-wrap gap-2" aria-label="Recent recipients">
+                      {recentRecipients.filter((recipient) => recipient.email).map((recipient) => (
+                        <Button
+                          key={recipient.email}
+                          type="button"
+                          size="sm"
+                          variant={normaliseEmail(recipientEmail) === normaliseEmail(recipient.email) ? "default" : "outline"}
+                          aria-pressed={normaliseEmail(recipientEmail) === normaliseEmail(recipient.email)}
+                          disabled={isSending}
+                          onClick={() => setRecipientEmail(recipient.email)}
+                        >
+                          {recipient.label || recipient.email}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="grid gap-2">
+                    <Label htmlFor="bulk-share-email">Recipient email</Label>
+                    <Input
+                      id="bulk-share-email"
+                      type="email"
+                      autoComplete="off"
+                      value={recipientEmail}
+                      onChange={(event) => setRecipientEmail(event.target.value)}
+                      placeholder="recipient@example.com"
                       disabled={isSending}
-                      onClick={() => setRecipientEmail(recipient.email)}
-                    >
-                      {recipient.email}
-                    </Button>
-                  ))}
+                    />
+                  </div>
                 </div>
               )}
 
-              <div className="grid gap-2">
-                <Label htmlFor="bulk-share-email">Recipient email</Label>
-                <Input
-                  id="bulk-share-email"
-                  type="email"
-                  autoComplete="off"
-                  value={recipientEmail}
-                  onChange={(event) => setRecipientEmail(event.target.value)}
-                  placeholder="recipient@example.com"
-                  disabled={isSending}
-                />
-              </div>
+              {mode === MODES.CODE && (
+                <div className="space-y-3">
+                  <p className="text-xs text-muted-foreground">{SHARING_CODE_COPY.recipient}</p>
+
+                  {recentRecipients.some((recipient) => recipient.sharingCode) && (
+                    <div className="flex flex-wrap gap-2" aria-label="Recent code recipients">
+                      {recentRecipients.filter((recipient) => recipient.sharingCode).map((recipient) => (
+                        <Button
+                          key={recipient.sharingCode}
+                          type="button"
+                          size="sm"
+                          variant={sharingCode === recipient.sharingCode ? "default" : "outline"}
+                          aria-pressed={sharingCode === recipient.sharingCode}
+                          disabled={isSending}
+                          onClick={() => {
+                            setSharingCode(recipient.sharingCode);
+                            setCodeRecipient({ name: recipient.name });
+                          }}
+                        >
+                          {recipient.label}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="grid gap-2">
+                    <Label htmlFor="bulk-share-code">Their sharing code</Label>
+                    <div className="flex gap-2">
+                      <Input
+                        id="bulk-share-code"
+                        autoComplete="off"
+                        value={sharingCode}
+                        onChange={(event) => {
+                          setSharingCode(formatSharingCode(event.target.value));
+                          // A changed code is a different person until checked.
+                          setCodeRecipient(null);
+                        }}
+                        placeholder="XXXX-XXXX-XXXX"
+                        className="font-mono tracking-widest"
+                        disabled={isSending}
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={resolveSharingCode}
+                        disabled={isSending || isResolvingCode || !isValidSharingCode(sharingCode)}
+                      >
+                        {isResolvingCode && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        Check
+                      </Button>
+                    </div>
+                    {codeRecipient && (
+                      <p className="flex items-center gap-1 text-sm text-muted-foreground">
+                        <UserCheck className="h-4 w-4" />
+                        Sharing with <span className="font-medium">{codeRecipient.name}</span>
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {mode === MODES.CLAIM && (
+                <div className="space-y-3">
+                  <p className="text-xs text-muted-foreground">{SHARING_CODE_COPY.claim}</p>
+
+                  {issuedClaimCode ? (
+                    <div className="space-y-2 rounded-md border p-3">
+                      <p className="text-sm font-medium">Your code — copy it now</p>
+                      <div className="flex items-center gap-2">
+                        <code
+                          className="flex-1 rounded bg-muted px-3 py-2 font-mono text-sm tracking-widest"
+                          aria-label="Your new sharing code"
+                        >
+                          {issuedClaimCode}
+                        </code>
+                        <Button variant="outline" size="sm" onClick={copyClaimCode} aria-label="Copy the sharing code">
+                          {claimCodeCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                        </Button>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        It is not stored and cannot be shown again. Create another if you lose it.
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="grid gap-2">
+                      <Label htmlFor="bulk-share-uses">How many people may use it</Label>
+                      <div className="flex items-center gap-3">
+                        <Input
+                          id="bulk-share-uses"
+                          type="number"
+                          min={1}
+                          max={MAX_CLAIM_USES}
+                          value={claimUses}
+                          onChange={(event) => setClaimUses(
+                            event.target.value.replace(/[^0-9]/g, "").slice(0, 2)
+                          )}
+                          // Corrected when the field is left rather than as it
+                          // is typed, so what is sent is always what is shown.
+                          onBlur={() => setClaimUses(String(claimUsesValue))}
+                          className="w-24"
+                          disabled={isSending}
+                        />
+                        <span className="text-xs text-muted-foreground">
+                          1–{MAX_CLAIM_USES} uses · expires after 24 hours
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </section>
 
             <section className="space-y-3">
               <div>
                 <h3 className="font-semibold">3. Review</h3>
-                <p className="text-sm text-muted-foreground">
-                  {selectedComics.length === 0
-                    ? "Select at least one comic above."
-                    : `${selectedComics.length} ${selectedComics.length === 1 ? "comic" : "comics"} will be offered to ${recipientEmail.trim() || "the recipient"} in one invitation email. `
-                      + "They must accept each one before they can read it, and you can withdraw any of them later."}
-                </p>
+                <p className="text-sm text-muted-foreground">{reviewSummary}</p>
               </div>
 
               {selectedComics.length > 0 && (
@@ -419,20 +698,15 @@ export function ShareComicsDialog({
         )}
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={isSending}>Cancel</Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={
-              isLoading
-              || isSending
-              || selectedComicIds.length === 0
-              || !isValidShareEmail(recipientEmail)
-              || !responsibilityAccepted
-            }
-          >
-            {isSending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Send {selectedComicIds.length > 1 ? `${selectedComicIds.length} invitations` : "invitation"}
+          <Button variant="outline" onClick={onClose} disabled={isSending}>
+            {issuedClaimCode ? "Done" : "Cancel"}
           </Button>
+          {!issuedClaimCode && (
+            <Button onClick={handleSubmit} disabled={isLoading || isSending || !canSubmit}>
+              {isSending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {submitLabel}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/ShareComicsDialog.test.jsx
+++ b/frontend/src/components/ShareComicsDialog.test.jsx
@@ -116,4 +116,37 @@ describe("ShareComicsDialog", () => {
     await waitFor(() => expect(onShared).toHaveBeenCalled());
     expect(onClose).toHaveBeenCalled();
   });
+
+  it("closes after a successful share even if refreshing the sharing list fails", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onShared = vi.fn().mockRejectedValue(new Error("refresh failed"));
+    vi.mocked(api.post).mockResolvedValue({
+      created: 1,
+      total: 1,
+      results: [{ comicId: 1, status: "created" }],
+    });
+
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={onClose}
+        initialRecipient="jane@example.com"
+        initialComicIds={[1]}
+        sharedByMe={[]}
+        onShared={onShared}
+      />
+    );
+
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
+    await user.click(screen.getByRole("checkbox", { name: "I understand" }));
+    await user.click(screen.getByRole("button", { name: "Send invitation" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Invitation sent",
+      description: expect.stringContaining("could not refresh"),
+    }));
+  });
 });

--- a/frontend/src/components/ShareComicsDialog.test.jsx
+++ b/frontend/src/components/ShareComicsDialog.test.jsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ShareComicsDialog } from "./ShareComicsDialog";
 import { api } from "@/lib/api";
 
-const toast = vi.fn();
+const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
 
 vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn() } }));
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));

--- a/frontend/src/components/ShareComicsDialog.test.jsx
+++ b/frontend/src/components/ShareComicsDialog.test.jsx
@@ -115,6 +115,84 @@ describe("ShareComicsDialog", () => {
     ));
     await waitFor(() => expect(onShared).toHaveBeenCalled());
     expect(onClose).toHaveBeenCalled();
+    // One email, however many comics went into it — the wording must not
+    // promise the recipient a message each.
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "2 comics shared",
+      description: "One invitation email was sent to jane@example.com.",
+    }));
+  });
+
+  it("reports comics the server refused instead of calling them skipped", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    vi.mocked(api.post).mockResolvedValue({
+      created: 1,
+      total: 2,
+      results: [
+        { comicId: 1, status: "created" },
+        {
+          comicId: 2,
+          status: "skipped",
+          message: "An invitation is already pending for that person. Resend it instead.",
+        },
+      ],
+    });
+
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={onClose}
+        initialRecipient="jane@example.com"
+        initialComicIds={[1, 2]}
+        sharedByMe={[]}
+        onShared={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
+    await user.click(screen.getByRole("checkbox", { name: "I understand" }));
+    await user.click(screen.getByRole("button", { name: "Send 2 invitations" }));
+
+    await waitFor(() => expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Comic shared",
+      description: expect.stringContaining("1 comic was left out: An invitation is already pending"),
+    })));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps the dialog open and explains why when nothing was created", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    vi.mocked(api.post).mockResolvedValue({
+      created: 0,
+      total: 1,
+      results: [{
+        comicId: 1,
+        status: "skipped",
+        message: "This comic is already shared with that person.",
+      }],
+    });
+
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={onClose}
+        initialRecipient="jane@example.com"
+        initialComicIds={[1]}
+        sharedByMe={[]}
+        onShared={vi.fn()}
+      />
+    );
+
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
+    await user.click(screen.getByRole("checkbox", { name: "I understand" }));
+    await user.click(screen.getByRole("button", { name: "Send invitation" }));
+
+    expect(await screen.findByText("This comic is already shared with that person."))
+      .toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
   });
 
   it("closes after a successful share even if refreshing the sharing list fails", async () => {

--- a/frontend/src/components/ShareComicsDialog.test.jsx
+++ b/frontend/src/components/ShareComicsDialog.test.jsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ShareComicsDialog } from "./ShareComicsDialog";
+import { api } from "@/lib/api";
+
+const toast = vi.fn();
+
+vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
+
+const comics = [
+  { id: 1, title: "Batman #1", author: "Writer A", canShare: true, explicitContent: false },
+  { id: 2, title: "Superman #1", author: "Writer B", canShare: true, explicitContent: false },
+  { id: 3, title: "Received Comic", author: "Writer C", canShare: false, explicitContent: false },
+];
+
+const loadPicker = () => {
+  vi.mocked(api.get).mockImplementation((url) => {
+    if (url === "/api/comics?ownership=mine") return Promise.resolve({ comics });
+    if (url === "/api/shares/recent-recipients") {
+      return Promise.resolve({ recipients: [{ email: "jane@example.com" }] });
+    }
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+};
+
+describe("ShareComicsDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadPicker();
+  });
+
+  it("only offers owned shareable comics and sender-owned recipient history", async () => {
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={vi.fn()}
+        sharedByMe={[]}
+        onShared={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText("Batman #1")).toBeInTheDocument();
+    expect(screen.getByText("Superman #1")).toBeInTheDocument();
+    expect(screen.queryByText("Received Comic")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "jane@example.com" })).toBeInTheDocument();
+
+    expect(api.get).toHaveBeenCalledWith("/api/comics?ownership=mine");
+    expect(api.get).toHaveBeenCalledWith("/api/shares/recent-recipients");
+  });
+
+  it("marks live shares for the selected recipient instead of creating duplicates", async () => {
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={vi.fn()}
+        initialRecipient="jane@example.com"
+        sharedByMe={[{
+          comicId: 1,
+          recipients: [{
+            id: 10,
+            recipientEmail: "jane@example.com",
+            status: "accepted",
+            isExpired: false,
+          }],
+        }]}
+        onShared={vi.fn()}
+      />
+    );
+
+    await screen.findByText("Batman #1");
+    expect(screen.getByText("Already shared")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select Batman #1" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Select Superman #1" })).not.toBeDisabled();
+  });
+
+  it("submits several comics through the bulk endpoint with the acknowledgement", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onShared = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.post).mockResolvedValue({
+      created: 2,
+      total: 2,
+      results: [
+        { comicId: 1, status: "created" },
+        { comicId: 2, status: "created" },
+      ],
+    });
+
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={onClose}
+        initialRecipient="jane@example.com"
+        initialComicIds={[1, 2]}
+        sharedByMe={[]}
+        onShared={onShared}
+      />
+    );
+
+    await screen.findByText("Batman #1");
+    await user.click(screen.getByRole("checkbox", { name: "I understand" }));
+    await user.click(screen.getByRole("button", { name: "Send 2 invitations" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/shares/invitations/bulk",
+      {
+        comicIds: [1, 2],
+        email: "jane@example.com",
+        senderResponsibilityAccepted: true,
+      }
+    ));
+    await waitFor(() => expect(onShared).toHaveBeenCalled());
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ShareComicsDialog.test.jsx
+++ b/frontend/src/components/ShareComicsDialog.test.jsx
@@ -101,7 +101,7 @@ describe("ShareComicsDialog", () => {
       />
     );
 
-    await screen.findByText("Batman #1");
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
     await user.click(screen.getByRole("checkbox", { name: "I understand" }));
     await user.click(screen.getByRole("button", { name: "Send 2 invitations" }));
 

--- a/frontend/src/components/ShareComicsDialog.test.jsx
+++ b/frontend/src/components/ShareComicsDialog.test.jsx
@@ -161,6 +161,143 @@ describe("ShareComicsDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("shares by sharing code without ever asking for an address", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    vi.mocked(api.post).mockImplementation((url) => {
+      if (url === "/api/shares/resolve-code") {
+        return Promise.resolve({ recipient: { name: "Jane Reader", sharingCode: "7RFX-KP3M-Q82D" } });
+      }
+      return Promise.resolve({ created: 1, total: 1, results: [{ comicId: 1, status: "created" }] });
+    });
+
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={onClose}
+        initialSharingCode="7RFX-KP3M-Q82D"
+        initialComicIds={[1]}
+        sharedByMe={[]}
+        onShared={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
+    // A code opens the dialog on the code tab rather than the email one.
+    expect(screen.getByLabelText(/their sharing code/i)).toHaveValue("7RFX-KP3M-Q82D");
+
+    await user.click(screen.getByRole("button", { name: "Check" }));
+    expect(await screen.findByText("Jane Reader")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "I understand" }));
+    await user.click(screen.getByRole("button", { name: "Send invitation" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/shares/invitations/bulk",
+      {
+        comicIds: [1],
+        sharingCode: "7RFXKP3MQ82D",
+        senderResponsibilityAccepted: true,
+      }
+    ));
+    // The address is the whole thing a code withholds, so it must not appear on
+    // the wire or in what the sender is told afterwards.
+    expect(vi.mocked(api.post).mock.calls.every(([, body]) => !("email" in (body || {})))).toBe(true);
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      description: "One invitation email was sent to Jane Reader.",
+    }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("forgets a checked name as soon as the code is edited", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      recipient: { name: "Jane Reader", sharingCode: "7RFX-KP3M-Q82D" },
+    });
+
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={vi.fn()}
+        initialSharingCode="7RFX-KP3M-Q82D"
+        sharedByMe={[]}
+        onShared={vi.fn()}
+      />
+    );
+
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
+    await user.click(screen.getByRole("button", { name: "Check" }));
+    expect(await screen.findByText("Jane Reader")).toBeInTheDocument();
+
+    // A different code is a different person until it has been checked again.
+    await user.type(screen.getByLabelText(/their sharing code/i), "X");
+    expect(screen.queryByText("Jane Reader")).not.toBeInTheDocument();
+  });
+
+  it("creates a claim code and shows it once, without naming anybody", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    vi.mocked(api.post).mockResolvedValue({
+      code: "83AY-GXKP-SNSY",
+      claimCode: { id: 3, usesRemaining: 4, maxUses: 4 },
+    });
+
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={onClose}
+        initialComicIds={[1]}
+        sharedByMe={[]}
+        onShared={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
+    await user.click(screen.getByRole("tab", { name: "Create a code" }));
+
+    const uses = screen.getByLabelText(/how many people may use it/i);
+    await user.clear(uses);
+    await user.type(uses, "4");
+
+    await user.click(screen.getByRole("checkbox", { name: "I understand" }));
+    await user.click(screen.getByRole("button", { name: "Create sharing code" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/shares/claim-codes",
+      { comicIds: [1], maxUses: 4, senderResponsibilityAccepted: true }
+    ));
+
+    // Shown rather than auto-closed: only the hash is stored, so this is the
+    // one moment the code is readable.
+    expect(await screen.findByText("83AY-GXKP-SNSY")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+
+  it("will not let a claim code be created for more than ten people", async () => {
+    const user = userEvent.setup();
+    render(
+      <ShareComicsDialog
+        isOpen
+        onClose={vi.fn()}
+        initialComicIds={[1]}
+        sharedByMe={[]}
+        onShared={vi.fn()}
+      />
+    );
+
+    await screen.findByRole("checkbox", { name: "Select Batman #1" });
+    await user.click(screen.getByRole("tab", { name: "Create a code" }));
+
+    const uses = screen.getByLabelText(/how many people may use it/i);
+    await user.clear(uses);
+    await user.type(uses, "99");
+    // Corrected when the field is left, so what is sent is what is shown.
+    await user.tab();
+
+    expect(uses).toHaveValue(10);
+  });
+
   it("keeps the dialog open and explains why when nothing was created", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/frontend/src/components/SharingCodesCard.jsx
+++ b/frontend/src/components/SharingCodesCard.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
-import { Check, Copy, KeyRound, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Check, Copy, KeyRound, Loader2, XCircle } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -15,21 +16,47 @@ import {
   normaliseSharingCode,
 } from "@/lib/sharing";
 
+/** Why a code has stopped working, in the words the owner needs. */
+const DEAD_REASON_LABELS = {
+  withdrawn: "Withdrawn",
+  expired: "Expired",
+  used_up: "Used up",
+  comics_removed: "Comics removed",
+};
+
 /**
- * The two things somebody does with a code on their own account: hand out the
- * permanent one that identifies them, and redeem one they were given.
+ * Everything to do with codes on your own account: the permanent one that
+ * identifies you, redeeming one you were given, and withdrawing one you handed
+ * out before it would have died on its own.
  *
- * Creating a code that gives comics away is not here. That belongs to the
- * sharing flow, because it starts by choosing comics — this card is about the
- * account, not about a library.
+ * *Creating* a code that gives comics away is not here. That belongs to the
+ * sharing flow, because it starts by choosing comics — but the codes it creates
+ * come back here to be watched and withdrawn, so there is one place to look.
  */
-export function SharingCodesCard({ onRedeemed }) {
+export function SharingCodesCard({ onRedeemed, reloadKey = 0 }) {
   const [myCode, setMyCode] = useState(null);
   const [copied, setCopied] = useState(false);
   const [redeemValue, setRedeemValue] = useState("");
   const [isRedeeming, setIsRedeeming] = useState(false);
   const [redeemError, setRedeemError] = useState(null);
+  const [handedOut, setHandedOut] = useState([]);
+  const [withdrawingId, setWithdrawingId] = useState(null);
   const { toast } = useToast();
+
+  // Fetches without touching state, so both the effect below and the withdraw
+  // handler can decide for themselves whether their result is still wanted.
+  const fetchHandedOut = useCallback(
+    () => api.get("/api/shares/claim-codes")
+      .then((data) => data.codes || [])
+      .catch((err) => {
+        // Not worth an error banner: the rest of the page works, and this list
+        // is a record of what was handed out rather than what the page is for.
+        logger.error("Could not load handed-out sharing codes:", err);
+
+        return null;
+      }),
+    []
+  );
 
   useEffect(() => {
     let ignore = false;
@@ -38,13 +65,47 @@ export function SharingCodesCard({ onRedeemed }) {
       .then((data) => { if (!ignore) setMyCode(data); })
       .catch((err) => {
         if (ignore) return;
-        // Not worth an error banner: the rest of the page works, and the code
-        // is a convenience rather than something the page is for.
         logger.error("Could not load the sharing code:", err);
       });
 
     return () => { ignore = true; };
   }, []);
+
+  // Reloaded when the page says something changed — creating a code from the
+  // share dialog is what usually adds one to this list.
+  useEffect(() => {
+    let ignore = false;
+
+    fetchHandedOut().then((codes) => {
+      if (!ignore && codes) setHandedOut(codes);
+    });
+
+    return () => { ignore = true; };
+  }, [fetchHandedOut, reloadKey]);
+
+  const withdraw = async (code) => {
+    setWithdrawingId(code.id);
+
+    try {
+      await api.delete(`/api/shares/claim-codes/${code.id}`);
+      toast({
+        title: "Sharing code withdrawn",
+        description: "Nobody else can use it. Anyone who already claimed a comic keeps it — "
+          + "revoke them from Shared by me if you want it back.",
+      });
+      const codes = await fetchHandedOut();
+      if (codes) setHandedOut(codes);
+    } catch (err) {
+      logger.error("Withdrawing a sharing code failed:", err);
+      toast({
+        title: "Could not withdraw the code",
+        description: err.message || "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setWithdrawingId(null);
+    }
+  };
 
   const copyCode = async () => {
     try {
@@ -166,6 +227,49 @@ export function SharingCodesCard({ onRedeemed }) {
           </div>
           {redeemError && <p className="text-sm text-destructive">{redeemError}</p>}
         </div>
+
+        {handedOut.length > 0 && (
+          <div className="space-y-2 border-t pt-4 md:col-span-2">
+            <h2 className="font-semibold">Codes you have handed out</h2>
+            <p className="text-xs text-muted-foreground">{SHARING_CODE_COPY.handedOut}</p>
+            <ul className="divide-y rounded-md border">
+              {handedOut.map((code) => (
+                <li key={code.id} className="flex flex-wrap items-center justify-between gap-2 p-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm">
+                      {code.comicCount === 1 ? code.comicTitles[0] : `${code.comicCount} comics`}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {`Claimed ${code.timesUsed} of ${code.maxUses} ${code.maxUses === 1 ? "use" : "uses"}`
+                        + (code.isRedeemable
+                          ? ` · expires ${new Date(code.expiresAt).toLocaleString()}`
+                          : "")}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={code.isRedeemable ? "default" : "outline"}>
+                      {DEAD_REASON_LABELS[code.deadReason] || "Active"}
+                    </Badge>
+                    {code.isRedeemable && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={withdrawingId === code.id}
+                        aria-label={`Withdraw the code for ${code.comicCount === 1 ? code.comicTitles[0] : `${code.comicCount} comics`}`}
+                        onClick={() => withdraw(code)}
+                      >
+                        {withdrawingId === code.id
+                          ? <Loader2 className="h-4 w-4 animate-spin" />
+                          : <XCircle className="h-4 w-4" />}
+                        <span className="ml-2 hidden sm:inline">Withdraw</span>
+                      </Button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/SharingCodesCard.jsx
+++ b/frontend/src/components/SharingCodesCard.jsx
@@ -75,6 +75,17 @@ export function SharingCodesCard({ onRedeemed }) {
       const claimed = Number(data.claimed) || 0;
       const gated = (data.results || []).filter((r) => r.status === "awaiting_age_confirmation").length;
 
+      // A code can be spent without adding anything — every comic on it may
+      // already be shared with this account. "0 comics added" as a success
+      // toast reads like the feature working; it is not.
+      if (claimed === 0) {
+        setRedeemError(
+          (data.results || []).find((result) => result.message)?.message
+            || "That code added nothing new to your collection."
+        );
+        return;
+      }
+
       toast({
         title: claimed === 1 ? "Comic added" : `${claimed} comics added`,
         description: gated > 0

--- a/frontend/src/components/SharingCodesCard.jsx
+++ b/frontend/src/components/SharingCodesCard.jsx
@@ -1,9 +1,17 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Copy, KeyRound, Loader2, XCircle } from "lucide-react";
+import { Check, Copy, KeyRound, Loader2, RefreshCw, XCircle } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/lib/api";
@@ -41,6 +49,8 @@ export function SharingCodesCard({ onRedeemed, reloadKey = 0 }) {
   const [redeemError, setRedeemError] = useState(null);
   const [handedOut, setHandedOut] = useState([]);
   const [withdrawingId, setWithdrawingId] = useState(null);
+  const [confirmingRotation, setConfirmingRotation] = useState(false);
+  const [isRotating, setIsRotating] = useState(false);
   const { toast } = useToast();
 
   // Fetches without touching state, so both the effect below and the withdraw
@@ -82,6 +92,29 @@ export function SharingCodesCard({ onRedeemed, reloadKey = 0 }) {
 
     return () => { ignore = true; };
   }, [fetchHandedOut, reloadKey]);
+
+  const rotate = async () => {
+    setIsRotating(true);
+
+    try {
+      const data = await api.post("/api/shares/my-code/rotate", {});
+      setMyCode(data);
+      setConfirmingRotation(false);
+      toast({
+        title: "Sharing code replaced",
+        description: "The old code no longer works. Send the new one to anyone who needs it.",
+      });
+    } catch (err) {
+      logger.error("Rotating the sharing code failed:", err);
+      toast({
+        title: "Could not replace the code",
+        description: err.message || "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsRotating(false);
+    }
+  };
 
   const withdraw = async (code) => {
     setWithdrawingId(code.id);
@@ -199,6 +232,17 @@ export function SharingCodesCard({ onRedeemed, reloadKey = 0 }) {
             >
               {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
             </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!myCode || isRotating}
+              onClick={() => setConfirmingRotation(true)}
+              aria-label="Replace your sharing code"
+            >
+              {isRotating
+                ? <Loader2 className="h-4 w-4 animate-spin" />
+                : <RefreshCw className="h-4 w-4" />}
+            </Button>
           </div>
         </div>
 
@@ -271,6 +315,28 @@ export function SharingCodesCard({ onRedeemed, reloadKey = 0 }) {
           </div>
         )}
       </CardContent>
+
+      {/* A confirmation rather than a plain button: rotating is one click that
+          silently breaks the code in every conversation it was pasted into, and
+          that consequence has to be stated before it happens rather than
+          explained afterwards. */}
+      <Dialog open={confirmingRotation} onOpenChange={setConfirmingRotation}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Replace your sharing code?</DialogTitle>
+            <DialogDescription>{SHARING_CODE_COPY.rotate}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmingRotation(false)} disabled={isRotating}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={rotate} disabled={isRotating}>
+              {isRotating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Replace my code
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/frontend/src/components/SharingCodesCard.jsx
+++ b/frontend/src/components/SharingCodesCard.jsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { Check, Copy, KeyRound, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+import { useToast } from "@/hooks/use-toast";
+import {
+  SHARING_CODE_COPY,
+  formatSharingCode,
+  isValidSharingCode,
+  normaliseSharingCode,
+} from "@/lib/sharing";
+
+/**
+ * The two things somebody does with a code on their own account: hand out the
+ * permanent one that identifies them, and redeem one they were given.
+ *
+ * Creating a code that gives comics away is not here. That belongs to the
+ * sharing flow, because it starts by choosing comics — this card is about the
+ * account, not about a library.
+ */
+export function SharingCodesCard({ onRedeemed }) {
+  const [myCode, setMyCode] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [redeemValue, setRedeemValue] = useState("");
+  const [isRedeeming, setIsRedeeming] = useState(false);
+  const [redeemError, setRedeemError] = useState(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    let ignore = false;
+
+    api.get("/api/shares/my-code")
+      .then((data) => { if (!ignore) setMyCode(data); })
+      .catch((err) => {
+        if (ignore) return;
+        // Not worth an error banner: the rest of the page works, and the code
+        // is a convenience rather than something the page is for.
+        logger.error("Could not load the sharing code:", err);
+      });
+
+    return () => { ignore = true; };
+  }, []);
+
+  const copyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(myCode.sharingCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      // Clipboard access can be refused; the code is on screen and selectable,
+      // so say so rather than pretending the copy worked.
+      logger.error("Could not copy the sharing code:", err);
+      toast({
+        title: "Could not copy the code",
+        description: "Select the code and copy it manually.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const redeem = async () => {
+    setIsRedeeming(true);
+    setRedeemError(null);
+
+    try {
+      const data = await api.post("/api/shares/claim-codes/redeem", {
+        code: normaliseSharingCode(redeemValue),
+      });
+
+      const claimed = Number(data.claimed) || 0;
+      const gated = (data.results || []).filter((r) => r.status === "awaiting_age_confirmation").length;
+
+      toast({
+        title: claimed === 1 ? "Comic added" : `${claimed} comics added`,
+        description: gated > 0
+          ? `From ${data.ownerName}. ${gated === 1 ? "One comic needs" : `${gated} comics need`} your age confirmed below.`
+          : `${data.ownerName} shared ${claimed === 1 ? "a comic" : "these"} with you.`,
+      });
+
+      setRedeemValue("");
+
+      try {
+        await onRedeemed?.();
+      } catch (refreshError) {
+        logger.error("Sharing data refresh failed:", refreshError);
+        toast({
+          title: "Comics added",
+          description: "They were added, but the page could not refresh. Reload to see them.",
+          variant: "destructive",
+        });
+      }
+    } catch (err) {
+      logger.error("Redeeming a sharing code failed:", err);
+      setRedeemError(err.message || "That code could not be redeemed.");
+    } finally {
+      setIsRedeeming(false);
+    }
+  };
+
+  return (
+    <Card className="mb-6">
+      <CardContent className="grid gap-6 p-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4 text-comic-purple" />
+            <h2 className="font-semibold">Your sharing code</h2>
+          </div>
+          <p className="text-xs text-muted-foreground">{SHARING_CODE_COPY.mine}</p>
+          <div className="flex items-center gap-2">
+            <code
+              className="flex-1 rounded border bg-muted px-3 py-2 font-mono text-sm tracking-widest"
+              aria-label="Your sharing code"
+            >
+              {myCode?.sharingCode || "····-····-····"}
+            </code>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!myCode}
+              onClick={copyCode}
+              aria-label="Copy your sharing code"
+            >
+              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="font-semibold">Redeem a code</h2>
+          <p className="text-xs text-muted-foreground">{SHARING_CODE_COPY.redeem}</p>
+          <div className="flex items-end gap-2">
+            <div className="flex-1 space-y-1">
+              <Label htmlFor="redeem-sharing-code" className="sr-only">Sharing code</Label>
+              <Input
+                id="redeem-sharing-code"
+                value={redeemValue}
+                onChange={(event) => setRedeemValue(formatSharingCode(event.target.value))}
+                placeholder="XXXX-XXXX-XXXX"
+                className="font-mono tracking-widest"
+                disabled={isRedeeming}
+              />
+            </div>
+            <Button
+              onClick={redeem}
+              disabled={isRedeeming || !isValidSharingCode(redeemValue)}
+            >
+              {isRedeeming && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Redeem
+            </Button>
+          </div>
+          {redeemError && <p className="text-sm text-destructive">{redeemError}</p>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/SharingCodesCard.test.jsx
+++ b/frontend/src/components/SharingCodesCard.test.jsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SharingCodesCard } from "./SharingCodesCard";
+import { api } from "@/lib/api";
+
+const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
+
+vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
+
+const renderCard = (props = {}) => render(
+  <SharingCodesCard onRedeemed={vi.fn().mockResolvedValue(undefined)} {...props} />
+);
+
+describe("SharingCodesCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.get).mockResolvedValue({ name: "Test Reader", sharingCode: "7RFX-KP3M-Q82D" });
+  });
+
+  it("shows the account's own permanent code and never offers to change it", async () => {
+    renderCard();
+
+    expect(await screen.findByText("7RFX-KP3M-Q82D")).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledWith("/api/shares/my-code");
+    // The code is an address, not a credential. Rotating it would break every
+    // conversation it was ever pasted into, so nothing here offers to.
+    expect(screen.queryByRole("button", { name: /generate|regenerate|new code/i }))
+      .not.toBeInTheDocument();
+  });
+
+  it("keeps Redeem disabled until the code is the right shape", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const redeem = screen.getByRole("button", { name: "Redeem" });
+    expect(redeem).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("XXXX-XXXX-XXXX"), "7RFXKP3MQ82");
+    expect(redeem).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("XXXX-XXXX-XXXX"), "D");
+    expect(redeem).toBeEnabled();
+  });
+
+  it("groups and corrects what somebody types, the way the server will read it", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const input = screen.getByPlaceholderText("XXXX-XXXX-XXXX");
+    // Lowercase, no dashes, and the letters the alphabet leaves out: somebody
+    // transcribing a code by hand rather than holding the wrong one.
+    await user.type(input, "7rfxkpimq82o");
+
+    expect(input).toHaveValue("7RFX-KP1M-Q820");
+  });
+
+  it("redeems a code and reports what arrived", async () => {
+    const user = userEvent.setup();
+    const onRedeemed = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.post).mockResolvedValue({
+      claimed: 2,
+      ownerName: "Alex Owner",
+      results: [
+        { comicId: 1, status: "claimed" },
+        { comicId: 2, status: "claimed" },
+      ],
+    });
+
+    renderCard({ onRedeemed });
+
+    await user.type(screen.getByPlaceholderText("XXXX-XXXX-XXXX"), "7RFXKP3MQ82D");
+    await user.click(screen.getByRole("button", { name: "Redeem" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      "/api/shares/claim-codes/redeem",
+      { code: "7RFXKP3MQ82D" }
+    ));
+    expect(onRedeemed).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: "2 comics added" }));
+  });
+
+  it("says an explicit comic still needs an age confirmation", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      claimed: 2,
+      ownerName: "Alex Owner",
+      results: [
+        { comicId: 1, status: "claimed" },
+        { comicId: 2, status: "awaiting_age_confirmation" },
+      ],
+    });
+
+    renderCard();
+
+    await user.type(screen.getByPlaceholderText("XXXX-XXXX-XXXX"), "7RFXKP3MQ82D");
+    await user.click(screen.getByRole("button", { name: "Redeem" }));
+
+    // Redeeming stands in for accepting, but never for declaring an age.
+    await waitFor(() => expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      description: expect.stringContaining("age confirmed"),
+    })));
+  });
+
+  it("explains a code that cannot be redeemed without clearing what was typed", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockRejectedValue(
+      new Error("That sharing code is not valid, or has already been used up.")
+    );
+
+    renderCard();
+
+    await user.type(screen.getByPlaceholderText("XXXX-XXXX-XXXX"), "7RFXKP3MQ82D");
+    await user.click(screen.getByRole("button", { name: "Redeem" }));
+
+    expect(await screen.findByText(/already been used up/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("XXXX-XXXX-XXXX")).toHaveValue("7RFX-KP3M-Q82D");
+  });
+});

--- a/frontend/src/components/SharingCodesCard.test.jsx
+++ b/frontend/src/components/SharingCodesCard.test.jsx
@@ -7,9 +7,33 @@ import { api } from "@/lib/api";
 
 const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
 
-vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }));
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
 vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
+
+const liveCode = {
+  id: 3,
+  comicTitles: ["Batman #1"],
+  comicCount: 1,
+  maxUses: 5,
+  usesRemaining: 3,
+  timesUsed: 2,
+  expiresAt: "2026-08-10T10:00:00+00:00",
+  isExpired: false,
+  isRevoked: false,
+  isRedeemable: true,
+  deadReason: null,
+};
+
+const stubGets = (codes = []) => {
+  vi.mocked(api.get).mockImplementation((url) => {
+    if (url === "/api/shares/my-code") {
+      return Promise.resolve({ name: "Test Reader", sharingCode: "7RFX-KP3M-Q82D" });
+    }
+    if (url === "/api/shares/claim-codes") return Promise.resolve({ codes });
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+};
 
 const renderCard = (props = {}) => render(
   <SharingCodesCard onRedeemed={vi.fn().mockResolvedValue(undefined)} {...props} />
@@ -18,7 +42,7 @@ const renderCard = (props = {}) => render(
 describe("SharingCodesCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(api.get).mockResolvedValue({ name: "Test Reader", sharingCode: "7RFX-KP3M-Q82D" });
+    stubGets();
   });
 
   it("shows the account's own permanent code and never offers to change it", async () => {
@@ -30,6 +54,44 @@ describe("SharingCodesCard", () => {
     // conversation it was ever pasted into, so nothing here offers to.
     expect(screen.queryByRole("button", { name: /generate|regenerate|new code/i }))
       .not.toBeInTheDocument();
+  });
+
+  it("lets the owner withdraw a live code before it would have expired", async () => {
+    const user = userEvent.setup();
+    stubGets([liveCode]);
+    vi.mocked(api.delete).mockResolvedValue({ message: "Sharing code withdrawn." });
+
+    renderCard();
+
+    expect(await screen.findByText("Batman #1")).toBeInTheDocument();
+    expect(screen.getByText(/Claimed 2 of 5 uses/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /withdraw the code for batman #1/i }));
+
+    await waitFor(() => expect(api.delete).toHaveBeenCalledWith("/api/shares/claim-codes/3"));
+    // Withdrawing stops the code, not the shares it already produced.
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Sharing code withdrawn",
+      description: expect.stringContaining("already claimed a comic keeps it"),
+    }));
+  });
+
+  it("keeps a dead code listed and offers no way to withdraw it again", async () => {
+    stubGets([{
+      ...liveCode,
+      usesRemaining: 0,
+      timesUsed: 5,
+      isRedeemable: false,
+      deadReason: "used_up",
+    }]);
+
+    renderCard();
+
+    // Kept for a month after it dies, because "how many people took it up?" is
+    // asked after a code stops working, not while it still does.
+    expect(await screen.findByText("Used up")).toBeInTheDocument();
+    expect(screen.getByText(/Claimed 5 of 5 uses/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /withdraw/i })).not.toBeInTheDocument();
   });
 
   it("keeps Redeem disabled until the code is the right shape", async () => {

--- a/frontend/src/components/SharingCodesCard.test.jsx
+++ b/frontend/src/components/SharingCodesCard.test.jsx
@@ -45,15 +45,44 @@ describe("SharingCodesCard", () => {
     stubGets();
   });
 
-  it("shows the account's own permanent code and never offers to change it", async () => {
+  it("shows the account's own code", async () => {
     renderCard();
 
     expect(await screen.findByText("7RFX-KP3M-Q82D")).toBeInTheDocument();
     expect(api.get).toHaveBeenCalledWith("/api/shares/my-code");
-    // The code is an address, not a credential. Rotating it would break every
-    // conversation it was ever pasted into, so nothing here offers to.
-    expect(screen.queryByRole("button", { name: /generate|regenerate|new code/i }))
-      .not.toBeInTheDocument();
+  });
+
+  it("asks before replacing a code, because the old one breaks everywhere at once", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ name: "Test Reader", sharingCode: "83AY-GXKP-SNSY" });
+
+    renderCard();
+    await screen.findByText("7RFX-KP3M-Q82D");
+
+    await user.click(screen.getByRole("button", { name: /replace your sharing code/i }));
+
+    // The consequence is stated before it happens, not explained afterwards.
+    expect(await screen.findByText(/The old one stops working immediately/)).toBeInTheDocument();
+    expect(api.post).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Replace my code" }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith("/api/shares/my-code/rotate", {}));
+    // The new code replaces the old one on screen without a reload.
+    expect(await screen.findByText("83AY-GXKP-SNSY")).toBeInTheDocument();
+    expect(screen.queryByText("7RFX-KP3M-Q82D")).not.toBeInTheDocument();
+  });
+
+  it("keeps the old code when the rotation is cancelled", async () => {
+    const user = userEvent.setup();
+    renderCard();
+    await screen.findByText("7RFX-KP3M-Q82D");
+
+    await user.click(screen.getByRole("button", { name: /replace your sharing code/i }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(api.post).not.toHaveBeenCalled();
+    expect(screen.getByText("7RFX-KP3M-Q82D")).toBeInTheDocument();
   });
 
   it("lets the owner withdraw a live code before it would have expired", async () => {

--- a/frontend/src/components/SharingCodesCard.test.jsx
+++ b/frontend/src/components/SharingCodesCard.test.jsx
@@ -105,6 +105,26 @@ describe("SharingCodesCard", () => {
     })));
   });
 
+  it("does not call a code that added nothing a success", async () => {
+    const user = userEvent.setup();
+    const onRedeemed = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.post).mockResolvedValue({
+      claimed: 0,
+      ownerName: "Alex Owner",
+      results: [{ comicId: 1, status: "already_yours", message: "You already have this comic." }],
+    });
+
+    renderCard({ onRedeemed });
+
+    await user.type(screen.getByPlaceholderText("XXXX-XXXX-XXXX"), "7RFXKP3MQ82D");
+    await user.click(screen.getByRole("button", { name: "Redeem" }));
+
+    // A spent code that changed nothing is not "0 comics added".
+    expect(await screen.findByText("You already have this comic.")).toBeInTheDocument();
+    expect(toast).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText("XXXX-XXXX-XXXX")).toHaveValue("7RFX-KP3M-Q82D");
+  });
+
   it("explains a code that cannot be redeemed without clearing what was typed", async () => {
     const user = userEvent.setup();
     vi.mocked(api.post).mockRejectedValue(

--- a/frontend/src/lib/sharing.js
+++ b/frontend/src/lib/sharing.js
@@ -256,6 +256,9 @@ export const SHARING_CODE_COPY = {
   claim: "Create a code instead of naming anyone. Anyone you give it to can claim these "
     + "comics until it runs out of uses, and it expires after 24 hours.",
   redeem: "Someone sent you a code? Redeem it here to add their comics to your collection.",
+  handedOut: "Withdraw a code at any time to stop anyone else using it. Anyone who already "
+    + "claimed a comic keeps it until you revoke them. Codes that have stopped working are kept "
+    + "for a month so you can see who took them up.",
 };
 
 /**

--- a/frontend/src/lib/sharing.js
+++ b/frontend/src/lib/sharing.js
@@ -202,6 +202,82 @@ export function isValidShareEmail(email) {
 }
 
 /* -------------------------------------------------------------------------- */
+/* Sharing codes                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Mirrors SharingCodeFormat on the server: twelve characters from Crockford's
+ * alphabet, shown in threes. No I, L, O or U, so a code read off one screen and
+ * typed into another survives the trip.
+ */
+export const SHARING_CODE_LENGTH = 12;
+
+const SHARING_CODE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/**
+ * What somebody typed, reduced to the form the server compares.
+ *
+ * Lowercase, spaces, missing dashes and the letters the alphabet leaves out are
+ * all somebody transcribing a code by hand rather than holding the wrong one,
+ * so they are corrected here exactly as they are on the server.
+ */
+export function normaliseSharingCode(value) {
+  if (typeof value !== "string") return "";
+
+  return value
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .replace(/I|L/g, "1")
+    .replace(/O/g, "0")
+    .replace(/U/g, "V")
+    .slice(0, SHARING_CODE_LENGTH);
+}
+
+/** The grouped form, which is the only form anybody is shown. */
+export function formatSharingCode(value) {
+  const normalised = normaliseSharingCode(value);
+
+  return (normalised.match(/.{1,4}/g) || []).join("-");
+}
+
+export function isValidSharingCode(value) {
+  const normalised = normaliseSharingCode(value);
+
+  return normalised.length === SHARING_CODE_LENGTH
+    && [...normalised].every((character) => SHARING_CODE_ALPHABET.includes(character));
+}
+
+/** How the two kinds of code are described wherever they are offered. */
+export const SHARING_CODE_COPY = {
+  mine: "Give this to someone so they can share comics with you. It never changes, "
+    + "and it only ever shows them your name — never your email address.",
+  recipient: "Share with someone by their code instead of their email address. "
+    + "You will see their name to check you have the right person.",
+  claim: "Create a code instead of naming anyone. Anyone you give it to can claim these "
+    + "comics until it runs out of uses, and it expires after 24 hours.",
+  redeem: "Someone sent you a code? Redeem it here to add their comics to your collection.",
+};
+
+/**
+ * What an owner is shown against a recipient.
+ *
+ * A recipient reached by code has no address to show — that was the point —
+ * so the server sends a label instead and this prefers it wherever it exists.
+ */
+export function recipientLabel(recipient) {
+  return recipient?.recipientLabel || recipient?.recipientEmail || "Shared by code";
+}
+
+/** Whether this recipient can be reached again, and how. */
+export function recipientTarget(recipient) {
+  if (recipient?.recipientSharingCode) {
+    return { sharingCode: recipient.recipientSharingCode, email: "" };
+  }
+
+  return { sharingCode: "", email: recipient?.recipientEmail || "" };
+}
+
+/* -------------------------------------------------------------------------- */
 /* Explicit content                                                            */
 /* -------------------------------------------------------------------------- */
 

--- a/frontend/src/lib/sharing.js
+++ b/frontend/src/lib/sharing.js
@@ -249,8 +249,11 @@ export function isValidSharingCode(value) {
 
 /** How the two kinds of code are described wherever they are offered. */
 export const SHARING_CODE_COPY = {
-  mine: "Give this to someone so they can share comics with you. It never changes, "
-    + "and it only ever shows them your name — never your email address.",
+  mine: "Give this to someone so they can share comics with you. It only ever shows them "
+    + "your name — never your email address.",
+  rotate: "Replace your code if it has ended up somewhere you did not intend. The old one stops "
+    + "working immediately, and anyone who still has it will need the new one. Comics already "
+    + "shared with you are not affected.",
   recipient: "Share with someone by their code instead of their email address. "
     + "You will see their name to check you have the right person.",
   claim: "Create a code instead of naming anyone. Anyone you give it to can claim these "

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -5,6 +5,7 @@ import { Navigate, useSearchParams } from "react-router-dom";
 import { AdminUsersList } from "@/components/AdminUsersList";
 import { AdminComicsList } from "@/components/AdminComicsList";
 import { AdminTagsList } from "@/components/AdminTagsList";
+import { AdminSharingCodesList } from "@/components/AdminSharingCodesList";
 import { AdminOverview } from "@/components/AdminOverview";
 import { AdminDropbox } from "@/components/AdminDropbox";
 import { AdminAuditList } from "@/components/AdminAuditList";
@@ -53,6 +54,7 @@ export default function AdminDashboard() {
           <TabsTrigger value="users">Users</TabsTrigger>
           <TabsTrigger value="comics">Comics</TabsTrigger>
           <TabsTrigger value="tags">Tags</TabsTrigger>
+          <TabsTrigger value="sharing-codes">Sharing codes</TabsTrigger>
           <TabsTrigger value="dropbox">Dropbox</TabsTrigger>
           <TabsTrigger value="audit">Audit</TabsTrigger>
         </TabsList>
@@ -75,6 +77,10 @@ export default function AdminDashboard() {
         
         <TabsContent value="tags" className="space-y-6">
           <AdminTagsList />
+        </TabsContent>
+
+        <TabsContent value="sharing-codes" className="space-y-6">
+          <AdminSharingCodesList />
         </TabsContent>
 
         <TabsContent value="dropbox" className="space-y-6">

--- a/frontend/src/pages/AdminUserDetails.jsx
+++ b/frontend/src/pages/AdminUserDetails.jsx
@@ -59,6 +59,8 @@ function AdminUserDetailsPage({ userId }) {
   const [form, setForm] = useState({ name: "", password: "", roles: [] });
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isRotateOpen, setIsRotateOpen] = useState(false);
+  const [isRotatingCode, setIsRotatingCode] = useState(false);
 
   const passwordErrors = form.password ? validatePassword(form.password) : [];
   const isSelf = currentUser && user && currentUser.id === user.id;
@@ -131,6 +133,23 @@ function AdminUserDetailsPage({ userId }) {
       toast({ title: "User verified" });
     } catch (error) {
       toast({ title: "Verification failed", description: error.message, variant: "destructive" });
+    }
+  };
+
+  const rotateSharingCode = async () => {
+    setIsRotatingCode(true);
+
+    try {
+      await api.post(`/api/users/${userId}/sharing-code/rotate`, {});
+      toast({
+        title: "Sharing code replaced",
+        description: "The old code no longer works. The user can see the new one on their Sharing page.",
+      });
+    } catch (error) {
+      toast({ title: "Could not replace the code", description: error.message, variant: "destructive" });
+    } finally {
+      setIsRotatingCode(false);
+      setIsRotateOpen(false);
     }
   };
 
@@ -294,6 +313,31 @@ function AdminUserDetailsPage({ userId }) {
             </CardContent>
           </Card>
 
+          {/* Support's version of the button the user has on their own Sharing
+              page, for when they report the code has ended up somewhere they
+              cannot take it back from. The new code is deliberately not shown
+              here: an administrator has no reason to hold somebody's contact
+              handle, and the user reads it off their own page. */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Sharing code</CardTitle>
+              <CardDescription>
+                Replace this user&apos;s sharing code if it has been posted somewhere they did not
+                intend. The old code stops working immediately. Comics already shared with them,
+                and people they have shared with, are not affected.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="outline"
+                onClick={() => setIsRotateOpen(true)}
+                disabled={isRotatingCode}
+              >
+                {isRotatingCode ? "Replacing…" : "Replace sharing code"}
+              </Button>
+            </CardContent>
+          </Card>
+
           <Card className="border-destructive/40">
             <CardHeader>
               <CardTitle className="flex items-center gap-2"><ShieldAlert className="h-5 w-5" /> Delete account</CardTitle>
@@ -332,6 +376,27 @@ function AdminUserDetailsPage({ userId }) {
               onClick={(event) => { event.preventDefault(); deleteUser(); }}
             >
               Delete account
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={isRotateOpen} onOpenChange={setIsRotateOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Replace this user&apos;s sharing code?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The old code stops working immediately, and anyone who still has it will need the new
+              one. Existing shares are not affected. The user can see the new code on their own
+              Sharing page.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => { event.preventDefault(); rotateSharingCode(); }}
+            >
+              Replace sharing code
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/pages/Sharing.jsx
+++ b/frontend/src/pages/Sharing.jsx
@@ -215,6 +215,7 @@ export default function Sharing() {
                         <Button
                           size="sm"
                           variant="ghost"
+                          aria-label={`Share another comic with ${recipient.recipientEmail}`}
                           onClick={() => setShareDialog({
                             recipient: recipient.recipientEmail,
                             comicIds: [],

--- a/frontend/src/pages/Sharing.jsx
+++ b/frontend/src/pages/Sharing.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -27,7 +27,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
-import { ShareComicModal } from "@/components/ShareComicModal";
+import { ShareComicsDialog } from "@/components/ShareComicsDialog";
 import { useSharingLists } from "@/hooks/use-sharing";
 import { useComicLibrary } from "@/hooks/use-comic-library";
 import {
@@ -90,7 +90,7 @@ export default function Sharing() {
   // The two dialogs act on a comic or on the whole history rather than on one
   // share, so they get their own flag instead of borrowing a share id.
   const [isDialogBusy, setIsDialogBusy] = useState(false);
-  const [inviteTarget, setInviteTarget] = useState(null);
+  const [shareDialog, setShareDialog] = useState(null);
   const [confirmingCleanup, setConfirmingCleanup] = useState(false);
   const [stopSharingTarget, setStopSharingTarget] = useState(null);
 
@@ -125,6 +125,11 @@ export default function Sharing() {
     }
   };
 
+  const refreshAfterShare = async () => {
+    await reload();
+    await loadLibrary();
+  };
+
   const cleanupCopy = describeDeadShareCleanup(dead.length);
 
   /**
@@ -147,10 +152,20 @@ export default function Sharing() {
       return (
         <>
           {responsibilityReminder}
-          <p className="py-12 text-center text-muted-foreground">
-            You have not shared any comics yet. Use the share action on a comic in{" "}
-            <Link to="/dashboard" className="text-primary hover:underline">your library</Link>.
-          </p>
+          <div className="py-12 text-center text-muted-foreground">
+            <p>You have not shared any comics yet.</p>
+            <p className="mt-1 text-sm">
+              Share comics privately with someone you know. They must accept the invitation before
+              they can read anything.
+            </p>
+            <Button
+              className="mt-4"
+              onClick={() => setShareDialog({ recipient: "", comicIds: [] })}
+            >
+              <UserPlus className="mr-2 h-4 w-4" />
+              Share comics
+            </Button>
+          </div>
         </>
       );
     }
@@ -183,7 +198,7 @@ export default function Sharing() {
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={() => setInviteTarget({ id: group.comicId, title: group.title })}
+                      onClick={() => setShareDialog({ recipient: "", comicIds: [group.comicId] })}
                     >
                       <UserPlus className="mr-2 h-4 w-4" />
                       Invite someone
@@ -215,10 +230,21 @@ export default function Sharing() {
                           <span className="text-xs text-muted-foreground">Invitation expired</span>
                         )}
                       </div>
-                      <div className="flex items-center gap-2">
+                      <div className="flex flex-wrap items-center justify-end gap-2">
                         <Badge variant={STATUS_VARIANTS[recipient.status] || "outline"}>
                           {SHARE_STATUS_LABELS[recipient.status] || recipient.status}
                         </Badge>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => setShareDialog({
+                            recipient: recipient.recipientEmail,
+                            comicIds: [],
+                          })}
+                        >
+                          <UserPlus className="h-4 w-4" />
+                          <span className="ml-2 hidden md:inline">Share another comic</span>
+                        </Button>
                         {recipient.canResend && (
                           <Button
                             size="sm"
@@ -490,9 +516,15 @@ export default function Sharing() {
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="mb-8 flex items-center gap-3">
-        <Share2Icon className="h-6 w-6 text-comic-purple" />
-        <h1 className="font-comic text-3xl">Sharing</h1>
+      <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Share2Icon className="h-6 w-6 text-comic-purple" />
+          <h1 className="font-comic text-3xl">Sharing</h1>
+        </div>
+        <Button onClick={() => setShareDialog({ recipient: "", comicIds: [] })}>
+          <UserPlus className="mr-2 h-4 w-4" />
+          Share comics
+        </Button>
       </div>
 
       <p className="mb-6 max-w-3xl text-sm text-muted-foreground">
@@ -528,13 +560,17 @@ export default function Sharing() {
         </Tabs>
       )}
 
-      <ShareComicModal
-        isOpen={inviteTarget !== null}
-        onClose={() => setInviteTarget(null)}
-        comicId={inviteTarget?.id}
-        comicTitle={inviteTarget?.title}
-        onShared={reload}
-      />
+      {shareDialog && (
+        <ShareComicsDialog
+          key={`${shareDialog.recipient}:${shareDialog.comicIds.join(",")}`}
+          isOpen
+          onClose={() => setShareDialog(null)}
+          sharedByMe={sharedByMe}
+          initialRecipient={shareDialog.recipient}
+          initialComicIds={shareDialog.comicIds}
+          onShared={refreshAfterShare}
+        />
+      )}
 
       <Dialog open={confirmingCleanup} onOpenChange={setConfirmingCleanup}>
         <DialogContent>

--- a/frontend/src/pages/Sharing.jsx
+++ b/frontend/src/pages/Sharing.jsx
@@ -57,6 +57,8 @@ function ShareCover({ src, title, gated = false }) {
   if (!src) {
     return (
       <div className="flex h-24 w-16 flex-none items-center justify-center rounded bg-muted">
+        {/* No cover URL and none coming: for a gated share the server withheld
+            it, so this placeholder stands in rather than a blurred real one. */}
         {gated
           ? <ShieldAlert className="h-6 w-6 text-muted-foreground" />
           : <BookOpen className="h-6 w-6 text-muted-foreground" />}
@@ -81,18 +83,37 @@ export default function Sharing() {
   const { toast } = useToast();
   const navigate = useNavigate();
 
+  // The share currently being acted on, not the action being taken. Accept and
+  // Decline are alternatives, as are Resend and Revoke, so keying this by
+  // action would leave the opposite button live and let two conflicting
+  // transitions be requested for one share at once.
   const [busyShareId, setBusyShareId] = useState(null);
+  // The two confirmation dialogs act on a comic or on the whole history rather
+  // than on one share, so they get their own flag instead of borrowing a share
+  // id.
   const [isDialogBusy, setIsDialogBusy] = useState(false);
+  // The multi-comic flow, or null when it is closed. Holds the recipient and
+  // comics it should open with, so "Share another comic" can arrive with the
+  // recipient already chosen.
   const [shareDialog, setShareDialog] = useState(null);
   const [inviteTarget, setInviteTarget] = useState(null);
   const [confirmingCleanup, setConfirmingCleanup] = useState(false);
   const [stopSharingTarget, setStopSharingTarget] = useState(null);
+  // Controlled so a completed share can move the page to the half that now has
+  // something new on it. Answering an invitation is what most visits are for,
+  // so that stays the tab the page opens on.
+  const [activeTab, setActiveTab] = useState("with-me");
 
   const { invitations, collection, dead } = useMemo(
     () => groupReceivedShares(sharedWithMe),
     [sharedWithMe]
   );
 
+  /**
+   * Every action here changes what the collection contains, so the library is
+   * reloaded alongside the sharing lists. Without that, accepting an invitation
+   * would leave the dashboard showing a collection that predates it.
+   */
   const runAction = async (shareId, action, successMessage) => {
     setBusyShareId(shareId);
     try {
@@ -114,13 +135,31 @@ export default function Sharing() {
     }
   };
 
+  /**
+   * What both sharing flows do once invitations exist: the new relationships
+   * belong on **Shared by me**, and a comic that was not shared before now is.
+   * Deliberately not wrapped in a try — the dialog reports a refresh failure
+   * itself, and must not mistake one for a share that did not happen.
+   */
   const refreshAfterShare = async () => {
+    // Before the reload rather than after it, so a sender who started from the
+    // header is not left looking at "Shared with me" wondering whether anything
+    // happened — even if the refresh itself fails.
+    setActiveTab("by-me");
     await reload();
     await loadLibrary();
   };
 
   const cleanupCopy = describeDeadShareCleanup(dead.length);
 
+  /**
+   * The sender-side reminder.
+   *
+   * Informational only — the acknowledgement that actually goes on the record
+   * is the tick box in the share dialog, once per share. This is here so the
+   * expectation is visible while somebody is looking at what they have already
+   * handed out, not only at the moment they hand out the next one.
+   */
   const responsibilityReminder = (
     <Alert className="mb-4">
       <ShieldAlert className="h-5 w-5" />
@@ -202,6 +241,9 @@ export default function Sharing() {
                       key={recipient.id}
                       className="flex flex-wrap items-center justify-between gap-2 px-3 py-2"
                     >
+                      {/* Every share here belongs to a comic the owner still
+                          has — a deleted one leaves this list entirely — so the
+                          only state worth calling out is a lapsed invitation. */}
                       <div className="min-w-0">
                         <span className="block truncate text-sm">{recipient.recipientEmail}</span>
                         {recipient.status === SHARE_STATUS.PENDING && recipient.isExpired && (
@@ -269,6 +311,12 @@ export default function Sharing() {
     );
   };
 
+  /**
+   * Record the age declaration for one share and reload.
+   *
+   * The same endpoint the invitation page uses, because it is the same
+   * declaration: the gate follows the share, not the screen it is met on.
+   */
   const confirmAdult = (share) => runAction(
     share.id,
     () => api.post(`/api/shares/${share.id}/confirm-adult`, { adultConfirmed: true }),
@@ -346,6 +394,8 @@ export default function Sharing() {
                         Restore
                       </Button>
                     )}
+                    {/* A tombstone offers no way to read anything — there is
+                        nothing left behind it — only a way to clear the entry. */}
                     {share.isDead && (
                       <Button
                         size="sm"
@@ -413,6 +463,11 @@ export default function Sharing() {
                             {describeReceivedShare(share)}
                           </p>
                         </div>
+                        {/* The emailed link is not the only way in: somebody
+                            signed in and looking at their own invitation has
+                            already identified themselves. That still is not an
+                            age declaration, so an explicit invitation offers the
+                            gate here instead of Accept. */}
                         <div className="flex flex-none flex-col gap-2">
                           {gated ? (
                             <Button
@@ -512,7 +567,7 @@ export default function Sharing() {
           </AlertDescription>
         </Alert>
       ) : (
-        <Tabs defaultValue="with-me" className="space-y-6">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
           <TabsList>
             <TabsTrigger value="with-me">
               Shared with me ({sharedWithMe.length})
@@ -526,6 +581,9 @@ export default function Sharing() {
         </Tabs>
       )}
 
+      {/* Mounted only while open, and keyed on what it opens with, so a dialog
+          started from a different recipient never inherits the previous
+          selection or a stale "already shared" marking. */}
       {shareDialog && (
         <ShareComicsDialog
           key={`${shareDialog.recipient}:${shareDialog.comicIds.join(",")}`}
@@ -538,6 +596,10 @@ export default function Sharing() {
         />
       )}
 
+      {/* Kept alongside the multi-comic flow rather than replaced by it: this
+          is the one-comic shortcut, and it is the only path that hands the
+          owner the copyable invitation link for when the email does not
+          arrive. */}
       {inviteTarget && (
         <ShareComicModal
           key={inviteTarget.id}

--- a/frontend/src/pages/Sharing.jsx
+++ b/frontend/src/pages/Sharing.jsx
@@ -106,6 +106,10 @@ export default function Sharing() {
   // something new on it. Answering an invitation is what most visits are for,
   // so that stays the tab the page opens on.
   const [activeTab, setActiveTab] = useState("with-me");
+  // Bumped whenever a sharing action completes, so the codes card refetches
+  // what has been handed out. A code created from the share dialog belongs in
+  // that list straight away.
+  const [codesReloadKey, setCodesReloadKey] = useState(0);
 
   const { invitations, collection, dead } = useMemo(
     () => groupReceivedShares(sharedWithMe),
@@ -149,6 +153,7 @@ export default function Sharing() {
     // header is not left looking at "Shared with me" wondering whether anything
     // happened — even if the refresh itself fails.
     setActiveTab("by-me");
+    setCodesReloadKey((key) => key + 1);
     await reload();
     await loadLibrary();
   };
@@ -578,7 +583,7 @@ export default function Sharing() {
       {/* Above the tabs, because neither half of the page owns it: your own
           code is how people reach you, and redeeming one is how a comic arrives
           without anybody knowing your address. */}
-      <SharingCodesCard onRedeemed={refreshAfterReceiving} />
+      <SharingCodesCard onRedeemed={refreshAfterReceiving} reloadKey={codesReloadKey} />
 
       {isLoading ? (
         <div className="flex items-center gap-2 py-12 text-muted-foreground">

--- a/frontend/src/pages/Sharing.jsx
+++ b/frontend/src/pages/Sharing.jsx
@@ -29,6 +29,7 @@ import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import { ShareComicModal } from "@/components/ShareComicModal";
 import { ShareComicsDialog } from "@/components/ShareComicsDialog";
+import { SharingCodesCard } from "@/components/SharingCodesCard";
 import { useSharingLists } from "@/hooks/use-sharing";
 import { useComicLibrary } from "@/hooks/use-comic-library";
 import {
@@ -41,6 +42,8 @@ import {
   describeDeadShareCleanup,
   describeReceivedShare,
   groupReceivedShares,
+  recipientLabel,
+  recipientTarget,
   requiresAdultConfirmation,
   shareDisplayTitle,
   summariseRecipients,
@@ -150,6 +153,17 @@ export default function Sharing() {
     await loadLibrary();
   };
 
+  /**
+   * The mirror of the above, for comics arriving rather than leaving. Redeeming
+   * a code puts them under **Shared with me**, which is already the tab the page
+   * opens on, so this only reloads.
+   */
+  const refreshAfterReceiving = async () => {
+    setActiveTab("with-me");
+    await reload();
+    await loadLibrary();
+  };
+
   const cleanupCopy = describeDeadShareCleanup(dead.length);
 
   /**
@@ -180,7 +194,7 @@ export default function Sharing() {
             </p>
             <Button
               className="mt-4"
-              onClick={() => setShareDialog({ recipient: "", comicIds: [] })}
+              onClick={() => setShareDialog({ email: "", sharingCode: "", comicIds: [] })}
             >
               <UserPlus className="mr-2 h-4 w-4" />
               Share comics
@@ -243,9 +257,17 @@ export default function Sharing() {
                     >
                       {/* Every share here belongs to a comic the owner still
                           has — a deleted one leaves this list entirely — so the
-                          only state worth calling out is a lapsed invitation. */}
+                          only state worth calling out is a lapsed invitation.
+                          Somebody reached by their sharing code is named rather
+                          than addressed: the point of the code was that the
+                          sender never learned the address. */}
                       <div className="min-w-0">
-                        <span className="block truncate text-sm">{recipient.recipientEmail}</span>
+                        <span className="block truncate text-sm">{recipientLabel(recipient)}</span>
+                        {recipient.recipientSharingCode && (
+                          <span className="text-xs text-muted-foreground">
+                            Sharing code {recipient.recipientSharingCode}
+                          </span>
+                        )}
                         {recipient.status === SHARE_STATUS.PENDING && recipient.isExpired && (
                           <span className="text-xs text-muted-foreground">Invitation expired</span>
                         )}
@@ -257,9 +279,9 @@ export default function Sharing() {
                         <Button
                           size="sm"
                           variant="ghost"
-                          aria-label={`Share another comic with ${recipient.recipientEmail}`}
+                          aria-label={`Share another comic with ${recipientLabel(recipient)}`}
                           onClick={() => setShareDialog({
-                            recipient: recipient.recipientEmail,
+                            ...recipientTarget(recipient),
                             comicIds: [],
                           })}
                         >
@@ -542,7 +564,7 @@ export default function Sharing() {
           <Share2Icon className="h-6 w-6 text-comic-purple" />
           <h1 className="font-comic text-3xl">Sharing</h1>
         </div>
-        <Button onClick={() => setShareDialog({ recipient: "", comicIds: [] })}>
+        <Button onClick={() => setShareDialog({ email: "", sharingCode: "", comicIds: [] })}>
           <UserPlus className="mr-2 h-4 w-4" />
           Share comics
         </Button>
@@ -552,6 +574,11 @@ export default function Sharing() {
         Sharing gives someone permission to read your comic. The file stays yours — nothing is
         copied — and you can withdraw access at any time.
       </p>
+
+      {/* Above the tabs, because neither half of the page owns it: your own
+          code is how people reach you, and redeeming one is how a comic arrives
+          without anybody knowing your address. */}
+      <SharingCodesCard onRedeemed={refreshAfterReceiving} />
 
       {isLoading ? (
         <div className="flex items-center gap-2 py-12 text-muted-foreground">
@@ -586,11 +613,12 @@ export default function Sharing() {
           selection or a stale "already shared" marking. */}
       {shareDialog && (
         <ShareComicsDialog
-          key={`${shareDialog.recipient}:${shareDialog.comicIds.join(",")}`}
+          key={`${shareDialog.email}:${shareDialog.sharingCode}:${shareDialog.comicIds.join(",")}`}
           isOpen
           onClose={() => setShareDialog(null)}
           sharedByMe={sharedByMe}
-          initialRecipient={shareDialog.recipient}
+          initialRecipient={shareDialog.email}
+          initialSharingCode={shareDialog.sharingCode}
           initialComicIds={shareDialog.comicIds}
           onShared={refreshAfterShare}
         />

--- a/frontend/src/pages/Sharing.jsx
+++ b/frontend/src/pages/Sharing.jsx
@@ -27,6 +27,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
+import { ShareComicModal } from "@/components/ShareComicModal";
 import { ShareComicsDialog } from "@/components/ShareComicsDialog";
 import { useSharingLists } from "@/hooks/use-sharing";
 import { useComicLibrary } from "@/hooks/use-comic-library";
@@ -56,8 +57,6 @@ function ShareCover({ src, title, gated = false }) {
   if (!src) {
     return (
       <div className="flex h-24 w-16 flex-none items-center justify-center rounded bg-muted">
-        {/* No cover URL and none coming: for a gated share the server withheld
-            it, so this placeholder stands in rather than a blurred real one. */}
         {gated
           ? <ShieldAlert className="h-6 w-6 text-muted-foreground" />
           : <BookOpen className="h-6 w-6 text-muted-foreground" />}
@@ -82,15 +81,10 @@ export default function Sharing() {
   const { toast } = useToast();
   const navigate = useNavigate();
 
-  // The share currently being acted on, not the action being taken. Accept and
-  // Decline are alternatives, as are Resend and Revoke, so keying this by
-  // action would leave the opposite button live and let two conflicting
-  // transitions be requested for one share at once.
   const [busyShareId, setBusyShareId] = useState(null);
-  // The two dialogs act on a comic or on the whole history rather than on one
-  // share, so they get their own flag instead of borrowing a share id.
   const [isDialogBusy, setIsDialogBusy] = useState(false);
   const [shareDialog, setShareDialog] = useState(null);
+  const [inviteTarget, setInviteTarget] = useState(null);
   const [confirmingCleanup, setConfirmingCleanup] = useState(false);
   const [stopSharingTarget, setStopSharingTarget] = useState(null);
 
@@ -99,11 +93,6 @@ export default function Sharing() {
     [sharedWithMe]
   );
 
-  /**
-   * Every action here changes what the collection contains, so the library is
-   * reloaded alongside the sharing lists. Without that, accepting an invitation
-   * would leave the dashboard showing a collection that predates it.
-   */
   const runAction = async (shareId, action, successMessage) => {
     setBusyShareId(shareId);
     try {
@@ -132,14 +121,6 @@ export default function Sharing() {
 
   const cleanupCopy = describeDeadShareCleanup(dead.length);
 
-  /**
-   * The sender-side reminder.
-   *
-   * Informational only — the acknowledgement that actually goes on the record
-   * is the tick box in the share modal, once per share. This is here so the
-   * expectation is visible while somebody is looking at what they have already
-   * handed out, not only at the moment they hand out the next one.
-   */
   const responsibilityReminder = (
     <Alert className="mb-4">
       <ShieldAlert className="h-5 w-5" />
@@ -198,7 +179,7 @@ export default function Sharing() {
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={() => setShareDialog({ recipient: "", comicIds: [group.comicId] })}
+                      onClick={() => setInviteTarget({ id: group.comicId, title: group.title })}
                     >
                       <UserPlus className="mr-2 h-4 w-4" />
                       Invite someone
@@ -221,9 +202,6 @@ export default function Sharing() {
                       key={recipient.id}
                       className="flex flex-wrap items-center justify-between gap-2 px-3 py-2"
                     >
-                      {/* Every share here belongs to a comic the owner still
-                          has — a deleted one leaves this list entirely — so the
-                          only state worth calling out is a lapsed invitation. */}
                       <div className="min-w-0">
                         <span className="block truncate text-sm">{recipient.recipientEmail}</span>
                         {recipient.status === SHARE_STATUS.PENDING && recipient.isExpired && (
@@ -290,12 +268,6 @@ export default function Sharing() {
     );
   };
 
-  /**
-   * Record the age declaration for one share and reload.
-   *
-   * The same endpoint the invitation page uses, because it is the same
-   * declaration: the gate follows the share, not the screen it is met on.
-   */
   const confirmAdult = (share) => runAction(
     share.id,
     () => api.post(`/api/shares/${share.id}/confirm-adult`, { adultConfirmed: true }),
@@ -308,93 +280,91 @@ export default function Sharing() {
         const gated = requiresAdultConfirmation(share);
 
         return (
-        <li key={share.id}>
-          <Card>
-            <CardContent className="flex gap-4 p-4">
-              <ShareCover src={share.coverImagePath} title={shareDisplayTitle(share)} gated={gated} />
-              <div className="min-w-0 flex-1">
-                <h3 className="truncate font-bold">{shareDisplayTitle(share)}</h3>
-                <p className="truncate text-sm text-muted-foreground">
-                  Shared by {share.ownerName}
-                  {share.comicAuthor ? ` · ${share.comicAuthor}` : ""}
-                </p>
-                {gated && (
-                  <p className="mt-1 flex items-center gap-1 text-sm font-medium text-destructive">
-                    <ShieldAlert className="h-4 w-4" />
-                    {EXPLICIT_GATE_TITLE}
+          <li key={share.id}>
+            <Card>
+              <CardContent className="flex gap-4 p-4">
+                <ShareCover src={share.coverImagePath} title={shareDisplayTitle(share)} gated={gated} />
+                <div className="min-w-0 flex-1">
+                  <h3 className="truncate font-bold">{shareDisplayTitle(share)}</h3>
+                  <p className="truncate text-sm text-muted-foreground">
+                    Shared by {share.ownerName}
+                    {share.comicAuthor ? ` · ${share.comicAuthor}` : ""}
                   </p>
-                )}
-                <p className="mt-1 text-sm text-muted-foreground">{describeReceivedShare(share)}</p>
-              </div>
-              {showActions && (
-                <div className="flex flex-none flex-col gap-2">
-                  {gated && !share.isDead && (
-                    <Button
-                      size="sm"
-                      disabled={busyShareId === share.id}
-                      onClick={() => confirmAdult(share)}
-                    >
-                      {busyShareId === share.id && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                      {EXPLICIT_GATE_CONFIRM_LABEL}
-                    </Button>
+                  {gated && (
+                    <p className="mt-1 flex items-center gap-1 text-sm font-medium text-destructive">
+                      <ShieldAlert className="h-4 w-4" />
+                      {EXPLICIT_GATE_TITLE}
+                    </p>
                   )}
-                  {share.canRead && (
-                    <Button size="sm" onClick={() => navigate(`/read/${share.comicId}`)}>
-                      <BookOpen className="mr-2 h-4 w-4" />
-                      Read
-                    </Button>
-                  )}
-                  {share.canRemove && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={busyShareId === share.id}
-                      onClick={() => runAction(
-                        share.id,
-                        () => api.post(`/api/shares/${share.id}/remove`, {}),
-                        "Removed from your collection."
-                      )}
-                    >
-                      Remove from my collection
-                    </Button>
-                  )}
-                  {share.canRestore && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={busyShareId === share.id}
-                      onClick={() => runAction(
-                        share.id,
-                        () => api.post(`/api/shares/${share.id}/restore`, {}),
-                        "Restored to your collection."
-                      )}
-                    >
-                      <Undo2 className="mr-2 h-4 w-4" />
-                      Restore
-                    </Button>
-                  )}
-                  {/* A tombstone offers no way to read anything — there is
-                      nothing left behind it — only a way to clear the entry. */}
-                  {share.isDead && (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      disabled={busyShareId === share.id}
-                      onClick={() => runAction(
-                        share.id,
-                        () => api.delete("/api/shares/tombstones", { body: { shareIds: [share.id] } }),
-                        "Entry removed."
-                      )}
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Remove
-                    </Button>
-                  )}
+                  <p className="mt-1 text-sm text-muted-foreground">{describeReceivedShare(share)}</p>
                 </div>
-              )}
-            </CardContent>
-          </Card>
-        </li>
+                {showActions && (
+                  <div className="flex flex-none flex-col gap-2">
+                    {gated && !share.isDead && (
+                      <Button
+                        size="sm"
+                        disabled={busyShareId === share.id}
+                        onClick={() => confirmAdult(share)}
+                      >
+                        {busyShareId === share.id && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        {EXPLICIT_GATE_CONFIRM_LABEL}
+                      </Button>
+                    )}
+                    {share.canRead && (
+                      <Button size="sm" onClick={() => navigate(`/read/${share.comicId}`)}>
+                        <BookOpen className="mr-2 h-4 w-4" />
+                        Read
+                      </Button>
+                    )}
+                    {share.canRemove && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busyShareId === share.id}
+                        onClick={() => runAction(
+                          share.id,
+                          () => api.post(`/api/shares/${share.id}/remove`, {}),
+                          "Removed from your collection."
+                        )}
+                      >
+                        Remove from my collection
+                      </Button>
+                    )}
+                    {share.canRestore && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busyShareId === share.id}
+                        onClick={() => runAction(
+                          share.id,
+                          () => api.post(`/api/shares/${share.id}/restore`, {}),
+                          "Restored to your collection."
+                        )}
+                      >
+                        <Undo2 className="mr-2 h-4 w-4" />
+                        Restore
+                      </Button>
+                    )}
+                    {share.isDead && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={busyShareId === share.id}
+                        onClick={() => runAction(
+                          share.id,
+                          () => api.delete("/api/shares/tombstones", { body: { shareIds: [share.id] } }),
+                          "Entry removed."
+                        )}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Remove
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </li>
         );
       })}
     </ul>
@@ -419,72 +389,67 @@ export default function Sharing() {
                 const gated = requiresAdultConfirmation(share);
 
                 return (
-                <li key={share.id}>
-                  <Card>
-                    <CardContent className="flex gap-4 p-4">
-                      <ShareCover
-                        src={share.coverImagePath}
-                        title={shareDisplayTitle(share)}
-                        gated={gated}
-                      />
-                      <div className="min-w-0 flex-1">
-                        <h3 className="truncate font-bold">{shareDisplayTitle(share)}</h3>
-                        <p className="truncate text-sm text-muted-foreground">
-                          {share.ownerName} wants to share this with you.
-                        </p>
-                        {gated && (
-                          <p className="mt-1 flex items-center gap-1 text-sm font-medium text-destructive">
-                            <ShieldAlert className="h-4 w-4" />
-                            {EXPLICIT_GATE_TITLE}
+                  <li key={share.id}>
+                    <Card>
+                      <CardContent className="flex gap-4 p-4">
+                        <ShareCover
+                          src={share.coverImagePath}
+                          title={shareDisplayTitle(share)}
+                          gated={gated}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <h3 className="truncate font-bold">{shareDisplayTitle(share)}</h3>
+                          <p className="truncate text-sm text-muted-foreground">
+                            {share.ownerName} wants to share this with you.
                           </p>
-                        )}
-                        <p className="mt-1 text-sm text-muted-foreground">
-                          {describeReceivedShare(share)}
-                        </p>
-                      </div>
-                      {/* The emailed link is not the only way in: somebody
-                          signed in and looking at their own invitation has
-                          already identified themselves. That still is not an
-                          age declaration, so an explicit invitation offers the
-                          gate here instead of Accept. */}
-                      <div className="flex flex-none flex-col gap-2">
-                        {gated ? (
+                          {gated && (
+                            <p className="mt-1 flex items-center gap-1 text-sm font-medium text-destructive">
+                              <ShieldAlert className="h-4 w-4" />
+                              {EXPLICIT_GATE_TITLE}
+                            </p>
+                          )}
+                          <p className="mt-1 text-sm text-muted-foreground">
+                            {describeReceivedShare(share)}
+                          </p>
+                        </div>
+                        <div className="flex flex-none flex-col gap-2">
+                          {gated ? (
+                            <Button
+                              size="sm"
+                              disabled={!share.canAnswer || busyShareId === share.id}
+                              onClick={() => confirmAdult(share)}
+                            >
+                              {EXPLICIT_GATE_CONFIRM_LABEL}
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              disabled={!share.canAnswer || busyShareId === share.id}
+                              onClick={() => runAction(
+                                share.id,
+                                () => api.post(`/api/shares/${share.id}/accept`, {}),
+                                "Comic added to your collection."
+                              )}
+                            >
+                              Add to my collection
+                            </Button>
+                          )}
                           <Button
                             size="sm"
-                            disabled={!share.canAnswer || busyShareId === share.id}
-                            onClick={() => confirmAdult(share)}
-                          >
-                            {EXPLICIT_GATE_CONFIRM_LABEL}
-                          </Button>
-                        ) : (
-                          <Button
-                            size="sm"
+                            variant="outline"
                             disabled={!share.canAnswer || busyShareId === share.id}
                             onClick={() => runAction(
                               share.id,
-                              () => api.post(`/api/shares/${share.id}/accept`, {}),
-                              "Comic added to your collection."
+                              () => api.post(`/api/shares/${share.id}/decline`, {}),
+                              "Invitation declined."
                             )}
                           >
-                            Add to my collection
+                            Decline
                           </Button>
-                        )}
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          disabled={!share.canAnswer || busyShareId === share.id}
-                          onClick={() => runAction(
-                            share.id,
-                            () => api.post(`/api/shares/${share.id}/decline`, {}),
-                            "Invitation declined."
-                          )}
-                        >
-                          Decline
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </li>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </li>
                 );
               })}
             </ul>
@@ -568,6 +533,17 @@ export default function Sharing() {
           sharedByMe={sharedByMe}
           initialRecipient={shareDialog.recipient}
           initialComicIds={shareDialog.comicIds}
+          onShared={refreshAfterShare}
+        />
+      )}
+
+      {inviteTarget && (
+        <ShareComicModal
+          key={inviteTarget.id}
+          isOpen
+          onClose={() => setInviteTarget(null)}
+          comicId={inviteTarget.id}
+          comicTitle={inviteTarget.title}
           onShared={refreshAfterShare}
         />
       )}

--- a/frontend/src/pages/Sharing.test.jsx
+++ b/frontend/src/pages/Sharing.test.jsx
@@ -22,6 +22,7 @@ const stubGets = (overrides = {}) => {
     if (url === "/api/shares/my-code") {
       return Promise.resolve({ name: "Test Reader", sharingCode: "AAAA-BBBB-CCCC" });
     }
+    if (url === "/api/shares/claim-codes") return Promise.resolve({ codes: [] });
     if (url === "/api/comics?ownership=mine") return Promise.resolve({ comics: [] });
     if (url === "/api/shares/recent-recipients") return Promise.resolve({ recipients: [] });
     return Promise.reject(new Error(`Unexpected GET ${url}`));

--- a/frontend/src/pages/Sharing.test.jsx
+++ b/frontend/src/pages/Sharing.test.jsx
@@ -10,6 +10,23 @@ import { EXPLICIT_GATE_TITLE, SHARING_PAGE_RESPONSIBILITY_REMINDER } from "@/lib
 const lists = { sharedByMe: [], sharedWithMe: [], isLoading: false, error: null, reload: vi.fn() };
 
 vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }));
+
+/**
+ * The page asks for the account's own sharing code as soon as it mounts, and
+ * the picker asks for the library. Neither is what most of these tests are
+ * about, so they answer emptily unless a test says otherwise.
+ */
+const stubGets = (overrides = {}) => {
+  vi.mocked(api.get).mockImplementation((url) => {
+    if (url in overrides) return Promise.resolve(overrides[url]);
+    if (url === "/api/shares/my-code") {
+      return Promise.resolve({ name: "Test Reader", sharingCode: "AAAA-BBBB-CCCC" });
+    }
+    if (url === "/api/comics?ownership=mine") return Promise.resolve({ comics: [] });
+    if (url === "/api/shares/recent-recipients") return Promise.resolve({ recipients: [] });
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+};
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
 vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
 vi.mock("@/hooks/use-sharing", () => ({
@@ -54,6 +71,7 @@ const openSharedByMe = async (user) => {
 describe("Sharing page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stubGets();
     lists.sharedByMe = [];
     lists.sharedWithMe = [];
     lists.isLoading = false;
@@ -175,12 +193,6 @@ describe("Sharing page", () => {
       explicitContent: false,
       recipients: [{ id: 1, recipientEmail: "jane@example.com", status: "accepted" }],
     }];
-    vi.mocked(api.get).mockImplementation((url) => {
-      if (url === "/api/comics?ownership=mine") return Promise.resolve({ comics: [] });
-      if (url === "/api/shares/recent-recipients") return Promise.resolve({ recipients: [] });
-      return Promise.reject(new Error(`Unexpected GET ${url}`));
-    });
-
     renderPage();
     await openSharedByMe(user);
     await user.click(screen.getByRole("button", { name: /share another comic with jane@example.com/i }));
@@ -192,6 +204,37 @@ describe("Sharing page", () => {
     expect(api.get).toHaveBeenCalledWith("/api/comics?ownership=mine");
     expect(api.get).toHaveBeenCalledWith("/api/shares/recent-recipients");
     expect(vi.mocked(api.get).mock.calls.every(([url]) => !url.startsWith("/api/users"))).toBe(true);
+  });
+
+  it("names a code recipient instead of showing an address the sender never had", async () => {
+    const user = userEvent.setup();
+    lists.sharedByMe = [{
+      comicId: 5,
+      title: "Sandman",
+      author: "Neil Gaiman",
+      coverImagePath: null,
+      explicitContent: false,
+      recipients: [{
+        id: 1,
+        // What the server sends for somebody reached by their code: no address,
+        // because withholding it was the whole point.
+        recipientEmail: null,
+        recipientLabel: "Jane Reader",
+        recipientSharingCode: "7RFX-KP3M-Q82D",
+        status: "accepted",
+      }],
+    }];
+
+    renderPage();
+    await openSharedByMe(user);
+
+    expect(screen.getByText("Jane Reader")).toBeInTheDocument();
+    expect(screen.getByText("Sharing code 7RFX-KP3M-Q82D")).toBeInTheDocument();
+
+    // Sharing again reaches them the same way, by code rather than by address.
+    await user.click(screen.getByRole("button", { name: /share another comic with jane reader/i }));
+    expect(await screen.findByLabelText(/their sharing code/i)).toHaveValue("7RFX-KP3M-Q82D");
+    expect(screen.queryByLabelText(/recipient email/i)).not.toBeInTheDocument();
   });
 
   it("leaves a non-explicit share entirely alone", () => {

--- a/frontend/src/pages/Sharing.test.jsx
+++ b/frontend/src/pages/Sharing.test.jsx
@@ -152,6 +152,48 @@ describe("Sharing page", () => {
     expect(screen.getByText("Hidden — explicit content (18+)")).toBeInTheDocument();
   });
 
+  it("offers to start a share without sending anyone back to their library", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // On the header, so it is there before anything has ever been shared…
+    expect(screen.getByRole("button", { name: /^share comics$/i })).toBeInTheDocument();
+
+    // …and again in the empty state, which used to dead-end into /dashboard.
+    await openSharedByMe(user);
+    expect(screen.getAllByRole("button", { name: /^share comics$/i })).toHaveLength(2);
+    expect(screen.queryByRole("link", { name: /your library/i })).not.toBeInTheDocument();
+  });
+
+  it("preselects the recipient when sharing another comic with someone", async () => {
+    const user = userEvent.setup();
+    lists.sharedByMe = [{
+      comicId: 5,
+      title: "Sandman",
+      author: "Neil Gaiman",
+      coverImagePath: null,
+      explicitContent: false,
+      recipients: [{ id: 1, recipientEmail: "jane@example.com", status: "accepted" }],
+    }];
+    vi.mocked(api.get).mockImplementation((url) => {
+      if (url === "/api/comics?ownership=mine") return Promise.resolve({ comics: [] });
+      if (url === "/api/shares/recent-recipients") return Promise.resolve({ recipients: [] });
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+
+    renderPage();
+    await openSharedByMe(user);
+    await user.click(screen.getByRole("button", { name: /share another comic with jane@example.com/i }));
+
+    const email = await screen.findByLabelText(/recipient email/i);
+    expect(email).toHaveValue("jane@example.com");
+    // The picker asks for the caller's own comics and their own share history —
+    // never for a list of registered users.
+    expect(api.get).toHaveBeenCalledWith("/api/comics?ownership=mine");
+    expect(api.get).toHaveBeenCalledWith("/api/shares/recent-recipients");
+    expect(vi.mocked(api.get).mock.calls.every(([url]) => !url.startsWith("/api/users"))).toBe(true);
+  });
+
   it("leaves a non-explicit share entirely alone", () => {
     lists.sharedWithMe = [receivedShare({
       comicId: 5,

--- a/scripts/server/server-install.sh
+++ b/scripts/server/server-install.sh
@@ -156,10 +156,21 @@ Next steps (do them once):
    $APP_DIR/scripts/server/backup-comics.sh
    Optionally: sudo ln -sf $APP_DIR/scripts/server/backup-comics.sh /usr/local/bin/backup-comics
 
-5. (Optional) Daily Dropbox sync — install a systemd timer or cron job:
-   0 */2 * * * cd $APP_DIR/backend && php bin/console app:sync-dropbox-comics --env=prod >/var/log/comics-dropbox.log 2>&1
+5. REQUIRED: schedule the retention jobs — crontab -e as the deploy user.
+   Nothing runs these on its own. The retention periods in .env.local are
+   policy only; without these three the instance keeps everything for ever.
 
-6. From your laptop, set up scripts/.env.deploy and from now on deploy with:
+   0  3 * * * cd $APP_DIR/backend && php bin/console app:cleanup-personal-data --env=prod >>/var/log/comics-cleanup.log 2>&1
+   5  3 * * * cd $APP_DIR/backend && php bin/console app:cleanup-expired-shares --env=prod >>/var/log/comics-cleanup.log 2>&1
+   15 3 * * * cd $APP_DIR/backend && php bin/console app:cleanup-logs --env=prod >>/var/log/comics-cleanup.log 2>&1
+
+   See SSH-deploy.md section 7 for what each one removes and how to check the
+   schedule is actually firing.
+
+6. (Optional) Dropbox sync, only if this instance imports from Dropbox:
+   0 */2 * * * cd $APP_DIR/backend && php bin/console app:dropbox-sync --env=prod >>/var/log/comics-dropbox.log 2>&1
+
+7. From your laptop, set up scripts/.env.deploy and from now on deploy with:
    ./scripts/deploy-ssh.sh
 
 ==============================================================================


### PR DESCRIPTION
## Summary

Implements #101 — both the Phase 1 sharing UX and the Phase 2 sharing codes, the latter in the shape asked for on this PR rather than exactly as §9 sketches it.

## Phase 1 — starting a share from `/sharing`

- a global **Share comics** action on the page header and in the empty state, so `/sharing` no longer dead-ends into the library
- an owned-comic picker with search and multi-select (max 20)
- exact-email sharing, plus recent recipients derived only from addresses the owner previously entered
- **Share another comic** on each recipient row, with the recipient preselected
- comics already live-shared with the selected recipient are marked and cannot be shared twice
- a completed share moves the page to **Shared by me**
- the single-comic **Invite someone** modal stays — it is the only path that hands the owner the one-time copyable invitation link

### One grouped email per bulk share

The first draft sent one email per comic and claimed one invitation allowance per comic. With `MAX_BULK_COMICS` at 20 and `share_invitation` at 10 an hour that could never complete: ten shares created, ten rate limited, and the dialog reporting the second half as *skipped* — which reads as "they already have those" rather than "you are locked out for an hour".

Each comic still gets its own `ComicShare`, token, status and revocation. What a batch shares is the notice and the allowance:

- **One email**, listing the comics with a **Review invitation** link each, because each invitation is still answered on its own. A batch of one falls back to the single-comic template, and the 18+ gate is applied per comic so an explicit comic is announced without its title.
- **One allowance.** The limiter counts messages, not relationships, so mail volume is exactly what it was before bulk sharing existed.
- **All or nothing on the send**, and a refused batch (exhausted allowance, missing acknowledgement, an address the sender may not invite) creates nothing and is answered as one error with its real status.

`ComicShareService` owns the orchestration because it owns the transaction and the mail; `SharingWorkflowService` is the permission gate that resolves ids and asks `ComicVoter::SHARE`.

## Phase 2 — sharing codes, in both directions

Same format for both (`XXXX-XXXX-XXXX`, twelve characters of Crockford base32), because somebody copying one out of a chat window should not have to know which kind they were given. Neither is a login, neither reveals an address, neither grants access on its own.

### Receiver code — "this is me, share with me"

Tied to the account's display name, stored in the clear (unlike an invitation token) because it is an address rather than a capability — its owner has to read it back and hand it out again.

**Stable, but rotatable.** A code lives in chats, forums and group threads, which is exactly where things escape from, so its owner can retire it and take a new one — and support can do it on their behalf when asked. Rotation changes the identifier and nothing else: every share already made through the old code is a relationship, not an address, and survives untouched.

```
GET  /api/shares/my-code                     this account's code and name
POST /api/shares/resolve-code                the display name behind a code, nothing else
POST /api/shares/my-code/rotate              retire it and take a new one
POST /api/users/{id}/sharing-code/rotate     admin-only; does NOT return the new code
```

Rotation is rate limited (so a script cannot quietly make somebody uncontactable) and audited with ids only — a code rotated *because* it leaked is the last thing to write into a log. `comic_share.recipient_sharing_code` is historical metadata only: the Sharing page and the recent-recipient picker both resolve the recipient's **current** code through `recipientUser`, so a stale snapshot can never put a retired code back into circulation.

`POST /api/shares/invitations/bulk` now takes `sharingCode` in place of `email`. **The sender never learns the address** — `comic_share` carries `recipient_alias_name` and `recipient_sharing_code`, the owner-facing serializer returns `recipientEmail: null` with a label in its place, and recent recipients list such a person by name and code so the withheld address cannot reappear in the picker.

### Claim code — "these are mine, come and get them"

For when the owner does not know and should not have to ask for the other person's address. This one *is* a capability, so: hashed at rest, dead in 24 hours, and **spent as it is used between 1 and 10 times**, chosen when it is made. Worth nothing without an account to redeem it into.

**Unique across both kinds** — a candidate is checked against `share_claim_code.code_hash` *and* `user.sharing_code` before it is kept, with the unique index as the authority behind that check.

**One account, at most one use.** `share_claim_code_redemption` records who claimed what, unique on the pair, so a recipient submitting the same code ten times spends one use and cannot exhaust an offer made to ten people. A repeat is answered idempotently.

**Redemption goes through `ComicShareService::claimFromCode()`**, not a second copy of the share lifecycle — one service owns what a `ComicShare` is and how it changes, whatever created it. Claiming emits the canonical `SHARE_CREATED` / `SHARE_ACCEPTED` records tagged `via: claim_code`, and the sender's acknowledgement is **inherited from the code**, not stamped at redemption time: the owner acknowledged when they created it, possibly hours earlier, and that field is the canonical evidence of when they did.

**Withdrawable at any point** before it dies, from the list of handed-out codes on `/sharing` — what is on each, how many people have taken it up, and why it stopped working if it has. Withdrawing takes effect on the next redemption attempt and deliberately does not touch the shares the code already produced; those are ordinary relationships now, revoked from **Shared by me** like any other.

**Kept for 30 days past expiry, then swept** by `app:cleanup-expired-shares`, on the same clock whether the code was withdrawn, expired, used up or left with no comics. A dead code cannot be redeemed again the moment it dies, so keeping it is not a risk — but its owner is still asking how many people took it up and which comics went with it, and that question outlives the code by rather more than a day. Only the code rows and their join rows go.

Redemption runs as one unit of work with a pessimistic write lock taken on the row before the remaining uses are read, so two simultaneous redemptions of a one-use code cannot both succeed.

```
GET/POST /api/shares/claim-codes         list, mint
DELETE   /api/shares/claim-codes/{id}    withdraw
POST     /api/shares/claim-codes/redeem  claim
```

Redeeming is the recipient's own deliberate act, so it stands in for accepting an invitation — with one exception it cannot wave through. **An explicit comic is left pending behind the age gate**, decided before the share is accepted rather than undone afterwards, so there is no moment where an unconfirmed recipient holds an accepted share. Everything downstream is the ordinary model. Withdrawing a code does not touch the shares it already produced.

### Why this is still not a user directory

Resolving a code is the only place an identifier somebody typed becomes a person, so it is the only enumeration surface sharing has, and it is built to be a bad one: 60 bits of entropy over an unambiguous alphabet; one generic answer for every code that does not resolve (malformed, spent, expired, revoked or imaginary alike); a `sharing_code_lookup` allowance charged only for lookups that find nothing, which raises `security.share.sharing_code_enumeration_attempt` when exhausted; and a display name on success and nothing else. Minting claim codes has its own allowance, because it sends no mail and the invitation limiter would never see it.

## Admin

**Admin → Sharing codes** — every issued claim code, paginated, with status / owner / date-range filters, a **Withdraw** action and a **Run cleanup** button.

```
GET  /api/admin/sharing-codes             paginated, filtered
POST /api/admin/sharing-codes/{id}/revoke
POST /api/admin/sharing-codes/cleanup
```

Three things it deliberately cannot do: **show a code** (only the hash is stored — there is nothing to show, not even for an administrator), **take a comic back** (withdrawing closes the way in, never the access already granted; removing a share is moderation, a different decision on a different screen), and **delete a live record** (the button runs the same sweep the cron job does).

That last one is why the cleanup moved into `ExpiredShareCleanupService`, shared by `app:cleanup-expired-shares` and the admin action — a deletion rule that exists twice will eventually disagree with itself, and this one removes records from other people's accounts. Revocation likewise goes through `ShareClaimCodeService` rather than being reimplemented in a controller. Both admin actions are audited with the acting administrator, the target and the counts; the scheduled command stays quiet, because a cron job reporting its own runs is noise.

Receiver-code rotation is on the admin **user** page instead, beside the account it identifies, so the two lifecycles are not mixed.

## UI

One new card on `/sharing` (your code, a field to redeem one, and the codes you have handed out with a **Withdraw** on each live one), and one extra step in the dialog that already existed — Step 2 becomes **Email address / Sharing code / Create a code**, with two short lines of explanation swapped in per mode rather than three paragraphs stacked on top of each other. The comics, review step and acknowledgement are shared by all three.

## Migration

`Version20260809140000` adds `share_claim_code_redemption` (unique on claim code + recipient). `Version20260809100000` adds `user.sharing_code` (nullable + unique, issued lazily on first use rather than backfilled for every row inside a migration that runs against a live installation), the two `comic_share` alias columns, and the `share_claim_code` tables.

## Tests

Backend (392 passing):
- recent recipients: owner-scoped, deduplicated, most-recent-first, limit enforced, both endpoints authenticated
- one grouped email carries every invitation with a distinct link each, and still names no explicit comic
- a bulk share claims one allowance however many comics it carries; an exhausted allowance refuses the batch without creating anything
- batch cap, received comics not re-shareable, pending invitations not silently recreated, acknowledgement mandatory
- results identical for a registered and an unknown recipient
- a receiver code is issued once and never changes; resolving reveals a name and nothing else; every wrong code is answered identically
- sharing by code never shows the sender the address, on the Sharing page or in recent recipients
- a claim code is shown once, counts down, expires, cannot be self-redeemed, cannot carry somebody else's comic, cannot carry more than one action may, and needs the acknowledgement
- withdrawing takes effect immediately, leaves the code listed as withdrawn with no uses spent, and cannot be done to somebody else's code
- every issued code is unique across both kinds
- the cleanup keeps a dead code for a month and then removes it, without touching the comic
- ordinary users cannot reach any admin code endpoint; admins can list with pagination and filters; plaintext is never returned
- an admin can withdraw a code without revoking the shares it already produced, and it is audited
- manual cleanup removes only records past the retention window, never the shares a code produced, and is audited with who ran it
- the admin sweep and the scheduled one are the same sweep
- rotation retires the old code, issues a new one, leaves existing shares valid, and stops the picker offering the retired code
- an admin can rotate somebody else's code without seeing it; a non-admin gets 403; rotation is rate limited
- one account spends at most one use however often it redeems; distinct accounts each spend one until the code runs out
- a claimed share records the owner's acknowledgement timestamp, not the redemption time
- an exhausted code is indistinguishable from one that never existed
- redeeming leaves an explicit comic behind the age gate, still redacted

Frontend (219 passing): entry points, partial failures, preselection, refresh-failure handling in both the dialog and the single-comic modal, code-mode submission with no address on the wire, claim-code creation and its 1–10 clamp, code normalisation as it is typed, and code recipients rendered without an address.

## Known limitations
- The picker loads the owner's library in one request rather than paginating it (issue §11). Same shape as the dashboard, so no worse than the existing surface.
- Comics hidden by a `hideFromLibrary` tag do not appear in the picker, inherited from `GET /api/comics?ownership=mine`. Consistent with the dashboard, where those comics are also not shareable.
- Consent-based **sharing contacts** (§10) remain out of scope and are documented as such.
- Mail delivery is **not** transactional. A failed send leaves no invitation behind, but a send that succeeds before a failed commit leaves the recipient holding links to nothing. An SMTP call cannot join a database transaction; fixing both directions needs a notification outbox across all mail, not just sharing. The exact guarantee and its limit are stated in `ComicShareService::deliver()` and DEV_README.

Closes #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share multiple comics at once by email or sharing code.
  * Create, redeem, rotate, copy, revoke, and track sharing codes with usage and expiration details.
  * View recent recipients and quickly share additional comics.
  * Receive grouped invitation emails with comic links and explicit-content notices.
  * Administrators can review, revoke, and clean up sharing codes.
* **Privacy & Security**
  * Recipient details are protected for code-based sharing, with rate limits and access safeguards.
* **Bug Fixes**
  * Sharing remains successful even when a follow-up refresh fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->