### PR TITLE
Add persisted reader settings and shared navigation foundation

### DIFF
--- a/backend/migrations/Version20260810090000.php
+++ b/backend/migrations/Version20260810090000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260810090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Persist the versioned reader preferences that follow each user between devices.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\AbstractMySQLPlatform,
+            'This migration targets MySQL.'
+        );
+
+        $this->addSql('ALTER TABLE `user` ADD reader_preferences JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `user` DROP reader_preferences');
+    }
+}

--- a/backend/src/Controller/ReaderPreferencesController.php
+++ b/backend/src/Controller/ReaderPreferencesController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Reader\ReaderPreferences;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api/reader/preferences', name: 'api_reader_preferences_')]
+final class ReaderPreferencesController extends AbstractController
+{
+    #[Route('', name: 'get', methods: ['GET'])]
+    public function get(ReaderPreferences $readerPreferences): JsonResponse
+    {
+        $user = $this->authenticatedUser();
+
+        return $this->json([
+            'preferences' => $readerPreferences->normalize($user->getReaderPreferences()),
+        ]);
+    }
+
+    #[Route('', name: 'replace', methods: ['PUT'])]
+    public function replace(
+        Request $request,
+        ReaderPreferences $readerPreferences,
+        EntityManagerInterface $entityManager,
+    ): JsonResponse {
+        $payload = json_decode($request->getContent(), true);
+        if (!is_array($payload)) {
+            return $this->json(['message' => 'Invalid JSON payload.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if (array_keys($payload) !== ['preferences']) {
+            return $this->json(
+                ['message' => 'The request must contain only preferences.'],
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
+        }
+
+        try {
+            $preferences = $readerPreferences->validate($payload['preferences']);
+        } catch (\InvalidArgumentException $exception) {
+            return $this->json(['message' => $exception->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $user = $this->authenticatedUser();
+        $user->setReaderPreferences($preferences);
+        $entityManager->flush();
+
+        return $this->json(['preferences' => $preferences]);
+    }
+
+    #[Route('', name: 'reset', methods: ['DELETE'])]
+    public function reset(
+        ReaderPreferences $readerPreferences,
+        EntityManagerInterface $entityManager,
+    ): JsonResponse {
+        $user = $this->authenticatedUser();
+        $user->setReaderPreferences(null);
+        $entityManager->flush();
+
+        return $this->json(['preferences' => $readerPreferences->defaults()]);
+    }
+
+    private function authenticatedUser(): User
+    {
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return $user;
+    }
+}

--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -102,6 +102,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?\DateTimeImmutable $lastLoginAt = null;
 
+    /** @var array<string, mixed>|null */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $readerPreferences = null;
+
     /**
      * @var Collection<int, Comic>
      */
@@ -361,6 +365,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setLastLoginAt(?\DateTimeImmutable $lastLoginAt): static
     {
         $this->lastLoginAt = $lastLoginAt;
+        return $this;
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getReaderPreferences(): ?array
+    {
+        return $this->readerPreferences;
+    }
+
+    /** @param array<string, mixed>|null $readerPreferences */
+    public function setReaderPreferences(?array $readerPreferences): static
+    {
+        $this->readerPreferences = $readerPreferences;
+
         return $this;
     }
 

--- a/backend/src/Reader/ReaderPreferences.php
+++ b/backend/src/Reader/ReaderPreferences.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Reader;
+
+/**
+ * The persisted reader contract.
+ *
+ * Keeping an envelope around the global settings gives later reader work a
+ * place for device/orientation overrides without changing the meaning of the
+ * existing values. Stored data is always normalized before it reaches a
+ * client, while writes are strict so arbitrary JSON is never retained.
+ */
+final class ReaderPreferences
+{
+    public const SCHEMA_VERSION = 1;
+
+    /** @var list<string> */
+    private const MODES = ['single'];
+
+    /** @var list<string> */
+    private const DIRECTIONS = ['ltr'];
+
+    /** @var list<string> */
+    private const FITS = ['contain', 'width', 'height', 'original'];
+
+    /**
+     * @return array{
+     *     schemaVersion: int,
+     *     settings: array{
+     *         mode: string,
+     *         direction: string,
+     *         fit: string,
+     *         autoHideControls: bool,
+     *         showProgress: bool,
+     *         wakeLock: bool
+     *     },
+     *     overrides: array{}
+     * }
+     */
+    public function defaults(): array
+    {
+        return [
+            'schemaVersion' => self::SCHEMA_VERSION,
+            'settings' => [
+                'mode' => 'single',
+                'direction' => 'ltr',
+                'fit' => 'contain',
+                'autoHideControls' => true,
+                'showProgress' => true,
+                'wakeLock' => true,
+            ],
+            // Reserved for validated device/orientation contexts. Keeping the
+            // slot now lets later work extend the model instead of replacing it.
+            'overrides' => [],
+        ];
+    }
+
+    /**
+     * Safely consume persisted data written by this or an older application.
+     * Invalid fields fall back independently, so one stale value does not erase
+     * the rest of a user's preferences.
+     *
+     * @param array<string, mixed>|null $stored
+     * @return array<string, mixed>
+     */
+    public function normalize(?array $stored): array
+    {
+        $defaults = $this->defaults();
+        if (($stored['schemaVersion'] ?? null) !== self::SCHEMA_VERSION
+            || !is_array($stored['settings'] ?? null)) {
+            return $defaults;
+        }
+
+        $settings = $stored['settings'];
+
+        return [
+            'schemaVersion' => self::SCHEMA_VERSION,
+            'settings' => [
+                'mode' => $this->allowedString($settings['mode'] ?? null, self::MODES, $defaults['settings']['mode']),
+                'direction' => $this->allowedString($settings['direction'] ?? null, self::DIRECTIONS, $defaults['settings']['direction']),
+                'fit' => $this->allowedString($settings['fit'] ?? null, self::FITS, $defaults['settings']['fit']),
+                'autoHideControls' => is_bool($settings['autoHideControls'] ?? null)
+                    ? $settings['autoHideControls']
+                    : $defaults['settings']['autoHideControls'],
+                'showProgress' => is_bool($settings['showProgress'] ?? null)
+                    ? $settings['showProgress']
+                    : $defaults['settings']['showProgress'],
+                'wakeLock' => is_bool($settings['wakeLock'] ?? null)
+                    ? $settings['wakeLock']
+                    : $defaults['settings']['wakeLock'],
+            ],
+            'overrides' => [],
+        ];
+    }
+
+    /**
+     * Validate an API replacement. Unlike normalize(), this rejects malformed,
+     * incomplete, unknown, or currently unsupported values.
+     *
+     * @return array<string, mixed>
+     */
+    public function validate(mixed $candidate): array
+    {
+        if (!is_array($candidate)) {
+            throw new \InvalidArgumentException('preferences must be an object.');
+        }
+
+        $this->assertExactKeys($candidate, ['schemaVersion', 'settings', 'overrides'], 'preferences');
+
+        if (($candidate['schemaVersion'] ?? null) !== self::SCHEMA_VERSION) {
+            throw new \InvalidArgumentException('schemaVersion is not supported.');
+        }
+
+        $settings = $candidate['settings'] ?? null;
+        if (!is_array($settings)) {
+            throw new \InvalidArgumentException('settings must be an object.');
+        }
+
+        if (($candidate['overrides'] ?? null) !== []) {
+            throw new \InvalidArgumentException('overrides are not supported yet.');
+        }
+
+        $required = ['mode', 'direction', 'fit', 'autoHideControls', 'showProgress', 'wakeLock'];
+        $this->assertExactKeys($settings, $required, 'settings');
+
+        if (!in_array($settings['mode'], self::MODES, true)) {
+            throw new \InvalidArgumentException('mode is not supported.');
+        }
+        if (!in_array($settings['direction'], self::DIRECTIONS, true)) {
+            throw new \InvalidArgumentException('direction is not supported.');
+        }
+        if (!in_array($settings['fit'], self::FITS, true)) {
+            throw new \InvalidArgumentException('fit is not supported.');
+        }
+
+        foreach (['autoHideControls', 'showProgress', 'wakeLock'] as $field) {
+            if (!is_bool($settings[$field])) {
+                throw new \InvalidArgumentException(sprintf('%s must be a boolean.', $field));
+            }
+        }
+
+        return $this->normalize($candidate);
+    }
+
+    /** @param list<string> $allowed */
+    private function allowedString(mixed $value, array $allowed, string $fallback): string
+    {
+        return is_string($value) && in_array($value, $allowed, true) ? $value : $fallback;
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     * @param list<string> $expected
+     */
+    private function assertExactKeys(array $value, array $expected, string $field): void
+    {
+        $keys = array_keys($value);
+        sort($keys);
+        sort($expected);
+
+        if ($keys !== $expected) {
+            throw new \InvalidArgumentException(sprintf('%s has missing or unknown fields.', $field));
+        }
+    }
+}

--- a/backend/src/Service/PersonalDataExporter.php
+++ b/backend/src/Service/PersonalDataExporter.php
@@ -65,6 +65,7 @@ final class PersonalDataExporter
                 'dropboxConnected' => $user->getDropboxAccessToken() !== null
                     || $user->getDropboxRefreshToken() !== null,
                 'dropboxLastSyncedAt' => $user->getDropboxLastSyncedAt()?->format(\DateTimeInterface::ATOM),
+                'readerPreferences' => $user->getReaderPreferences(),
             ],
             'comics' => $comics,
             'readingProgress' => $progress,

--- a/backend/tests/Functional/Controller/ReaderPreferencesControllerTest.php
+++ b/backend/tests/Functional/Controller/ReaderPreferencesControllerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\User;
+use App\Reader\ReaderPreferences;
+use App\Tests\Factory\UserFactory;
+use App\Tests\Functional\AbstractApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class ReaderPreferencesControllerTest extends AbstractApiTestCase
+{
+    public function testDefaultsRequireAuthentication(): void
+    {
+        $this->getJson('/api/reader/preferences');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testReturnsDefaultsWhenNothingHasBeenSaved(): void
+    {
+        $this->createAndLoginUser();
+
+        $payload = $this->getJson('/api/reader/preferences');
+
+        self::assertResponseIsSuccessful();
+        self::assertSame('contain', $payload['preferences']['settings']['fit']);
+        self::assertSame(ReaderPreferences::SCHEMA_VERSION, $payload['preferences']['schemaVersion']);
+    }
+
+    public function testUnsafePreferenceWriteRequiresCsrfProtection(): void
+    {
+        $user = UserFactory::createOne()->object();
+        $this->browser()->loginUser($user);
+        $preferences = static::getContainer()->get(ReaderPreferences::class)->defaults();
+
+        $this->browser()->request(
+            'PUT',
+            '/api/reader/preferences',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            json_encode(['preferences' => $preferences], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertNull($user->getReaderPreferences());
+    }
+
+    public function testPersistsAValidatedReplacementForTheAuthenticatedUser(): void
+    {
+        $user = $this->createAndLoginUser();
+        $preferences = static::getContainer()->get(ReaderPreferences::class)->defaults();
+        $preferences['settings']['fit'] = 'width';
+        $preferences['settings']['autoHideControls'] = false;
+
+        $payload = $this->putJson('/api/reader/preferences', ['preferences' => $preferences]);
+
+        self::assertResponseIsSuccessful();
+        self::assertSame($preferences, $payload['preferences']);
+
+        $storedUser = static::getContainer()->get(EntityManagerInterface::class)->find(User::class, $user->getId());
+        self::assertEquals($preferences, $storedUser?->getReaderPreferences());
+
+        self::assertSame($preferences, $this->getJson('/api/reader/preferences')['preferences']);
+    }
+
+    public function testRejectsUnsupportedAndUnknownValuesWithoutChangingStoredData(): void
+    {
+        $user = UserFactory::createOne()->object();
+        $defaults = static::getContainer()->get(ReaderPreferences::class)->defaults();
+        $user->setReaderPreferences($defaults);
+        static::getContainer()->get(EntityManagerInterface::class)->flush();
+        $this->loginAs($user);
+
+        $invalid = $defaults;
+        $invalid['settings']['fit'] = 'stretch';
+        $invalid['settings']['script'] = '<script>alert(1)</script>';
+
+        $this->putJson('/api/reader/preferences', ['preferences' => $invalid]);
+
+        self::assertResponseStatusCodeSame(422);
+        $storedUser = static::getContainer()->get(EntityManagerInterface::class)->find(User::class, $user->getId());
+        self::assertEquals($defaults, $storedUser?->getReaderPreferences());
+    }
+
+    public function testResetRemovesStoredPreferencesAndReturnsDefaults(): void
+    {
+        $user = $this->createAndLoginUser();
+        $preferences = static::getContainer()->get(ReaderPreferences::class)->defaults();
+        $preferences['settings']['fit'] = 'height';
+        $user->setReaderPreferences($preferences);
+        static::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $payload = $this->deleteJson('/api/reader/preferences');
+
+        self::assertResponseIsSuccessful();
+        self::assertSame('contain', $payload['preferences']['settings']['fit']);
+        $storedUser = static::getContainer()->get(EntityManagerInterface::class)->find(User::class, $user->getId());
+        self::assertNull($storedUser?->getReaderPreferences());
+    }
+
+    public function testPreferencesAreIsolatedBetweenUsers(): void
+    {
+        $firstUser = UserFactory::createOne()->object();
+        $preferences = static::getContainer()->get(ReaderPreferences::class)->defaults();
+        $preferences['settings']['fit'] = 'original';
+        $firstUser->setReaderPreferences($preferences);
+        static::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $secondUser = $this->createAndLoginUser();
+        $payload = $this->getJson('/api/reader/preferences');
+
+        self::assertResponseIsSuccessful();
+        self::assertSame('contain', $payload['preferences']['settings']['fit']);
+        self::assertNotSame($firstUser->getId(), $secondUser->getId());
+    }
+}

--- a/backend/tests/Unit/Reader/ReaderPreferencesTest.php
+++ b/backend/tests/Unit/Reader/ReaderPreferencesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Reader;
+
+use App\Reader\ReaderPreferences;
+use PHPUnit\Framework\TestCase;
+
+final class ReaderPreferencesTest extends TestCase
+{
+    private ReaderPreferences $preferences;
+
+    protected function setUp(): void
+    {
+        $this->preferences = new ReaderPreferences();
+    }
+
+    public function testNormalizesInvalidStoredFieldsWithoutDiscardingValidOnes(): void
+    {
+        $normalized = $this->preferences->normalize([
+            'schemaVersion' => 1,
+            'settings' => [
+                'mode' => 'future-mode',
+                'direction' => 'rtl',
+                'fit' => 'width',
+                'autoHideControls' => false,
+                'showProgress' => 'yes',
+                'wakeLock' => true,
+                'unknown' => 'ignored',
+            ],
+        ]);
+
+        self::assertSame('single', $normalized['settings']['mode']);
+        self::assertSame('ltr', $normalized['settings']['direction']);
+        self::assertSame('width', $normalized['settings']['fit']);
+        self::assertFalse($normalized['settings']['autoHideControls']);
+        self::assertTrue($normalized['settings']['showProgress']);
+        self::assertTrue($normalized['settings']['wakeLock']);
+    }
+
+    public function testStaleSchemaFallsBackToAllDefaults(): void
+    {
+        self::assertSame(
+            $this->preferences->defaults(),
+            $this->preferences->normalize(['schemaVersion' => 99, 'settings' => ['fit' => 'width']]),
+        );
+    }
+
+    public function testValidReplacementIsAccepted(): void
+    {
+        $candidate = $this->preferences->defaults();
+        $candidate['settings']['fit'] = 'original';
+        $candidate['settings']['showProgress'] = false;
+
+        self::assertSame($candidate, $this->preferences->validate($candidate));
+    }
+
+    /** @dataProvider invalidReplacementProvider */
+    public function testInvalidOrArbitraryReplacementIsRejected(mixed $candidate): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->preferences->validate($candidate);
+    }
+
+    /** @return iterable<string, array{mixed}> */
+    public function invalidReplacementProvider(): iterable
+    {
+        $defaults = (new ReaderPreferences())->defaults();
+
+        yield 'not an object' => ['contain'];
+        yield 'unknown root field' => [[
+            ...$defaults,
+            'untrusted' => ['anything'],
+        ]];
+        yield 'unsupported mode' => [[
+            'schemaVersion' => 1,
+            'settings' => [
+                ...$defaults['settings'],
+                'mode' => 'double',
+            ],
+        ]];
+        yield 'wrong boolean type' => [[
+            'schemaVersion' => 1,
+            'settings' => [
+                ...$defaults['settings'],
+                'wakeLock' => 1,
+            ],
+        ]];
+    }
+}

--- a/docs/reader.md
+++ b/docs/reader.md
@@ -1,0 +1,61 @@
+# Reader settings and controls
+
+Reader preferences belong to the signed-in account. They are loaded when the
+reader opens and follow the user to another browser or device. If preferences
+cannot be loaded, the reader stays usable with safe defaults.
+
+Open **Reader settings** from the sliders button at the top-right of a page.
+Changes apply immediately and save in the background. **Reset defaults** returns
+every reader option to its default value.
+
+## Page sizing
+
+| Setting | Behaviour |
+| --- | --- |
+| Best fit | Shows the complete page inside the available reader area without changing its aspect ratio. This is the default. |
+| Fit width | Uses the available width. Tall pages scroll vertically. |
+| Fit height | Uses the available height without changing the page aspect ratio. |
+| Original size | Uses the image's native dimensions. Oversized pages scroll horizontally or vertically. |
+
+Changing page size does not reload the comic or reset reading progress. Changing
+it while zoomed returns the page to its natural scale so the selected fit is
+immediately clear.
+
+## Other settings
+
+- **Show progress bar** displays the slim indicator above the page controls.
+- **Fade fullscreen controls** hides the bottom controls until pointer hover or
+  keyboard focus. Turning it off keeps the controls visible.
+- **Keep screen awake** requests the browser's screen wake lock while the reader
+  is open. Unsupported or denied wake locks do not interrupt reading.
+
+## Keyboard controls
+
+| Key | Action |
+| --- | --- |
+| Left arrow | Previous logical page |
+| Right arrow | Next logical page |
+| Home | First logical page |
+| End | Last logical page |
+| Tab / Shift+Tab | Move through reader controls |
+| Enter / Space | Activate the focused control |
+| Escape | Close the settings popover; the browser's standard fullscreen key also exits fullscreen |
+
+Arrow shortcuts do not turn pages while focus is in the page-number input or
+another editable control.
+
+## Extension contract
+
+Navigation and progress always use the source comic's one-based logical page
+numbers. A future spread or continuous renderer may present those pages
+differently, but it must not persist a synthetic spread or viewport number.
+
+Page URLs are created in one source-neutral helper and retain the protected
+`/api/comics/{id}/pages/{page}` endpoint. Backend source-provider factories can
+therefore change how a page is read without changing reader navigation.
+
+The persisted preference envelope is versioned and already reserves an
+`overrides` section for validated device/orientation contexts. Unsupported modes,
+directions, and override data are rejected until their renderer or context logic
+is present; later reader work can extend the allowed values centrally without
+replacing existing user settings.

--- a/frontend/src/components/reader/ReaderSettings.jsx
+++ b/frontend/src/components/reader/ReaderSettings.jsx
@@ -1,0 +1,101 @@
+import { RotateCcw, Settings2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { READER_FITS } from "@/lib/reader-preferences";
+
+function SettingSwitch({ id, label, description, checked, onCheckedChange }) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-0.5">
+        <Label htmlFor={id} className="cursor-pointer">{label}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} aria-label={label} />
+    </div>
+  );
+}
+
+export function ReaderSettings({ settings, isLoaded, isSaving, onChange, onReset }) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="bg-card/80 opacity-80 hover:opacity-100"
+          aria-label="Reader settings"
+          title="Reader settings"
+        >
+          <Settings2 className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="max-h-[var(--radix-popover-content-available-height)] w-[min(22rem,calc(100vw-2rem))] space-y-4 overflow-y-auto">
+        <div>
+          <h2 className="font-semibold">Reader settings</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Single-page mode · saved to your account
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="reader-fit">Page size</Label>
+          <Select value={settings.fit} onValueChange={(fit) => onChange({ fit })} disabled={!isLoaded}>
+            <SelectTrigger id="reader-fit" aria-label="Page size">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {READER_FITS.map((fit) => (
+                <SelectItem key={fit.value} value={fit.value}>{fit.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Fit width can scroll vertically. Original size can scroll in either direction.
+          </p>
+        </div>
+
+        <Separator />
+
+        <div className="space-y-4">
+          <SettingSwitch
+            id="reader-show-progress"
+            label="Show progress bar"
+            description="Keep a slim page progress indicator above navigation."
+            checked={settings.showProgress}
+            onCheckedChange={(showProgress) => onChange({ showProgress })}
+          />
+          <SettingSwitch
+            id="reader-auto-hide"
+            label="Fade fullscreen controls"
+            description="Controls return on hover or keyboard focus."
+            checked={settings.autoHideControls}
+            onCheckedChange={(autoHideControls) => onChange({ autoHideControls })}
+          />
+          <SettingSwitch
+            id="reader-wake-lock"
+            label="Keep screen awake"
+            description="Prevent screen sleep while the reader is open, when supported."
+            checked={settings.wakeLock}
+            onCheckedChange={(wakeLock) => onChange({ wakeLock })}
+          />
+        </div>
+
+        <Separator />
+
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs text-muted-foreground" role="status" aria-live="polite">
+            {!isLoaded ? "Loading settings…" : isSaving ? "Saving…" : "Saved across devices"}
+          </span>
+          <Button variant="ghost" size="sm" onClick={onReset} disabled={!isLoaded}>
+            <RotateCcw className="mr-2 h-4 w-4" /> Reset defaults
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/reader/SinglePageReader.jsx
+++ b/frontend/src/components/reader/SinglePageReader.jsx
@@ -1,0 +1,73 @@
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const VIEWPORT_CLASSES = {
+  contain: "items-center justify-center overflow-hidden",
+  width: "items-start justify-center overflow-x-hidden overflow-y-auto",
+  height: "items-center justify-center overflow-hidden",
+  original: "items-start justify-start overflow-auto",
+};
+
+const IMAGE_CLASSES = {
+  contain: "max-h-full max-w-full h-auto w-auto object-contain",
+  width: "h-auto w-full max-h-none max-w-none object-contain",
+  height: "h-full w-auto max-h-full max-w-none object-contain",
+  original: "h-auto w-auto max-h-none max-w-none object-none",
+};
+
+export function SinglePageReader({
+  containerRef,
+  image,
+  isLoading,
+  hasFailed,
+  pageNumber,
+  title,
+  fit,
+  isFullscreen,
+  isZoomed,
+  zoomLevel,
+  mousePosition,
+  onMouseMove,
+  onImageClick,
+  onRetry,
+  children,
+}) {
+  const safeFit = Object.hasOwn(VIEWPORT_CLASSES, fit) ? fit : "contain";
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative max-h-full h-full w-full flex ${VIEWPORT_CLASSES[safeFit]} ${isFullscreen ? "fullscreen-container" : ""}`}
+      data-page-fit={safeFit}
+      onMouseMove={onMouseMove}
+    >
+      {image && (
+        <img
+          src={image.src}
+          alt={`Page ${pageNumber} of ${title || "Comic"}`}
+          className={`${IMAGE_CLASSES[safeFit]} mx-auto block shadow-lg transition-transform ${isZoomed ? "zoomed-image" : ""}`}
+          style={{
+            transform: isZoomed ? `scale(${zoomLevel})` : "none",
+            transformOrigin: isZoomed ? `${mousePosition.x * 100}% ${mousePosition.y * 100}%` : "center center",
+          }}
+          onClick={onImageClick}
+        />
+      )}
+
+      {hasFailed && (
+        <div className="m-auto flex flex-col items-center justify-center rounded-md bg-destructive-foreground p-4 text-destructive">
+          <p className="mb-2">Error loading page {pageNumber}.</p>
+          <Button variant="outline" onClick={onRetry}>Retry</Button>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Skeleton className="mx-auto h-full w-full max-w-full object-contain" />
+        </div>
+      )}
+
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-reader-navigation.js
+++ b/frontend/src/hooks/use-reader-navigation.js
@@ -1,0 +1,48 @@
+import { useCallback, useRef, useState } from "react";
+
+export function clampPageIndex(pageIndex, pageCount) {
+  if (!Number.isInteger(pageCount) || pageCount <= 0) return 0;
+  if (!Number.isFinite(pageIndex)) return 0;
+  return Math.min(pageCount - 1, Math.max(0, Math.trunc(pageIndex)));
+}
+
+/**
+ * One logical-page contract shared by buttons, keyboard shortcuts, page jump,
+ * and later visual modes. It intentionally knows nothing about left/right
+ * placement or source file formats.
+ */
+export function useReaderNavigation(pageCount) {
+  const [currentPage, setCurrentPageState] = useState(0);
+  const currentPageRef = useRef(0);
+
+  const setCurrentPage = useCallback((pageIndex) => {
+    currentPageRef.current = pageIndex;
+    setCurrentPageState(pageIndex);
+  }, []);
+
+  const goToPage = useCallback((pageIndex) => {
+    if (!Number.isInteger(pageIndex) || pageIndex < 0 || pageIndex >= pageCount) return false;
+    setCurrentPage(pageIndex);
+    return true;
+  }, [pageCount, setCurrentPage]);
+
+  const resetPage = useCallback((pageIndex, nextPageCount) => {
+    const nextPage = clampPageIndex(pageIndex, nextPageCount);
+    setCurrentPage(nextPage);
+    return nextPage;
+  }, [setCurrentPage]);
+
+  const goPrevious = useCallback(() => goToPage(currentPageRef.current - 1), [goToPage]);
+  const goNext = useCallback(() => goToPage(currentPageRef.current + 1), [goToPage]);
+
+  return {
+    currentPage,
+    currentPageRef,
+    goToPage,
+    goPrevious,
+    goNext,
+    resetPage,
+    canGoPrevious: currentPage > 0,
+    canGoNext: pageCount > 0 && currentPage < pageCount - 1,
+  };
+}

--- a/frontend/src/hooks/use-reader-navigation.test.jsx
+++ b/frontend/src/hooks/use-reader-navigation.test.jsx
@@ -1,0 +1,30 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { clampPageIndex, useReaderNavigation } from "./use-reader-navigation";
+
+describe("logical reader navigation", () => {
+  it("clamps restored progress without inventing visual page numbers", () => {
+    expect(clampPageIndex(-5, 10)).toBe(0);
+    expect(clampPageIndex(13, 10)).toBe(9);
+    expect(clampPageIndex(4, 10)).toBe(4);
+  });
+
+  it("shares bounded next, previous, and jump operations", () => {
+    const { result } = renderHook(() => useReaderNavigation(3));
+
+    act(() => result.current.goNext());
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.canGoPrevious).toBe(true);
+
+    act(() => result.current.goToPage(2));
+    expect(result.current.currentPage).toBe(2);
+    expect(result.current.canGoNext).toBe(false);
+
+    act(() => result.current.goNext());
+    expect(result.current.currentPage).toBe(2);
+
+    act(() => result.current.goPrevious());
+    expect(result.current.currentPage).toBe(1);
+  });
+});

--- a/frontend/src/hooks/use-reader-preferences.jsx
+++ b/frontend/src/hooks/use-reader-preferences.jsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+import {
+  DEFAULT_READER_PREFERENCES,
+  normalizeReaderPreferences,
+  updateReaderSettings,
+} from "@/lib/reader-preferences";
+
+/**
+ * Loads once and applies changes optimistically. Writes are serialized and
+ * collapsed to the newest pending value, preventing a slow older request from
+ * overwriting a rapid later choice on the server.
+ */
+export function useReaderPreferences(toast) {
+  const [preferences, setPreferences] = useState(DEFAULT_READER_PREFERENCES);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const preferencesRef = useRef(DEFAULT_READER_PREFERENCES);
+  const pendingOperationRef = useRef(null);
+  const pumpingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const changedLocallyRef = useRef(false);
+
+  const applyPreferences = useCallback((next) => {
+    preferencesRef.current = next;
+    if (mountedRef.current) setPreferences(next);
+  }, []);
+
+  const pump = useCallback(async () => {
+    if (pumpingRef.current) return;
+    pumpingRef.current = true;
+    if (mountedRef.current) setIsSaving(true);
+
+    while (pendingOperationRef.current) {
+      const operation = pendingOperationRef.current;
+      pendingOperationRef.current = null;
+      try {
+        const data = operation.kind === "reset"
+          ? await api.delete("/api/reader/preferences", { keepalive: true })
+          : await api.put(
+              "/api/reader/preferences",
+              { preferences: operation.preferences },
+              { keepalive: true }
+            );
+
+        if (!pendingOperationRef.current) {
+          applyPreferences(normalizeReaderPreferences(data?.preferences));
+        }
+      } catch (error) {
+        logger.error("Failed to save reader preferences:", error);
+        if (mountedRef.current) {
+          toast({
+            title: "Reader setting not saved",
+            description: "Your choice works for this session, but may not follow you to another device.",
+            variant: "destructive",
+          });
+        }
+      }
+    }
+
+    pumpingRef.current = false;
+    if (mountedRef.current) setIsSaving(false);
+  }, [applyPreferences, toast]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    let active = true;
+
+    api.get("/api/reader/preferences")
+      .then((data) => {
+        if (!active || changedLocallyRef.current) return;
+        applyPreferences(normalizeReaderPreferences(data?.preferences));
+      })
+      .catch((error) => {
+        if (!active) return;
+        logger.warn("Failed to load reader preferences; using defaults:", error);
+        toast({
+          title: "Using default reader settings",
+          description: "Your saved settings could not be loaded.",
+          variant: "destructive",
+        });
+      })
+      .finally(() => {
+        if (active) setIsLoaded(true);
+      });
+
+    return () => {
+      active = false;
+      mountedRef.current = false;
+    };
+  }, [applyPreferences, toast]);
+
+  const changeSettings = useCallback((patch) => {
+    changedLocallyRef.current = true;
+    const next = updateReaderSettings(preferencesRef.current, patch);
+    applyPreferences(next);
+    pendingOperationRef.current = { kind: "save", preferences: next };
+    void pump();
+  }, [applyPreferences, pump]);
+
+  const resetPreferences = useCallback(() => {
+    changedLocallyRef.current = true;
+    applyPreferences(DEFAULT_READER_PREFERENCES);
+    pendingOperationRef.current = { kind: "reset" };
+    void pump();
+  }, [applyPreferences, pump]);
+
+  return {
+    preferences,
+    settings: preferences.settings,
+    isLoaded,
+    isSaving,
+    changeSettings,
+    resetPreferences,
+  };
+}

--- a/frontend/src/hooks/use-reader-wake-lock.js
+++ b/frontend/src/hooks/use-reader-wake-lock.js
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+
+/** Keep long reading sessions awake when the browser supports the Screen Wake Lock API. */
+export function useReaderWakeLock(enabled) {
+  useEffect(() => {
+    if (!enabled || typeof navigator === "undefined" || !("wakeLock" in navigator)) return undefined;
+
+    let sentinel = null;
+    let cancelled = false;
+
+    const acquire = async () => {
+      if (cancelled || document.visibilityState !== "visible" || sentinel) return;
+      try {
+        const acquired = await navigator.wakeLock.request("screen");
+        if (cancelled) {
+          await acquired.release();
+          return;
+        }
+        sentinel = acquired;
+        acquired.addEventListener?.("release", () => {
+          if (sentinel === acquired) sentinel = null;
+        });
+      } catch {
+        // Support and permission vary by device. Reading remains fully usable.
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") void acquire();
+    };
+
+    void acquire();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      void sentinel?.release();
+      sentinel = null;
+    };
+  }, [enabled]);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -92,7 +92,11 @@
   /* Sits above .fullscreen-container (z-50), which otherwise paints its opaque
      background over these controls and swallows their clicks. */
   .reader-controls-fullscreen {
-    @apply fixed bottom-0 left-0 right-0 z-[60] bg-gradient-to-t from-background/90 to-transparent p-4 opacity-0 transition-opacity duration-300 hover:opacity-100 flex flex-col gap-3;
+    @apply fixed bottom-0 left-0 right-0 z-[60] bg-gradient-to-t from-background/90 to-transparent p-4 opacity-0 transition-opacity duration-300 hover:opacity-100 focus-within:opacity-100 flex flex-col gap-3;
+  }
+
+  .reader-controls-fullscreen.reader-controls-pinned {
+    @apply opacity-100;
   }
 
   .page-navigation {
@@ -108,7 +112,11 @@
   }
   
   .fullscreen-controls {
-    @apply fixed top-20 right-4 z-[60] flex gap-2 bg-card/80 p-2 rounded-md shadow-md;
+    @apply fixed top-20 right-4 z-[60] flex gap-2 bg-card/80 p-2 rounded-md shadow-md transition-opacity duration-300;
+  }
+
+  .fullscreen-controls.fullscreen-controls-auto-hide {
+    @apply opacity-0 hover:opacity-100 focus-within:opacity-100;
   }
   
   .fullscreen-reader-controls {

--- a/frontend/src/lib/reader-pages.js
+++ b/frontend/src/lib/reader-pages.js
@@ -1,0 +1,9 @@
+export function createComicPageUrls(comicId, pageCount) {
+  if (!comicId || !Number.isInteger(pageCount) || pageCount <= 0) return [];
+
+  const encodedComicId = encodeURIComponent(String(comicId));
+  return Array.from(
+    { length: pageCount },
+    (_, index) => `/api/comics/${encodedComicId}/pages/${index + 1}`
+  );
+}

--- a/frontend/src/lib/reader-preferences.js
+++ b/frontend/src/lib/reader-preferences.js
@@ -1,0 +1,53 @@
+export const READER_FITS = Object.freeze([
+  { value: "contain", label: "Best fit" },
+  { value: "width", label: "Fit width" },
+  { value: "height", label: "Fit height" },
+  { value: "original", label: "Original size" },
+]);
+
+const FIT_VALUES = new Set(READER_FITS.map(({ value }) => value));
+
+export const DEFAULT_READER_PREFERENCES = Object.freeze({
+  schemaVersion: 1,
+  settings: Object.freeze({
+    mode: "single",
+    direction: "ltr",
+    fit: "contain",
+    autoHideControls: true,
+    showProgress: true,
+    wakeLock: true,
+  }),
+  overrides: Object.freeze([]),
+});
+
+/**
+ * Treat server data as untrusted. This mirrors the backend's read-time
+ * normalization so a stale response can never select a broken renderer or
+ * distort a page.
+ */
+export function normalizeReaderPreferences(candidate) {
+  const settings = candidate?.schemaVersion === 1 && candidate?.settings && typeof candidate.settings === "object"
+    ? candidate.settings
+    : {};
+
+  return {
+    schemaVersion: 1,
+    settings: {
+      mode: settings.mode === "single" ? settings.mode : "single",
+      direction: settings.direction === "ltr" ? settings.direction : "ltr",
+      fit: FIT_VALUES.has(settings.fit) ? settings.fit : "contain",
+      autoHideControls: typeof settings.autoHideControls === "boolean" ? settings.autoHideControls : true,
+      showProgress: typeof settings.showProgress === "boolean" ? settings.showProgress : true,
+      wakeLock: typeof settings.wakeLock === "boolean" ? settings.wakeLock : true,
+    },
+    // Reserved for validated device/orientation contexts in later reader work.
+    overrides: [],
+  };
+}
+
+export function updateReaderSettings(preferences, patch) {
+  return normalizeReaderPreferences({
+    ...preferences,
+    settings: { ...preferences.settings, ...patch },
+  });
+}

--- a/frontend/src/lib/reader-preferences.test.js
+++ b/frontend/src/lib/reader-preferences.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_READER_PREFERENCES,
+  normalizeReaderPreferences,
+  updateReaderSettings,
+} from "./reader-preferences";
+
+describe("reader preferences", () => {
+  it("falls back safely for a stale or malformed response", () => {
+    expect(normalizeReaderPreferences({ schemaVersion: 99, settings: { fit: "width" } }))
+      .toEqual(DEFAULT_READER_PREFERENCES);
+
+    expect(normalizeReaderPreferences({
+      schemaVersion: 1,
+      settings: { fit: "stretch", showProgress: false, wakeLock: "yes" },
+    }).settings).toMatchObject({ fit: "contain", showProgress: false, wakeLock: true });
+  });
+
+  it("updates only recognized settings and preserves a complete envelope", () => {
+    const updated = updateReaderSettings(DEFAULT_READER_PREFERENCES, {
+      fit: "width",
+      showProgress: false,
+      arbitrary: "discarded",
+    });
+
+    expect(updated.settings.fit).toBe("width");
+    expect(updated.settings.showProgress).toBe(false);
+    expect(updated.settings).not.toHaveProperty("arbitrary");
+  });
+});

--- a/frontend/src/pages/ComicReader.jsx
+++ b/frontend/src/pages/ComicReader.jsx
@@ -11,13 +11,18 @@ import { isTypingTarget } from "@/lib/keyboard";
 import { parsePageNumber } from "@/lib/comic-progress";
 import { toggleFullscreen } from "@/lib/fullscreen";
 import { useComicLibrary } from "@/hooks/use-comic-library.jsx";
+import { useReaderNavigation } from "@/hooks/use-reader-navigation";
+import { useReaderPreferences } from "@/hooks/use-reader-preferences.jsx";
+import { useReaderWakeLock } from "@/hooks/use-reader-wake-lock";
+import { createComicPageUrls } from "@/lib/reader-pages";
+import { ReaderSettings } from "@/components/reader/ReaderSettings";
+import { SinglePageReader } from "@/components/reader/SinglePageReader";
 
 export default function ComicReader() {
   const { comicId } = useParams();
   const [comic, setComic] = useState(null);
   const [loadError, setLoadError] = useState(null);
   const [comicPages, setComicPages] = useState([]);
-  const [currentPage, setCurrentPage] = useState(0);
   const [isFetchingComic, setIsFetchingComic] = useState(true); // For overall comic data
   const [imageCache, setImageCache] = useState({});
   const [showDebug, setShowDebug] = useState(false); // For debug panel
@@ -27,19 +32,35 @@ export default function ComicReader() {
   const [mousePosition, setMousePosition] = useState({ x: 0.5, y: 0.5 });
   const imageContainerRef = useRef(null);
   const pageInputRef = useRef(null);
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { updateComicProgress } = useComicLibrary();
+  const {
+    currentPage,
+    currentPageRef,
+    goToPage,
+    goPrevious: handlePreviousPage,
+    goNext: handleNextPage,
+    resetPage,
+    canGoPrevious,
+    canGoNext,
+  } = useReaderNavigation(comicPages.length);
+  const {
+    settings,
+    isLoaded: arePreferencesLoaded,
+    isSaving: arePreferencesSaving,
+    changeSettings,
+    resetPreferences,
+  } = useReaderPreferences(toast);
+  useReaderWakeLock(settings.wakeLock);
   
   // Refs for async operations
   const progressAbortController = useRef(null);
-  const currentPageRef = useRef(0); // Ref to track current page for async operations
   const loadQueueRef = useRef([]); // Queue of pages to load
   const isLoadingRef = useRef(false); // Flag to track if we're currently loading a page
   const isMountedRef = useRef(true); // Progress saves outlive the component; used to suppress late toasts
   const progressRevisionRef = useRef(0); // Orders progress saves that may reach the server out of order
   
-  const navigate = useNavigate();
-  const { toast } = useToast();
-  const { updateComicProgress } = useComicLibrary();
-
   const CACHE_SIZE_FORWARD = 5;
   const CACHE_SIZE_BACKWARD = 5;
 
@@ -157,24 +178,25 @@ export default function ComicReader() {
       setLoadError(null);
       setComic(null);
       setComicPages([]);
+      resetPage(0, 0);
+      setImageCache({});
       try {
         const data = await api.get(`/api/comics/${comicId}`);
         if (!active) return;
         setComic(data.comic);
 
         if (data.comic && data.comic.pageCount > 0) {
-          setComicPages(
-            Array.from({ length: data.comic.pageCount }, (_, i) => `/api/comics/${comicId}/pages/${i + 1}`)
-          );
+          const pages = createComicPageUrls(comicId, data.comic.pageCount);
+          setComicPages(pages);
           // Continue the server's revision sequence, otherwise a reopened
           // reader would start below the stored value and every save would
           // look stale.
           progressRevisionRef.current = data.comic.readingProgress?.revision || 0;
 
           if (data.comic.readingProgress && data.comic.readingProgress.currentPage) {
-            setCurrentPage(data.comic.readingProgress.currentPage - 1);
+            resetPage(data.comic.readingProgress.currentPage - 1, pages.length);
           } else {
-            setCurrentPage(0); // Default to first page
+            resetPage(0, pages.length);
           }
         } else {
           toast({
@@ -220,13 +242,13 @@ export default function ComicReader() {
     }
 
     return () => { active = false; };
-  }, [comicId, navigate, toast]);
+  }, [comicId, navigate, resetPage, toast]);
 
   // Function to check if a page index is within the cache window
   const isInCacheWindow = useCallback((pageIndex) => {
     return pageIndex >= Math.max(0, currentPageRef.current - CACHE_SIZE_BACKWARD) && 
            pageIndex <= Math.min(comicPages.length - 1, currentPageRef.current + CACHE_SIZE_FORWARD);
-  }, [comicPages.length]);
+  }, [comicPages.length, currentPageRef]);
 
   // Object to track in-progress loads to prevent duplicate requests
   const loadingPagesRef = useRef({});
@@ -319,7 +341,7 @@ export default function ComicReader() {
     };
 
     drain();
-  }, [loadPageIntoCache]);
+  }, [currentPageRef, loadPageIntoCache]);
   
   // Function to queue pages for loading in priority order
   const queuePagesToLoad = useCallback(() => {
@@ -365,7 +387,7 @@ export default function ComicReader() {
     if (loadQueueRef.current.length > 0) {
       processLoadQueue();
     }
-  }, [processLoadQueue, imageCache, comicPages.length]);
+  }, [processLoadQueue, imageCache, comicPages.length, currentPageRef]);
   
   // Function to clean up the cache (remove pages outside the window)
   const cleanupCache = useCallback(() => {
@@ -387,13 +409,10 @@ export default function ComicReader() {
       stale.forEach(key => delete newCache[key]);
       return newCache;
     });
-  }, [comicPages.length]);
+  }, [comicPages.length, currentPageRef]);
   
   // Effect to handle page changes and update UI state - only runs when page actually changes
   useEffect(() => {
-    // Update the ref to ensure async operations have the latest value
-    currentPageRef.current = currentPage;
-    
     if (comicPages.length === 0) return;
     
     // Check if current page is available in cache
@@ -430,7 +449,7 @@ export default function ComicReader() {
       clearTimeout(cleanupTimer);
       clearTimeout(queueTimer);
     };
-  }, [currentPage, comicPages, imageCache, queuePagesToLoad, cleanupCache, loadPageIntoCache]);
+  }, [currentPage, comicPages, imageCache, queuePagesToLoad, cleanupCache, loadPageIntoCache, currentPageRef]);
 
 
 
@@ -453,22 +472,6 @@ export default function ComicReader() {
     // supersedes its own previous request.
   }, [currentPage, comic, comicId, comicPages.length, updateReadingProgress]);
 
-  // Move by one page, priming the loading state from the cache so an already
-  // cached page renders without a skeleton flash.
-  const goToPage = useCallback((newPage) => {
-    if (newPage < 0 || newPage > comicPages.length - 1) return;
-
-    setCurrentPage(newPage);
-  }, [comicPages.length]);
-
-  const handlePreviousPage = useCallback(() => {
-    goToPage(currentPage - 1);
-  }, [goToPage, currentPage]);
-
-  const handleNextPage = useCallback(() => {
-    goToPage(currentPage + 1);
-  }, [goToPage, currentPage]);
-
   // The jump-to-page box holds raw text, not a page number: it has to survive
   // the empty and half-typed states an input passes through. It is reconciled
   // with the reader whenever the page changes by any other means.
@@ -482,7 +485,7 @@ export default function ComicReader() {
     : String(currentPage + 1);
   const setPageInput = useCallback(
     (text) => setPageDraft({ forPage: currentPageRef.current, text }),
-    []
+    [currentPageRef]
   );
 
 
@@ -500,7 +503,7 @@ export default function ComicReader() {
     if (requestedPage !== currentPageRef.current) {
       goToPage(requestedPage);
     }
-  }, [pageInput, comicPages.length, goToPage, setPageInput]);
+  }, [pageInput, comicPages.length, currentPageRef, goToPage, setPageInput]);
 
   // Force a page to come from the server again, bypassing the browser cache.
   // A unique URL is what does the bypassing: the page endpoint is cacheable, so
@@ -582,7 +585,7 @@ export default function ComicReader() {
     loadingPagesRef.current[pageToReload] = forcedLoad;
 
     img.src = `${comicPages[pageToReload]}?_force_reload=${Date.now()}`;
-  }, [comicPages, currentPage, toast]);
+  }, [comicPages, currentPage, currentPageRef, toast]);
 
   const handleScreenNavClick = (direction) => {
     if (direction === 'left') {
@@ -671,6 +674,22 @@ export default function ComicReader() {
     };
   }, [isZoomed, handleWheel]);
 
+  const handleReaderSettingsChange = useCallback((patch) => {
+    // A fit choice describes the untransformed page. Leaving an old zoom
+    // active makes that choice look broken, so return to natural scale first.
+    if (patch.fit && patch.fit !== settings.fit) {
+      setIsZoomed(false);
+      setZoomLevel(1);
+    }
+    changeSettings(patch);
+  }, [changeSettings, settings.fit]);
+
+  const handleResetReaderSettings = useCallback(() => {
+    setIsZoomed(false);
+    setZoomLevel(1);
+    resetPreferences();
+  }, [resetPreferences]);
+
   if (isLoading) {
     return (
       <div className="min-h-screen flex justify-center items-center bg-background">
@@ -697,25 +716,34 @@ export default function ComicReader() {
   return (
     <div className="min-h-screen flex flex-col items-center bg-background overflow-hidden">
       {/* Navigation areas for clicking left/right sides of screen */}
-      <div 
+      <div
         className={`page-navigation left-0 ${isFullscreen ? 'z-[55]' : ''}`}
         style={{ bottom: '88px' }} // Leave space for controls to prevent overlap
         onClick={() => handleScreenNavClick('left')}
-        aria-label="Previous page"
+        aria-hidden="true"
       ></div>
       
       <div 
         className={`page-navigation right-0 ${isFullscreen ? 'z-[55]' : ''}`}
         style={{ bottom: '88px' }} // Leave space for controls to prevent overlap
         onClick={() => handleScreenNavClick('right')}
-        aria-label="Next page"
+        aria-hidden="true"
       ></div>
       
       {/* Main content area - adjusted height to account for the header in normal mode */}
-      <div className={`max-w-4xl w-full ${isFullscreen ? 'h-[calc(100vh-8rem)]' : 'h-[calc(100vh-10rem)]'} flex items-center justify-center py-4`}>
-        <div 
-          ref={imageContainerRef}
-          className={`relative max-h-full w-full h-full flex items-center justify-center ${isFullscreen ? 'fullscreen-container' : ''}`}
+      <div className={`${settings.fit === "contain" || settings.fit === "height" ? "max-w-4xl" : "max-w-none"} w-full ${isFullscreen ? 'h-[calc(100vh-8rem)]' : 'h-[calc(100vh-10rem)]'} flex items-center justify-center py-4`}>
+        <SinglePageReader
+          containerRef={imageContainerRef}
+          image={imageLoadedSuccessfully ? currentPageImage : null}
+          isLoading={isPageImageLoading}
+          hasFailed={!isPageImageLoading && !imageLoadedSuccessfully && comicPages.length > 0 && Boolean(comicPages[currentPage])}
+          pageNumber={currentPage + 1}
+          title={comic?.title}
+          fit={settings.fit}
+          isFullscreen={isFullscreen}
+          isZoomed={isZoomed}
+          zoomLevel={zoomLevel}
+          mousePosition={mousePosition}
           onMouseMove={(e) => {
             if (isZoomed) {
               const rect = e.currentTarget.getBoundingClientRect();
@@ -724,61 +752,39 @@ export default function ComicReader() {
               setMousePosition({ x, y });
             }
           }}
+          onImageClick={() => {
+            if (isZoomed) {
+              setIsZoomed(false);
+              setZoomLevel(1);
+            }
+          }}
+          onRetry={() => {
+            setImageCache((previousCache) => {
+              const nextCache = { ...previousCache };
+              delete nextCache[currentPage];
+              return nextCache;
+            });
+          }}
         >
-          {/* Main image display */}
-          {comicPages.length > 0 && imageCache[currentPage] && 
-           imageCache[currentPage] !== 'loading' && 
-           imageCache[currentPage] !== 'failed' && (
-            <img
-              key={`cached-${currentPage}`}
-              src={imageCache[currentPage].src}
-              alt={`Page ${currentPage + 1} of ${comic?.title || 'Comic'}`}
-              className={`max-h-full max-w-full object-contain mx-auto shadow-lg block transition-transform ${isZoomed ? 'zoomed-image' : ''}`}
-              style={{
-                transform: isZoomed ? `scale(${zoomLevel})` : 'none',
-                transformOrigin: isZoomed ? `${mousePosition.x * 100}% ${mousePosition.y * 100}%` : 'center center'
-              }}
-              onClick={() => {
-                if (isZoomed) {
-                  setIsZoomed(false);
-                  setZoomLevel(1);
-                }
-              }}
-            />
-          )}
-          {/* Error display for failed image load */}
-          {!isPageImageLoading && !imageLoadedSuccessfully && comicPages.length > 0 && comicPages[currentPage] && (
-            <div className="flex flex-col items-center justify-center text-destructive p-4 bg-destructive-foreground rounded-md">
-              <p className="mb-2">Error loading page {currentPage + 1}.</p>
-              <Button
-                variant="outline"
-                onClick={() => {
-                  // Retry logic: Clear from cache and set to loading to trigger reload
-                  setImageCache(prevCache => {
-                    const newCache = { ...prevCache };
-                    delete newCache[currentPage];
-                    return newCache;
-                  });
-                }}
-              >
-                Retry
-              </Button>
-            </div>
-          )}
-          {/* Loading state only if we don't have a cached image */}
-          {(!imageCache[currentPage] || imageCache[currentPage] === 'loading') && isPageImageLoading && (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <Skeleton className="w-full h-full max-w-full object-contain mx-auto" />
-            </div>
-          )}
           {/* Control buttons - positioned differently in fullscreen mode */}
-          <div className={isFullscreen ? "fullscreen-controls" : "absolute top-2 right-2 z-10 flex gap-2"}>
-            <Button 
+          <div className={isFullscreen
+            ? `fullscreen-controls ${settings.autoHideControls ? "fullscreen-controls-auto-hide" : ""}`
+            : "absolute top-2 right-2 z-10 flex gap-2"}>
+            <ReaderSettings
+              settings={settings}
+              isLoaded={arePreferencesLoaded}
+              isSaving={arePreferencesSaving}
+              onChange={handleReaderSettingsChange}
+              onReset={handleResetReaderSettings}
+            />
+
+            <Button
               variant="outline" 
               size="icon"
               className="opacity-80 hover:opacity-100 bg-card/80"
               onClick={() => toggleFullscreen(document)}
-              title="Toggle fullscreen"
+              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+              title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
             >
               <Maximize className="h-4 w-4" />
             </Button>
@@ -788,10 +794,12 @@ export default function ComicReader() {
                 variant="outline" 
                 size="icon"
                 className="opacity-80 hover:opacity-100 bg-card/80"
+                disabled={!arePreferencesLoaded}
                 onClick={() => {
                   setIsZoomed(false);
                   setZoomLevel(1);
                 }}
+                aria-label="Zoom out"
                 title="Zoom out"
               >
                 <ZoomOut className="h-4 w-4" />
@@ -801,10 +809,12 @@ export default function ComicReader() {
                 variant="outline" 
                 size="icon"
                 className="opacity-80 hover:opacity-100 bg-card/80"
+                disabled={!arePreferencesLoaded}
                 onClick={() => {
                   setIsZoomed(true);
                   setZoomLevel(2);
                 }}
+                aria-label="Zoom in"
                 title="Zoom in"
               >
                 <ZoomIn className="h-4 w-4" />
@@ -819,7 +829,8 @@ export default function ComicReader() {
                   size="icon"
                   className="opacity-80 hover:opacity-100 bg-card/80"
                   onClick={handlePreviousPage}
-                  disabled={currentPage === 0}
+                  disabled={!canGoPrevious}
+                  aria-label="Previous page"
                   title="Previous page"
                 >
                   <ArrowLeft className="h-4 w-4" />
@@ -830,7 +841,8 @@ export default function ComicReader() {
                   size="icon"
                   className="opacity-80 hover:opacity-100 bg-card/80"
                   onClick={handleNextPage}
-                  disabled={currentPage === comicPages.length - 1}
+                  disabled={!canGoNext}
+                  aria-label="Next page"
                   title="Next page"
                 >
                   <ArrowRight className="h-4 w-4" />
@@ -844,6 +856,8 @@ export default function ComicReader() {
               size="icon"
               className="opacity-80 hover:opacity-100 bg-card/80"
               onClick={() => setShowDebug(!showDebug)}
+              aria-label="Debug info"
+              aria-expanded={showDebug}
               title="Debug info"
             >
               <Info className="h-4 w-4" />
@@ -893,13 +907,15 @@ export default function ComicReader() {
           {comicPages.length === 0 && !isLoading && (
              <div className="text-xl">This comic has no pages to display.</div>
           )}
-        </div>
+        </SinglePageReader>
       </div>
       
       {/* Reader controls - different styling in fullscreen mode */}
-      <div className={isFullscreen ? "reader-controls-fullscreen" : "reader-controls"}>
+      <div className={isFullscreen
+        ? `reader-controls-fullscreen ${settings.autoHideControls ? "" : "reader-controls-pinned"}`
+        : "reader-controls"}>
         {/* How far through the comic this page is, at a glance */}
-        {comicPages.length > 0 && (
+        {settings.showProgress && comicPages.length > 0 && (
           <Progress
             value={((currentPage + 1) / comicPages.length) * 100}
             aria-label={`Page ${currentPage + 1} of ${comicPages.length}`}
@@ -912,10 +928,12 @@ export default function ComicReader() {
             <Button
               variant="outline"
               onClick={handlePreviousPage}
-              disabled={currentPage === 0}
+              disabled={!canGoPrevious}
+              aria-label="Previous page"
               className={isFullscreen ? "" : "bg-card"}
             >
-              <ArrowLeft className="mr-2 h-4 w-4" /> Previous
+              <ArrowLeft className="h-4 w-4 min-[360px]:mr-2" />
+              <span className="hidden min-[360px]:inline">Previous</span>
             </Button>
 
             {/* Force reload button */}
@@ -923,6 +941,7 @@ export default function ComicReader() {
               variant="outline"
               size="icon"
               onClick={handleForceReload}
+              aria-label="Force reload current page"
               title="Force reload current page"
               className={isFullscreen ? "" : "bg-card"}
             >
@@ -966,10 +985,12 @@ export default function ComicReader() {
           <Button
             variant="outline"
             onClick={handleNextPage}
-            disabled={currentPage === comicPages.length - 1}
+            disabled={!canGoNext}
+            aria-label="Next page"
             className={isFullscreen ? "" : "bg-card"}
           >
-            Next <ArrowRight className="ml-2 h-4 w-4" />
+            <span className="hidden min-[360px]:inline">Next</span>
+            <ArrowRight className="h-4 w-4 min-[360px]:ml-2" />
           </Button>
         </div>
       </div>

--- a/frontend/src/pages/ComicReader.test.jsx
+++ b/frontend/src/pages/ComicReader.test.jsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ComicReader from "./ComicReader";
 import { api } from "@/lib/api";
+import { toggleFullscreen } from "@/lib/fullscreen";
+import { DEFAULT_READER_PREFERENCES } from "@/lib/reader-preferences";
 
 /**
  * Stable identities, deliberately.
@@ -16,7 +18,7 @@ import { api } from "@/lib/api";
  */
 const mocks = vi.hoisted(() => ({ toast: vi.fn(), updateComicProgress: vi.fn() }));
 
-vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn() } }));
+vi.mock("@/lib/api", () => ({ api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() } }));
 vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: mocks.toast }) }));
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), log: vi.fn() } }));
 vi.mock("@/lib/fullscreen", () => ({ toggleFullscreen: vi.fn() }));
@@ -90,8 +92,17 @@ describe("ComicReader", () => {
     mocks.updateComicProgress.mockClear();
     vi.stubGlobal("Image", FakeImage);
     vi.mocked(api.get).mockReset();
-    vi.mocked(api.get).mockResolvedValue(comic());
+    vi.mocked(api.get).mockImplementation((path) => Promise.resolve(
+      path === "/api/reader/preferences"
+        ? { preferences: DEFAULT_READER_PREFERENCES }
+        : comic()
+    ));
     vi.mocked(api.post).mockResolvedValue({ progress: { currentPage: 1, revision: 1 } });
+    vi.mocked(api.put).mockReset();
+    vi.mocked(api.put).mockImplementation((_path, body) => Promise.resolve(body));
+    vi.mocked(api.delete).mockReset();
+    vi.mocked(api.delete).mockResolvedValue({ preferences: DEFAULT_READER_PREFERENCES });
+    vi.mocked(toggleFullscreen).mockClear();
   });
 
   afterEach(() => {
@@ -168,7 +179,7 @@ describe("ComicReader", () => {
 
       expect(pageBox()).toHaveValue(1);
 
-      await user.click(screen.getByLabelText(/next page/i));
+      await user.click(screen.getByRole("button", { name: /^next/i }));
 
       await waitFor(() => expect(pageBox()).toHaveValue(2));
     });
@@ -199,6 +210,138 @@ describe("ComicReader", () => {
       // match the page being shown.
       await waitFor(() => expect(pageBox()).toHaveValue(3));
       expect(await page(3)).toBeInTheDocument();
+    });
+  });
+
+  describe("shared navigation and logical progress", () => {
+    it("uses the same next and previous operations for keyboard navigation", async () => {
+      const user = userEvent.setup();
+      renderReader();
+      await page(1);
+
+      await user.keyboard("{ArrowRight}");
+      expect(await page(2)).toBeInTheDocument();
+
+      await user.keyboard("{ArrowLeft}");
+      expect(await page(1)).toBeInTheDocument();
+    });
+
+    it("does not steal arrow keys from the page input", async () => {
+      const user = userEvent.setup();
+      renderReader();
+      await page(1);
+
+      await user.click(pageBox());
+      await user.keyboard("{ArrowRight}");
+
+      expect(await page(1)).toBeInTheDocument();
+    });
+
+    it("restores and saves the underlying comic page number", async () => {
+      vi.mocked(api.get).mockImplementation((path) => Promise.resolve(
+        path === "/api/reader/preferences"
+          ? { preferences: DEFAULT_READER_PREFERENCES }
+          : { comic: { ...comic().comic, readingProgress: { currentPage: 2, revision: 7 } } }
+      ));
+
+      renderReader();
+
+      expect(await page(2)).toBeInTheDocument();
+      await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+        "/api/comics/42/progress",
+        expect.objectContaining({ currentPage: 2, revision: 8 }),
+        expect.objectContaining({ keepalive: true })
+      ));
+    });
+  });
+
+  describe("reader settings", () => {
+    it("loads a saved fit without reloading comic metadata", async () => {
+      const saved = {
+        ...DEFAULT_READER_PREFERENCES,
+        settings: { ...DEFAULT_READER_PREFERENCES.settings, fit: "width" },
+      };
+      vi.mocked(api.get).mockImplementation((path) => Promise.resolve(
+        path === "/api/reader/preferences" ? { preferences: saved } : comic()
+      ));
+
+      const { container } = renderReader();
+      await page(1);
+
+      await waitFor(() => expect(container.querySelector("[data-page-fit]")).toHaveAttribute("data-page-fit", "width"));
+      expect(api.get.mock.calls.filter(([path]) => path === "/api/comics/42")).toHaveLength(1);
+    });
+
+    it("changes fit immediately, persists it, and resets naturally", async () => {
+      const user = userEvent.setup();
+      const { container } = renderReader();
+      await page(1);
+
+      await user.click(screen.getByRole("button", { name: /reader settings/i }));
+      await user.click(screen.getByRole("combobox", { name: /page size/i }));
+      await user.click(await screen.findByRole("option", { name: /fit width/i }));
+
+      expect(container.querySelector("[data-page-fit]")).toHaveAttribute("data-page-fit", "width");
+      await waitFor(() => expect(api.put).toHaveBeenCalledWith(
+        "/api/reader/preferences",
+        { preferences: expect.objectContaining({ settings: expect.objectContaining({ fit: "width" }) }) },
+        { keepalive: true }
+      ));
+      expect(api.get.mock.calls.filter(([path]) => path === "/api/comics/42")).toHaveLength(1);
+
+      await user.click(screen.getByRole("button", { name: /reset defaults/i }));
+      await waitFor(() => expect(api.delete).toHaveBeenCalledWith(
+        "/api/reader/preferences",
+        { keepalive: true }
+      ));
+      expect(container.querySelector("[data-page-fit]")).toHaveAttribute("data-page-fit", "contain");
+    });
+
+    it("falls back safely when saved settings are stale", async () => {
+      vi.mocked(api.get).mockImplementation((path) => Promise.resolve(
+        path === "/api/reader/preferences"
+          ? { preferences: { schemaVersion: 99, settings: { fit: "stretch" } } }
+          : comic()
+      ));
+
+      const { container } = renderReader();
+      await page(1);
+
+      expect(container.querySelector("[data-page-fit]")).toHaveAttribute("data-page-fit", "contain");
+    });
+
+    it("can hide the progress indicator without affecting navigation", async () => {
+      const user = userEvent.setup();
+      renderReader();
+      await page(1);
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /reader settings/i }));
+      await user.click(screen.getByRole("switch", { name: /show progress bar/i }));
+
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^next/i })).toBeEnabled();
+    });
+  });
+
+  describe("fullscreen and preload regressions", () => {
+    it("keeps fullscreen available through an explicitly named button", async () => {
+      const user = userEvent.setup();
+      renderReader();
+      await page(1);
+
+      await user.click(screen.getByRole("button", { name: /enter fullscreen/i }));
+
+      expect(toggleFullscreen).toHaveBeenCalledWith(document);
+    });
+
+    it("does not request the same preload URL twice", async () => {
+      renderReader();
+      await page(1);
+
+      await waitFor(() => expect(FakeImage.instances.length).toBeGreaterThanOrEqual(3));
+      const pageUrls = FakeImage.instances.map(({ src }) => src).filter((src) => src.includes("/pages/"));
+      expect(new Set(pageUrls).size).toBe(pageUrls.length);
     });
   });
 


### PR DESCRIPTION
Closes #85

## What changed

- Add a versioned, strictly validated reader-preference envelope stored per authenticated user, with authenticated GET/PUT/reset endpoints and CSRF protection on writes.
- Add persisted Best fit, Fit width, Fit height, and Original size presentation without reloading comic metadata or changing page URLs.
- Make progress visibility, fullscreen control fading, and the Screen Wake Lock request real reader settings.
- Extract shared logical-page navigation, preference persistence, wake-lock handling, page URL creation, the settings UI, and the single-page renderer from the reader monolith.
- Preserve the existing bounded preload/cache behavior, retry behavior, logical progress revision ordering, and keepalive saves.
- Add focused backend/frontend coverage and `docs/reader.md`.

## UX and accessibility

- Settings apply immediately and save in the background; rapid changes are serialized and collapsed so older writes cannot win a race.
- The popover is keyboard reachable, announces save state, and scrolls focused controls into view on short screens.
- Icon-only controls have explicit names; fullscreen auto-hide restores controls on hover or keyboard focus.
- The reader control row remains fully reachable at 320 px, while 360 px and wider retain the familiar Previous/Next text.
- Invalid or stale saved data falls back field-by-field to safe defaults.

## Integration notes

### PR #103 / source-provider factory

This branch does not modify the provider factory, source types, page providers, `ComicController`, or comic-source services. It keeps the protected `/api/comics/{id}/pages/{logicalPage}` contract behind `createComicPageUrls()`, so the factory can change how the backend obtains bytes without leaking source formats into reader navigation.

A local `git merge-tree` check against the current PR #103 head (`9be9231`) completed without conflicts. The new migration is dated `Version20260810090000`, after #103's migrations, so no migration rename/TODO is currently required.

### Issue #86 / spreads and RTL

- Extend the centralized allowed mode/direction values only when their renderers exist.
- Reuse `useReaderNavigation`; it deliberately exposes logical next/previous/jump and knows nothing about visual left/right placement.
- Add the double-page renderer beside `SinglePageReader`; keep progress on underlying source page numbers.
- The preference envelope already reserves validated `overrides` for later device/orientation contexts.
- Page-source formats remain invisible to spread logic.

### Later mobile work

This PR only guarantees a safe, usable baseline at narrow widths; it does not choose artistic single-page vs spread behavior ahead of #86/#88. Browser checks covered 1280×720, 390×844, and 320×568.

## Validation

- Backend: `php bin/phpunit` — 404 tests, 1832 assertions
- Frontend: `npm test` — 232 tests
- Final focused reader tests — 22 tests
- `npm run lint`
- `npm run build`
- `npm run audit:production` — no production dependency advisories
- `php bin/console lint:container`
- Real-browser desktop and narrow-viewport checks with successful reader API requests and no console errors